### PR TITLE
fix(route): cap a lattice escalation attempt at its per-attempt budget slice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -672,6 +672,42 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **A lattice escalation attempt no longer gets the whole run's wall-clock
+  budget as its cap** (#4798) — every other routing engine receives its
+  escalation attempt's fair slice as `timeout=_per_attempt_budgeted_timeout(…)`
+  (#2823/#3463), but the lattice engine's only bound is the absolute
+  `lattice_deadline` stamped at `load_pcb_for_routing` time, and all three
+  escalation sites (`route_with_layer_escalation`, the rule-relaxation tier
+  ladder, the combined 2D layers × tiers matrix) passed
+  `_lattice_absolute_deadline(args)` — the end-of-invocation deadline spanning
+  **every** remaining attempt. Because the lattice negotiates the whole netset
+  in a single `route_netset` call, `route_all`'s between-nets `timeout` check
+  never fires mid-run, so under `--route-engine lattice --timeout N` with a
+  multi-attempt ladder the first attempt could consume the entire remaining
+  budget and starve the later attempts — the lattice equivalent of the
+  pre-#2823 "first attempt eats everything" regression. A new
+  `_lattice_attempt_deadline(args, attempt_timeout)` helper now returns
+  `min(whole-run deadline, now + this attempt's fair slice)`, and
+  `_attempt_timeout` is computed ahead of the load at those three sites so the
+  cap is available there. The result is never *looser* than before, only ever
+  tighter, and only when a *positive* fair slice is actually computed: with no
+  `--timeout` — including `--deterministic-budget` without `--timeout`, where
+  `_per_attempt_budgeted_timeout` returns `None` — and with the documented
+  unbounded sentinel `--timeout 0` (or negative), where the slice comes back
+  `0`/negative rather than as a real slice, it collapses to
+  `_lattice_absolute_deadline(args)` verbatim. The two genuinely single-attempt
+  call sites (`main()`'s primary load and the `--order-method` throwaway-router
+  factory) and the `--timeout` banner keep the unsliced absolute deadline,
+  which is already the correct per-attempt cap there. Hoisting the
+  `_per_attempt_budgeted_timeout` call feeds the negotiated / escape /
+  two-phase / multi-resolution / evolutionary arms the same inputs as before
+  (`args`, the loop indices); only the helper's `time.monotonic()` read moves
+  earlier, so each arm's slice grows by the PCB-load duration — measured inert
+  on board 04. Gated on a back-to-back host A/B of board 07 (which drives
+  `--strategy negotiated --no-auto-layers`, so the change is expected — and
+  measured — to be inert there); recorded in
+  `boards/07-matchgroup-test/diagnostic-runs/README.md`.
+
 - **The pure-Python pairwise (HV-isolation) search gate now measures from the
   per-net-class copper width** (#4793) — the three Python search kernels added
   by #4791 (`Router._cross_domain_trace_blocked`,

--- a/boards/07-matchgroup-test/diagnostic-runs/README.md
+++ b/boards/07-matchgroup-test/diagnostic-runs/README.md
@@ -579,6 +579,98 @@ wiring the flag at the CLI's own `route_all_negotiated` call site would
 not reach the passes that produced these numbers -- it would be a
 different experiment.
 
+## Per-attempt lattice deadline cap: A/B measurement (#4798)
+
+**What changed.** Issue #4798 caps the lattice engine's absolute
+`lattice_deadline` at the *current escalation attempt's*
+`_per_attempt_budgeted_timeout` fair slice instead of the whole remaining
+run budget, via a new `_lattice_attempt_deadline(args, attempt_timeout)`
+helper in `route_cmd.py`. The `_attempt_timeout` computation is hoisted
+ahead of `load_pcb_for_routing` at the three multi-attempt escalation
+sites (`route_with_layer_escalation`, the rule-relaxation tier ladder,
+the combined 2D layers x tiers matrix) so the value is available where
+the deadline is stamped. The two single-attempt call sites keep
+`_lattice_absolute_deadline` verbatim.
+
+**Why board 07 is expected to be inert.** `generate_design.py` drives
+`--strategy negotiated --no-auto-layers --layers 4`, so none of the three
+escalation loops runs at all, and the engine is the grid negotiator, not
+`--route-engine lattice` (only `Autorouter._negotiate_lattice_netset`
+reads `_lattice_deadline`). Per the #4802 precedent, the gate is still
+**measured and documented**, not waived.
+
+**What was compared.** Same-host local A/B (Apple Silicon, 28 cores),
+`PYTHONHASHSEED=42 uv run python boards/07-matchgroup-test/generate_design.py
+<out> --step all --seed 42` with the C++ backend built (build 19) in both
+arms. **B** = pristine clone of `main` @ `33666637` (a separate checkout, so
+the running arm cannot see the working-tree edits -- board 07 invokes
+`kct route` as a *subprocess*, which would otherwise pick them up
+mid-run). **A** = the #4798 change on top of the same head. A **second B
+run** (`B2`, same pristine clone, no source change) was added as the
+run-to-run control.
+
+| | B (`main`) | B2 (control, `main` again) | A (#4798) |
+|---|---|---|---|
+| final reach | 26/31 | 26/31 | 26/31 |
+| copper-LVS opens (`--expect-opens`) | `DQ3, DQ4, MIPI_DAT0_N, TMDS_D0_N, TMDS_D1_N` | identical | identical |
+| copper-LVS shorts / vacuous | 0 / 0 | 0 / 0 | 0 / 0 |
+| bound pads | 244 | 244 | 244 |
+| blocking DRC (`check_routed_drc.py`, jlcpcb) | **8** (== allowlist) | **8** | **8** |
+| DRC rule split | `diffpair_length_skew` 4 + `diffpair_routing_continuity` 4 | identical | identical |
+| raw `kct check` errors | 13 (8 blocking + 5 advisory `connectivity`) | 13 | 13 |
+| deltas proposed / kept | 10 / 0 | 10 / 0 | 10 / 0 |
+| final-pass rip-up iterations | 10 | 10 | 10 |
+| normalized PCB md5 (uuid-stripped, sorted) | `026d5506...` | `1f36faa9...` | `1f36faa9...` |
+
+**Every gated metric is identical across all three runs.** The md5 column
+is the interesting one: `B` and `B2` are the *same code* and still differ,
+while `B2` and `A` are **byte-identical after uuid normalization**. So the
+copper drift on this fixture is run-to-run wall-clock variance, not the
+change -- the same mechanism the #4770/#4781 sections above document
+(board 07's stage deadline is still a 600 s wall clock even under
+`--deterministic-budget`, so how much of a rip-up iteration fits is a
+function of host load). A normalized log diff between `B` and `A` is 30
+lines, all of them elapsed-time stamps, one zero-overflow-recovery
+denominator (`0/7` vs `0/8`), the stranded-pad coordinates of the same 5
+known-open nets, and a 1-segment orthogonal/45-deg split shift.
+
+**Board 04 cross-check (the board this change can actually reach).**
+`boards/04-stm32-devboard` is the fixture that runs `--auto-layers
+--auto-mfr-tier --deterministic-budget --timeout 600`, i.e. it *does* execute
+`route_with_layer_escalation` with a wall-clock budget, so it exercises
+the hoisted `_attempt_timeout` (which the negotiated arm still receives
+as its `timeout=` kwarg). Same-host A/B, same two checkouts:
+
+| | B (`main`) | A (#4798) |
+|---|---|---|
+| nets routed | 9/9 | 9/9 |
+| routed DRC (`check_routed_drc.py`, jlcpcb-tier1, strict 0) | **0** | **0** |
+| copper-LVS (`check_copper_lvs.py`, plain clean gate) | clean | clean |
+| recipe verdict | ERC PASS / Routing SUCCESS / DRC PASS / LVS PASS / Overall PASS | identical |
+| normalized PCB md5 (uuid-stripped, sorted) | `4444f351...` | `4444f351...` -- **identical artifact** |
+
+Board 04 is the strong result: byte-identical copper on the one fixture
+whose route actually enters an escalation loop under `--timeout`.
+
+### Reproducing this A/B
+
+```bash
+# B side: a PRISTINE checkout (clone, not your worktree) at the base commit.
+git clone --shared --no-checkout <repo> /tmp/ab-before && cd /tmp/ab-before
+git checkout <base-sha> && uv sync --frozen --extra dev --python 3.12
+uv run kct build-native                       # MUST report "available"
+PYTHONHASHSEED=42 uv run python boards/07-matchgroup-test/generate_design.py \
+  /tmp/board07-before --step all --seed 42
+
+# A side: the same command from the issue worktree.
+```
+
+The separate checkout is load-bearing, not hygiene: `route_pcb()` shells
+out to `python -m kicad_tools.cli route`, so a "before" arm launched from
+the worktree you are editing will silently pick up your changes on its
+*next* subprocess. Run at least two B arms before attributing any copper
+difference on this board to a diff.
+
 ## Files in this directory
 
 - `README.md` -- this file.

--- a/src/kicad_tools/cli/route_cmd.py
+++ b/src/kicad_tools/cli/route_cmd.py
@@ -5765,6 +5765,29 @@ def route_with_layer_escalation(
             )
             flush_print("=" * 60)
 
+        # Issue #2823: divide the remaining wall-clock budget fairly across
+        # the remaining layer-escalation attempts.  Without this, the first
+        # attempt (typically 2L) greedily consumes the entire ``--timeout``,
+        # leaving the higher-layer attempts (4L, 6L) no time to run -- so
+        # the escalation strategy degenerates to "spend everything on the
+        # lowest layer count, give up."  ``attempt_num`` is 1-based; the
+        # helper expects a 0-based index, hence ``attempt_num - 1``.
+        # Falls back to ``args.timeout`` when no deadline is configured.
+        #
+        # Issue #4798: computed HERE (ahead of ``load_pcb_for_routing``)
+        # rather than just before the route call, because the lattice's
+        # absolute ``lattice_deadline`` is stamped at load time and must be
+        # capped by this same fair slice.  ``_per_attempt_budgeted_timeout``
+        # depends only on ``args`` / ``attempt_num`` / ``layer_configs`` --
+        # same inputs, only the clock read moves earlier (slice grows by the
+        # load duration; measured inert on board 04) -- for the
+        # ``timeout=_attempt_timeout`` kwarg the other engines receive below.
+        _attempt_timeout = _per_attempt_budgeted_timeout(
+            args,
+            attempt_index=attempt_num - 1,
+            max_attempts=len(layer_configs),
+        )
+
         # Load PCB with this layer stack
         try:
             with spinner(f"Loading PCB ({layer_count} layers)...", quiet=quiet):
@@ -5794,7 +5817,11 @@ def route_with_layer_escalation(
                     # and --timeout supplies an absolute ceiling alongside it.
                     localize_lattice_to_region=getattr(args, "_complete_localized", False),
                     lattice_link_budget_s=_resolve_lattice_link_budget(args),
-                    lattice_deadline=_lattice_absolute_deadline(args),
+                    # Issue #4798: bound by THIS attempt's fair slice, not the
+                    # whole remaining run budget -- otherwise the lattice's
+                    # single whole-netset ``route_netset`` call can starve every
+                    # later escalation attempt.
+                    lattice_deadline=_lattice_attempt_deadline(args, _attempt_timeout),
                     # Issue #4170 (Phase 2b-1): board-relative boundary stub
                     # terminals whose tip cells are carved open as same-net
                     # reconnection targets (None when no --region / no stubs).
@@ -5872,19 +5899,8 @@ def route_with_layer_escalation(
 
         escape_flag = _resolve_escape_routing_flag(args)
 
-        # Issue #2823: divide the remaining wall-clock budget fairly across
-        # the remaining layer-escalation attempts.  Without this, the first
-        # attempt (typically 2L) greedily consumes the entire ``--timeout``,
-        # leaving the higher-layer attempts (4L, 6L) no time to run -- so
-        # the escalation strategy degenerates to "spend everything on the
-        # lowest layer count, give up."  ``attempt_num`` is 1-based; the
-        # helper expects a 0-based index, hence ``attempt_num - 1``.
-        # Falls back to ``args.timeout`` when no deadline is configured.
-        _attempt_timeout = _per_attempt_budgeted_timeout(
-            args,
-            attempt_index=attempt_num - 1,
-            max_attempts=len(layer_configs),
-        )
+        # ``_attempt_timeout`` (this attempt's #2823 fair slice) was computed
+        # ahead of ``load_pcb_for_routing`` above -- see issue #4798.
 
         try:
             if _should_use_escape_routing(router, escape_flag, quiet):
@@ -6796,6 +6812,24 @@ def route_with_rule_relaxation(
             via_in_pad_last_resort=getattr(args, "via_in_pad_last_resort", False),
         )
 
+        # Issue #2823: divide the remaining wall-clock budget fairly across
+        # the remaining rule-relaxation tiers so the looser-rule attempts
+        # also get a real chance to run.  Without this, tier 0 greedily
+        # consumes the full ``--timeout`` and the relaxation strategy
+        # degenerates to "spend everything on the strictest tier, give up."
+        # Falls back to ``args.timeout`` when no deadline is configured.
+        #
+        # Issue #4798: computed ahead of ``load_pcb_for_routing`` so the
+        # lattice's absolute ``lattice_deadline`` (stamped at load time) can be
+        # capped by the same slice.  Same inputs, only the clock read moves
+        # earlier (slice grows by the load duration; measured inert on board
+        # 04) for the value handed to the other engines as ``timeout=`` below.
+        _attempt_timeout = _per_attempt_budgeted_timeout(
+            args,
+            attempt_index=_tier_idx,
+            max_attempts=_relaxation_max_attempts,
+        )
+
         # Load PCB
         try:
             with spinner(f"Loading PCB (tier {tier.tier})...", quiet=quiet):
@@ -6822,7 +6856,9 @@ def route_with_rule_relaxation(
                     # and --timeout supplies an absolute ceiling alongside it.
                     localize_lattice_to_region=getattr(args, "_complete_localized", False),
                     lattice_link_budget_s=_resolve_lattice_link_budget(args),
-                    lattice_deadline=_lattice_absolute_deadline(args),
+                    # Issue #4798: bound by THIS tier's fair slice, not the
+                    # whole remaining run budget.
+                    lattice_deadline=_lattice_attempt_deadline(args, _attempt_timeout),
                     # Issue #4170 (Phase 2b-1): board-relative boundary stub
                     # terminals whose tip cells are carved open as same-net
                     # reconnection targets (None when no --region / no stubs).
@@ -6880,17 +6916,8 @@ def route_with_rule_relaxation(
 
         escape_flag = _resolve_escape_routing_flag(args)
 
-        # Issue #2823: divide the remaining wall-clock budget fairly across
-        # the remaining rule-relaxation tiers so the looser-rule attempts
-        # also get a real chance to run.  Without this, tier 0 greedily
-        # consumes the full ``--timeout`` and the relaxation strategy
-        # degenerates to "spend everything on the strictest tier, give up."
-        # Falls back to ``args.timeout`` when no deadline is configured.
-        _attempt_timeout = _per_attempt_budgeted_timeout(
-            args,
-            attempt_index=_tier_idx,
-            max_attempts=_relaxation_max_attempts,
-        )
+        # ``_attempt_timeout`` (this tier's #2823 fair slice) was computed
+        # ahead of ``load_pcb_for_routing`` above -- see issue #4798.
 
         try:
             if _should_use_escape_routing(router, escape_flag, quiet):
@@ -9048,6 +9075,26 @@ def route_with_combined_escalation(
                 via_in_pad_last_resort=getattr(args, "via_in_pad_last_resort", False),
             )
 
+            # Issue #2823: divide the remaining wall-clock budget fairly
+            # across all remaining cells of the 2D combined-escalation
+            # matrix so later (higher-layer or stricter-rule) attempts
+            # also get a real chance to run.  Without this, the first
+            # cell (2L, tier 0) greedily consumes the entire ``--timeout``
+            # and the rest of the matrix is starved.
+            # Falls back to ``args.timeout`` when no deadline is configured.
+            #
+            # Issue #4798: computed ahead of ``load_pcb_for_routing`` so the
+            # lattice's absolute ``lattice_deadline`` (stamped at load time)
+            # can be capped by the same slice.  Same inputs, only the clock
+            # read moves earlier (slice grows by the load duration; measured
+            # inert on board 04) for the value the other engines get as
+            # ``timeout=``.
+            _attempt_timeout = _per_attempt_budgeted_timeout(
+                args,
+                attempt_index=_combined_attempt_index,
+                max_attempts=_combined_max_attempts,
+            )
+
             # Load PCB
             try:
                 with spinner(f"Loading PCB ({layer_count}L, tier {tier.tier})...", quiet=quiet):
@@ -9074,7 +9121,9 @@ def route_with_combined_escalation(
                         # and --timeout supplies an absolute ceiling alongside it.
                         localize_lattice_to_region=getattr(args, "_complete_localized", False),
                         lattice_link_budget_s=_resolve_lattice_link_budget(args),
-                        lattice_deadline=_lattice_absolute_deadline(args),
+                        # Issue #4798: bound by THIS cell's fair slice, not the
+                        # whole remaining run budget.
+                        lattice_deadline=_lattice_attempt_deadline(args, _attempt_timeout),
                         # Issue #4170 (Phase 2b-1): board-relative boundary stub
                         # terminals whose tip cells are carved open as same-net
                         # reconnection targets (None when no --region / no stubs).
@@ -9118,18 +9167,8 @@ def route_with_combined_escalation(
             # Route
             escape_flag = _resolve_escape_routing_flag(args)
 
-            # Issue #2823: divide the remaining wall-clock budget fairly
-            # across all remaining cells of the 2D combined-escalation
-            # matrix so later (higher-layer or stricter-rule) attempts
-            # also get a real chance to run.  Without this, the first
-            # cell (2L, tier 0) greedily consumes the entire ``--timeout``
-            # and the rest of the matrix is starved.
-            # Falls back to ``args.timeout`` when no deadline is configured.
-            _attempt_timeout = _per_attempt_budgeted_timeout(
-                args,
-                attempt_index=_combined_attempt_index,
-                max_attempts=_combined_max_attempts,
-            )
+            # ``_attempt_timeout`` (this cell's #2823 fair slice) was computed
+            # ahead of ``load_pcb_for_routing`` above -- see issue #4798.
 
             try:
                 if _should_use_escape_routing(router, escape_flag, quiet):
@@ -10414,6 +10453,67 @@ def _lattice_absolute_deadline(args) -> float | None:
     if deadline is None:
         deadline = getattr(args, "_wall_clock_deadline", None)
     return float(deadline) if deadline is not None else None
+
+
+def _lattice_attempt_deadline(args, attempt_timeout: float | None) -> float | None:
+    """Absolute deadline for ONE escalation attempt's lattice negotiation.
+
+    Issue #4798.  Like :func:`_lattice_absolute_deadline`, but additionally
+    bounded by ``attempt_timeout`` -- this attempt's
+    :func:`_per_attempt_budgeted_timeout` slice -- when one is supplied.
+
+    Why this exists: the lattice negotiates the whole netset in a *single*
+    ``route_netset`` call, so ``route_all``'s between-nets ``timeout`` check
+    never fires and the absolute ``lattice_deadline`` is the only bound the
+    engine sees.  Handing it the whole-run deadline inside a multi-attempt
+    escalation loop lets attempt N consume every remaining attempt's budget --
+    the lattice equivalent of the pre-#2823 "first attempt eats everything"
+    regression that per-attempt budgeting exists to prevent for every other
+    engine (which all receive ``timeout=_attempt_timeout`` at the same sites).
+
+    The result is never *looser* than :func:`_lattice_absolute_deadline`:
+
+    * ``attempt_timeout`` is ``None`` (no ``--timeout``, or
+      ``--deterministic-budget`` without ``--timeout``, where
+      :func:`_per_attempt_budgeted_timeout` returns ``None``), **or is 0 /
+      negative** -- the documented unbounded sentinel
+      (:func:`_set_wall_clock_deadline`), which is not a slice at all -> the
+      absolute deadline verbatim, byte-identical to the pre-#4798 behaviour.
+    * otherwise (a real, positive slice) -> ``min(absolute deadline, now +
+      attempt slice)``, with the candidate returned verbatim when no absolute
+      deadline is configured.
+
+    Args:
+        args: Parsed CLI namespace (read only via
+            :func:`_lattice_absolute_deadline`).
+        attempt_timeout: This attempt's fair share of the remaining wall-clock
+            budget in seconds; ``None`` when no budget is configured, or
+            ``0``/negative for the unbounded sentinel.
+
+    Returns:
+        An absolute ``time.monotonic()`` ceiling, or ``None`` when neither
+        bound is configured.
+    """
+    absolute = _lattice_absolute_deadline(args)
+    # ``None``/``0``/negative are all "no real slice".  The 0-and-negative half
+    # matters: ``--timeout 0`` (and any negative value) is the documented
+    # UNBOUNDED sentinel -- see :func:`_set_wall_clock_deadline`, "If
+    # ``args.timeout`` is falsy (None, 0, or negative) the deadline is set to
+    # ``None`` so the rest of the orchestration treats the run as unbounded."
+    # On that path ``_per_attempt_budgeted_timeout`` returns the timeout
+    # verbatim (``_remaining_budget`` is ``None``) and no absolute deadline is
+    # stamped, so computing ``now + attempt_timeout`` here would hand the
+    # lattice an already-expired ceiling and abort an explicitly unbounded run
+    # instantly.  Returning ``absolute`` is also inert for a *genuine*
+    # exhausted-budget ``0.0``: that can only arise when ``_remaining_budget``
+    # clamps at zero, which requires an absolute deadline already <= now, where
+    # ``min(absolute, now) == absolute`` anyway.  Note ``not attempt_timeout``
+    # would NOT cover negatives (``not -5.0`` is ``False``), hence the explicit
+    # comparison.
+    if attempt_timeout is None or attempt_timeout <= 0:
+        return absolute
+    candidate = time.monotonic() + float(attempt_timeout)
+    return candidate if absolute is None else min(absolute, candidate)
 
 
 def _apply_complete_localization(args, pcb_path: Path) -> int:

--- a/tests/test_lattice_timeout_forwarding.py
+++ b/tests/test_lattice_timeout_forwarding.py
@@ -26,6 +26,8 @@ import pytest
 from kicad_tools.cli.route_cmd import (
     _COMPLETE_LINK_BUDGET_DEFAULT_S,
     _lattice_absolute_deadline,
+    _lattice_attempt_deadline,
+    _per_attempt_budgeted_timeout,
     _resolve_lattice_link_budget,
 )
 from kicad_tools.cli.route_cmd import (
@@ -154,6 +156,176 @@ class TestLatticeAbsoluteDeadline:
         got = _lattice_absolute_deadline(args)
         assert got is not None
         assert before < got <= before + 60.0 + 1.0
+
+
+# ---------------------------------------------------------------------------
+# _lattice_attempt_deadline: within a tier, the cap is the ATTEMPT's slice.
+#
+# Issue #4798.  ``_lattice_absolute_deadline`` returns the whole-invocation
+# deadline, which is the correct cap at the two single-attempt call sites but
+# wrong inside a multi-attempt escalation loop: the lattice negotiates the whole
+# netset in ONE ``route_netset`` call, so an unsliced absolute deadline lets
+# attempt N consume every later attempt's budget.  These cases pin the
+# arithmetic itself (never looser than the absolute deadline; only ever tighter,
+# and only when a fair slice is actually computed).
+# ---------------------------------------------------------------------------
+class TestLatticeAttemptDeadline:
+    def test_none_attempt_timeout_is_passthrough(self):
+        """No fair slice -> byte-identical to the pre-#4798 absolute cap."""
+        stamp = time.monotonic() + 120.0
+        args = argparse.Namespace(_routing_deadline=stamp, _wall_clock_deadline=stamp)
+        assert _lattice_attempt_deadline(args, None) == _lattice_absolute_deadline(args) == stamp
+
+    def test_none_everywhere_stays_uncapped(self):
+        args = argparse.Namespace(_routing_deadline=None, _wall_clock_deadline=None)
+        assert _lattice_attempt_deadline(args, None) is None
+
+    def test_attempt_slice_tighter_than_absolute_wins(self):
+        """The whole-run deadline is 600s out; this attempt only owns 150s."""
+        absolute = time.monotonic() + 600.0
+        args = argparse.Namespace(_routing_deadline=absolute, _wall_clock_deadline=absolute)
+        before = time.monotonic()
+        got = _lattice_attempt_deadline(args, 150.0)
+        assert got is not None
+        # now + 150s, comfortably inside the absolute cap.
+        assert before + 150.0 <= got <= time.monotonic() + 150.0
+        assert got < absolute
+
+    def test_absolute_tighter_than_attempt_slice_wins(self):
+        """A nearly-expired run budget clamps a generous per-attempt slice."""
+        absolute = time.monotonic() + 5.0
+        args = argparse.Namespace(_routing_deadline=absolute, _wall_clock_deadline=absolute)
+        assert _lattice_attempt_deadline(args, 900.0) == absolute
+
+    def test_no_absolute_deadline_returns_candidate_verbatim(self):
+        """--timeout absent but a slice supplied -> the slice becomes the cap."""
+        args = argparse.Namespace(_routing_deadline=None, _wall_clock_deadline=None)
+        before = time.monotonic()
+        got = _lattice_attempt_deadline(args, 30.0)
+        assert got is not None
+        assert before + 30.0 <= got <= time.monotonic() + 30.0
+
+    def test_missing_attributes_with_a_slice(self):
+        before = time.monotonic()
+        got = _lattice_attempt_deadline(argparse.Namespace(), 12.0)
+        assert got is not None
+        assert before + 12.0 <= got <= time.monotonic() + 12.0
+
+    @pytest.mark.parametrize("slice_s", [0.0, 1.0, 60.0, 600.0, 100_000.0])
+    def test_never_looser_than_the_absolute_deadline(self, slice_s: float):
+        """The invariant: this helper only ever TIGHTENS the pre-#4798 cap."""
+        absolute = time.monotonic() + 300.0
+        args = argparse.Namespace(_routing_deadline=absolute, _wall_clock_deadline=absolute)
+        got = _lattice_attempt_deadline(args, slice_s)
+        assert got is not None and got <= absolute
+
+    # -- the ``--timeout 0`` / negative UNBOUNDED sentinel must not expire ----
+    #
+    # ``_set_wall_clock_deadline``: "If ``args.timeout`` is falsy (None, 0, or
+    # negative) the deadline is set to ``None`` so the rest of the
+    # orchestration treats the run as unbounded."  On that path
+    # ``_per_attempt_budgeted_timeout`` returns the timeout verbatim (0.0 /
+    # -5.0) and no absolute deadline is stamped, so a naive ``now +
+    # attempt_timeout`` would hand the lattice an already-expired ceiling and
+    # abort an explicitly unbounded run instantly.
+    def test_zero_slice_without_an_absolute_deadline_stays_unbounded(self):
+        """``--timeout 0`` is the unbounded sentinel, not a zero-length slice."""
+        args = argparse.Namespace(_routing_deadline=None, _wall_clock_deadline=None)
+        assert _lattice_attempt_deadline(args, 0.0) is None
+
+    def test_negative_slice_without_an_absolute_deadline_stays_unbounded(self):
+        """Negative ``--timeout`` is unbounded too (``not -5.0`` is ``False``)."""
+        args = argparse.Namespace(_routing_deadline=None, _wall_clock_deadline=None)
+        assert _lattice_attempt_deadline(args, -5.0) is None
+
+    @pytest.mark.parametrize("slice_s", [0.0, -5.0])
+    def test_nonpositive_slice_with_an_absolute_deadline_returns_it_verbatim(self, slice_s: float):
+        """A non-slice never tightens the cap -- the absolute deadline stands.
+
+        Inert for a *genuine* exhausted-budget ``0.0``, which can only arise
+        when ``_remaining_budget`` clamps at zero -- and that requires an
+        absolute deadline already ``<= now``, where the old
+        ``min(absolute, now)`` collapsed to ``absolute`` anyway.
+        """
+        absolute = time.monotonic() + 300.0
+        args = argparse.Namespace(_routing_deadline=absolute, _wall_clock_deadline=absolute)
+        assert _lattice_attempt_deadline(args, slice_s) == absolute
+
+    def test_expired_absolute_budget_still_yields_a_past_deadline(self):
+        """The real exhausted-budget shape: the absolute cap is already past."""
+        absolute = time.monotonic() - 1.0
+        args = argparse.Namespace(_routing_deadline=absolute, _wall_clock_deadline=absolute)
+        got = _lattice_attempt_deadline(args, 0.0)
+        assert got is not None and got <= time.monotonic()
+
+    def test_auto_fix_reserve_is_still_honored(self):
+        """The absolute term still comes from ``_routing_deadline`` (#3238)."""
+        routing = time.monotonic() + 40.0
+        args = argparse.Namespace(_routing_deadline=routing, _wall_clock_deadline=routing + 20.0)
+        assert _lattice_attempt_deadline(args, 900.0) == routing
+
+    # -- the #4802 --deterministic-budget sentinel must stay inert ----------
+    def test_deterministic_budget_without_timeout_collapses_to_absolute(self):
+        """``--deterministic-budget`` alone: no deadline -> nothing changes.
+
+        ``--deterministic-budget`` pins ``per_net_timeout`` to the ``0.0``
+        sentinel (#4776/#4802) and does NOT stamp a wall-clock deadline, so
+        ``_per_attempt_budgeted_timeout`` returns ``None`` at every escalation
+        site and ``_lattice_attempt_deadline`` collapses to
+        ``_lattice_absolute_deadline`` -- byte-identical to pre-#4798.
+        """
+        args = argparse.Namespace(
+            timeout=None,
+            per_net_timeout=0.0,
+            _routing_deadline=None,
+            _wall_clock_deadline=None,
+        )
+        slice_s = _per_attempt_budgeted_timeout(args, attempt_index=0, max_attempts=4)
+        assert slice_s is None
+        assert _lattice_attempt_deadline(args, slice_s) == _lattice_absolute_deadline(args) is None
+
+    def test_zero_per_net_timeout_sentinel_is_not_read_as_a_slice(self):
+        """The ``0.0`` sentinel must never leak in as ``attempt_timeout``.
+
+        Guards the #4798 hoist against accidentally coupling to
+        ``args.per_net_timeout``: with a real ``--timeout`` present the slice
+        comes from the wall-clock budget (75s of a 300s budget across 4
+        attempts), not from the disabled per-link sentinel.
+        """
+        absolute = time.monotonic() + 300.0
+        args = argparse.Namespace(
+            timeout=300.0,
+            per_net_timeout=0.0,
+            _routing_deadline=absolute,
+            _wall_clock_deadline=absolute,
+        )
+        slice_s = _per_attempt_budgeted_timeout(args, attempt_index=0, max_attempts=4)
+        assert slice_s is not None
+        assert 70.0 <= slice_s <= 75.0  # ~300/4, minus test-execution jitter
+        got = _lattice_attempt_deadline(args, slice_s)
+        assert got is not None and got < absolute
+
+    def test_fair_slice_shrinks_the_cap_across_a_four_attempt_ladder(self):
+        """End-to-end arithmetic: attempt 0 of 4 gets ~1/4 of the budget."""
+        args = argparse.Namespace(timeout=400.0, auto_fix=False)
+        from kicad_tools.cli.route_cmd import _set_wall_clock_deadline
+
+        _set_wall_clock_deadline(args)
+        absolute = _lattice_absolute_deadline(args)
+        assert absolute is not None
+
+        first = _lattice_attempt_deadline(
+            args, _per_attempt_budgeted_timeout(args, attempt_index=0, max_attempts=4)
+        )
+        last = _lattice_attempt_deadline(
+            args, _per_attempt_budgeted_timeout(args, attempt_index=3, max_attempts=4)
+        )
+        assert first is not None and last is not None
+        # The first attempt is capped near now+100s, NOT near the now+400s
+        # whole-run deadline it used to receive.
+        assert first < absolute - 250.0
+        # The final attempt may use whatever remains -> the absolute cap.
+        assert last == absolute
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_layer_escalation.py
+++ b/tests/test_layer_escalation.py
@@ -3047,3 +3047,223 @@ class TestStartingLayersEndToEnd:
             f"Expected first attempt to be 2L by default, got "
             f"{layer_counts_seen[0]} (full sequence: {layer_counts_seen})"
         )
+
+
+class TestLatticeDeadlineIsPerAttempt:
+    """Issue #4798: the ``lattice_deadline`` handed to ``load_pcb_for_routing``
+    inside an escalation loop is capped by THIS attempt's #2823 fair slice, not
+    by the whole remaining run budget.
+
+    The lattice engine negotiates the whole netset in a single ``route_netset``
+    call, so ``route_all``'s between-nets ``timeout`` check never fires and the
+    absolute ``lattice_deadline`` is the only bound it sees.  Before this fix
+    the first attempt could consume every later attempt's budget -- the lattice
+    equivalent of the pre-#2823 regression.
+    """
+
+    def _make_mock_router(self, nets_routed=1, nets_to_route=5, overflow=20):
+        from unittest.mock import MagicMock
+
+        router = MagicMock()
+        router.nets = {i: [f"pad{j}" for j in range(2)] for i in range(1, nets_to_route + 1)}
+        router.grid.width = 50.0
+        router.grid.height = 40.0
+        router.grid.get_total_overflow.return_value = overflow
+        router.get_statistics.return_value = {
+            "nets_routed": nets_routed,
+            "segments": 10,
+            "vias": 2,
+        }
+        router.power_stall_abort = False
+        router._pour_nets_without_zones = set()
+        router._is_pour_net.return_value = False
+        router.rules.via_diameter = 0.6
+        router.rules.min_drill_clearance = 0.0
+        router.rules.trace_width = 0.2
+        router.rules.trace_clearance = 0.15
+        router._edge_clearance = None
+        router._edge_segments = None
+        return router
+
+    def _make_args(self, **overrides):
+        defaults = {
+            "backend": "python",
+            "grid": 0.25,
+            "trace_width": 0.2,
+            "clearance": 0.15,
+            "via_drill": 0.3,
+            "via_diameter": 0.6,
+            "fine_pitch_clearance": None,
+            "skip_nets": None,
+            "auto_pour": False,
+            "max_layers": 6,
+            "starting_layers": None,
+            "min_completion": 0.95,
+            "strategy": "negotiated",
+            "verbose": False,
+            "force": False,
+            "timeout": 600,
+            "iterations": 3,
+            "per_net_timeout": None,
+            "batch_routing": False,
+            "high_performance": False,
+            "hierarchical": False,
+            "perturbation": True,
+            "two_phase": False,
+            "multi_resolution": False,
+            "edge_clearance": 0.25,
+            "escape_routing": None,
+            "no_optimize": True,
+            "dry_run": True,
+        }
+        defaults.update(overrides)
+        return SimpleNamespace(**defaults)
+
+    _PCB = (
+        "(kicad_pcb\n"
+        "  (version 20240101)\n"
+        '  (generator "test")\n'
+        "  (layers\n"
+        '    (0 "F.Cu" signal)\n'
+        '    (31 "B.Cu" signal)\n'
+        "  )\n"
+        ")"
+    )
+
+    def _run(self, tmp_path, args):
+        """Drive the escalation loop, returning every ``lattice_deadline`` seen."""
+        from kicad_tools.cli.route_cmd import route_with_layer_escalation
+
+        pcb = tmp_path / "two_layer.kicad_pcb"
+        pcb.write_text(self._PCB)
+        out = tmp_path / "out.kicad_pcb"
+
+        seen: list[float | None] = []
+
+        def mock_load(*_args, **kwargs):
+            seen.append(kwargs.get("lattice_deadline"))
+            return self._make_mock_router(), {}
+
+        with patch("kicad_tools.router.load_pcb_for_routing", mock_load):
+            with patch("kicad_tools.router.is_cpp_available", return_value=False):
+                route_with_layer_escalation(pcb, out, args, quiet=True)
+        return seen
+
+    @patch("kicad_tools.cli.route_cmd._auto_skip_pour_nets", return_value=([], []))
+    @patch("kicad_tools.cli.route_cmd._should_use_escape_routing", return_value=False)
+    @patch("kicad_tools.cli.route_cmd._resolve_escape_routing_flag", return_value=None)
+    def test_first_attempt_is_capped_by_its_fair_slice(self, _esc_flag, _esc_use, _pour, tmp_path):
+        """With a 600 s budget over an N-attempt ladder, attempt 1 gets ~600/N.
+
+        The pre-#4798 behaviour handed attempt 1 the full ``now + 600 s``
+        whole-run deadline.
+        """
+        import time
+
+        from kicad_tools.cli.route_cmd import _set_wall_clock_deadline
+
+        args = self._make_args(timeout=600, auto_fix=False)
+        _set_wall_clock_deadline(args)
+        absolute = args._routing_deadline
+        assert absolute is not None
+
+        seen = self._run(tmp_path, args)
+        assert seen, "the escalation loop must have loaded at least one attempt"
+        assert len(seen) > 1, "need a multi-attempt ladder to exercise the slice"
+
+        # Every attempt is bounded by the whole-run deadline (never looser).
+        for deadline in seen:
+            assert deadline is not None
+            assert deadline <= absolute + 1e-6
+
+        # The FIRST attempt is strictly tighter than the whole-run deadline:
+        # its fair slice is ~600/len(seen) seconds from now.
+        expected_slice = 600.0 / len(seen)
+        assert seen[0] < absolute, (
+            "the first lattice attempt must NOT receive the whole-run deadline "
+            f"(got {seen[0]}, whole-run {absolute})"
+        )
+        assert seen[0] <= time.monotonic() + expected_slice + 5.0
+
+    @patch("kicad_tools.cli.route_cmd._auto_skip_pour_nets", return_value=([], []))
+    @patch("kicad_tools.cli.route_cmd._should_use_escape_routing", return_value=False)
+    @patch("kicad_tools.cli.route_cmd._resolve_escape_routing_flag", return_value=None)
+    def test_no_timeout_leaves_the_deadline_none(self, _esc_flag, _esc_use, _pour, tmp_path):
+        """No ``--timeout`` -> no slice -> ``None``, byte-identical to pre-#4798."""
+        args = self._make_args(timeout=None, auto_fix=False)
+        args._routing_deadline = None
+        args._wall_clock_deadline = None
+
+        seen = self._run(tmp_path, args)
+        assert seen
+        assert all(deadline is None for deadline in seen), seen
+
+
+class TestLatticeDeadlineCallSites:
+    """Issue #4798 structural guard: the three multi-attempt escalation loops
+    must use ``_lattice_attempt_deadline``; the two single-attempt call sites
+    must keep using ``_lattice_absolute_deadline`` verbatim.
+    """
+
+    @pytest.mark.parametrize(
+        "func_name",
+        [
+            "route_with_layer_escalation",
+            "route_with_rule_relaxation",
+            "route_with_combined_escalation",
+        ],
+    )
+    def test_escalation_loops_use_the_attempt_capped_helper(self, func_name):
+        import inspect
+
+        from kicad_tools.cli import route_cmd as route_cmd_mod
+
+        source = inspect.getsource(getattr(route_cmd_mod, func_name))
+        assert "lattice_deadline=_lattice_attempt_deadline(args, _attempt_timeout)" in source, (
+            f"{func_name} must cap the lattice deadline by this attempt's "
+            "_per_attempt_budgeted_timeout slice (issue #4798)"
+        )
+        assert "_lattice_absolute_deadline" not in source, (
+            f"{func_name} must NOT pass the whole-run deadline to the lattice (issue #4798)"
+        )
+
+    @pytest.mark.parametrize(
+        "func_name",
+        [
+            "route_with_layer_escalation",
+            "route_with_rule_relaxation",
+            "route_with_combined_escalation",
+        ],
+    )
+    def test_attempt_timeout_is_computed_before_the_load(self, func_name):
+        """The hoist: ``_attempt_timeout`` must precede ``load_pcb_for_routing``.
+
+        Otherwise the ``lattice_deadline=`` kwarg would reference an undefined
+        (or stale, previous-attempt) value.
+        """
+        import inspect
+
+        from kicad_tools.cli import route_cmd as route_cmd_mod
+
+        source = inspect.getsource(getattr(route_cmd_mod, func_name))
+        compute = source.index("_attempt_timeout = _per_attempt_budgeted_timeout(")
+        load = source.index("router, net_map = load_pcb_for_routing(")
+        assert compute < load, (
+            f"{func_name} must compute _attempt_timeout BEFORE load_pcb_for_routing "
+            "so the lattice deadline can be capped by it (issue #4798)"
+        )
+
+    def test_single_attempt_call_sites_keep_the_absolute_deadline(self):
+        """``main()``'s primary load + the ``--order-method`` throwaway router
+        are not inside a multi-attempt loop, so the whole-run deadline is
+        already the correct per-attempt cap there.
+        """
+        import inspect
+
+        from kicad_tools.cli import route_cmd as route_cmd_mod
+
+        source = inspect.getsource(route_cmd_mod)
+        assert source.count("lattice_deadline=_lattice_absolute_deadline(args)") == 2, (
+            "exactly the two single-attempt call sites must keep the "
+            "unsliced absolute deadline (issue #4798)"
+        )


### PR DESCRIPTION
## Summary

Within an escalation attempt, the lattice engine's absolute wall-clock cap was
the **whole remaining run budget**, not that attempt's fair
`_per_attempt_budgeted_timeout` slice.

The lattice negotiates the whole netset in a *single* `route_netset` call, so
`route_all`'s between-nets `timeout` check never fires mid-run and the absolute
`lattice_deadline` (stamped onto `router._lattice_deadline` by
`load_pcb_for_routing`, consumed by `Autorouter._negotiate_lattice_netset`) is
the **only** bound `--route-engine lattice` sees. All three multi-attempt
escalation sites passed `_lattice_absolute_deadline(args)` — the
end-of-invocation deadline spanning *every* remaining attempt — so under
`--route-engine lattice --timeout N` with a multi-attempt ladder, attempt 1
could consume the entire remaining budget and starve attempts 2..N. That is the
lattice equivalent of the pre-#2823 "first attempt eats everything" regression
that per-attempt budgeting already prevents for every other engine (all of which
receive `timeout=_attempt_timeout` at these same sites).

## Changes

- **`src/kicad_tools/cli/route_cmd.py`**
  - New `_lattice_attempt_deadline(args, attempt_timeout)` beside
    `_lattice_absolute_deadline`: returns `min(whole-run deadline, now + this
    attempt's slice)`; passes the absolute deadline through **verbatim** when
    `attempt_timeout is None`; returns the candidate verbatim when no absolute
    deadline is configured. Only ever *tighter*, never looser. No new
    `time.monotonic()` read anywhere else.
  - `_attempt_timeout = _per_attempt_budgeted_timeout(...)` hoisted ahead of
    `load_pcb_for_routing` at exactly three sites —
    `route_with_layer_escalation` (`attempt_num - 1` / `len(layer_configs)`),
    the rule-relaxation tier ladder (`_tier_idx` /
    `_relaxation_max_attempts`), and the combined 2D matrix
    (`_combined_attempt_index` / `_combined_max_attempts`) — and each site's
    `lattice_deadline=` switched to `_lattice_attempt_deadline(args,
    _attempt_timeout)`.
- **`tests/test_lattice_timeout_forwarding.py`** — new
  `TestLatticeAttemptDeadline` (13 cases) pinning the cap arithmetic.
- **`tests/test_layer_escalation.py`** — new `TestLatticeDeadlineIsPerAttempt`
  (behavioural, through the real escalation loop with a mocked router boundary)
  and `TestLatticeDeadlineCallSites` (structural guards for all five call
  sites).
- **`boards/07-matchgroup-test/diagnostic-runs/README.md`** — the A/B below.
- **`CHANGELOG.md`** — `[Unreleased] → ### Fixed`.

### Scope guard (what deliberately did **not** change)

- `_lattice_absolute_deadline` itself is untouched, and still used verbatim at
  the two genuinely single-attempt call sites (`main()`'s primary
  `load_pcb_for_routing`, the `--order-method` throwaway-router factory) and by
  the display-only `--timeout` banner check. A structural test asserts the
  literal `lattice_deadline=_lattice_absolute_deadline(args)` appears **exactly
  twice** in the module.
- The `--deterministic-budget` `0.0` sentinel semantics from #4776/#4802:
  without `--timeout`, `_remaining_budget` is `None` ⇒
  `_per_attempt_budgeted_timeout` is `None` ⇒ `_lattice_attempt_deadline`
  collapses to `_lattice_absolute_deadline`, byte-identical to today. Pinned by
  two tests, one of which specifically asserts the hoist did not start reading
  `args.per_net_timeout`.
- `Autorouter._post_negotiation_sweep_bounds` / `_active_expansion_cap` and
  `cli/mfr_tier_budget.py` (`per_tier_routing_budget`) — not touched.

## Acceptance Criteria Verification

| AC | Status | Evidence |
|---|---|---|
| Attempt deadline is `min(whole-run deadline, now + slice)`; never looser | ✅ | `_lattice_attempt_deadline`; `test_never_looser_than_the_absolute_deadline` (parametrized 0/1/60/600/100 000 s), `test_absolute_tighter_than_attempt_slice_wins`, `test_attempt_slice_tighter_than_absolute_wins` |
| `_attempt_timeout` hoisted across `load_pcb_for_routing` at all three sites; no other call sites touched | ✅ | `TestLatticeDeadlineCallSites::test_attempt_timeout_is_computed_before_the_load` (parametrized over the three functions) + `test_escalation_loops_use_the_attempt_capped_helper` |
| No behavior change without `--timeout`, and none for `--deterministic-budget` without `--timeout` | ✅ | `test_none_attempt_timeout_is_passthrough`, `test_none_everywhere_stays_uncapped`, `test_deterministic_budget_without_timeout_collapses_to_absolute`, `test_zero_per_net_timeout_sentinel_is_not_read_as_a_slice`, `test_no_timeout_leaves_the_deadline_none` (end-to-end through the loop) |
| No behavior change at the two single-attempt call sites or the banner | ✅ | `test_single_attempt_call_sites_keep_the_absolute_deadline` (exact count == 2); banner line untouched in the diff |
| Unit test on the cap arithmetic itself (None / slice-wins / absolute-wins / no-absolute) | ✅ | `TestLatticeAttemptDeadline`, 13 cases, table-style like the existing file |
| **MANDATORY board-07 A/B** posted, identical-or-better | ✅ | tables below; nothing regressed |

## MANDATORY A/B: board 07 (merge gate)

**Method.** Same host (Apple Silicon, 28 cores), C++ backend built in both
checkouts (`build version 19`), `PYTHONHASHSEED=42 uv run python
boards/07-matchgroup-test/generate_design.py <out> --step all --seed 42`, then
the two CI asserters out-of-process (`python -m kicad_tools.lvs.copper_lvs` →
`check_copper_lvs.py --expect-opens`, and `check_routed_drc.py` over the staged
repo-relative path). Arms run **serially**, never concurrently.

**The "before" arm was run from a separate pristine clone at the base commit
`33666637`, not from the worktree.** This is load-bearing: `route_pcb()` shells
out to `python -m kicad_tools.cli route`, so a "before" arm launched from the
checkout you are editing silently picks up your changes on its *next*
subprocess. (My first attempt did exactly that and was discarded.)

A **second "before" run (B2)** on the same pristine clone was added as the
run-to-run control.

| | B (`main` @ `33666637`) | B2 (control, same `main`) | A (#4798) |
|---|---|---|---|
| final reach | 26/31 | 26/31 | **26/31** |
| copper-LVS opens | `DQ3, DQ4, MIPI_DAT0_N, TMDS_D0_N, TMDS_D1_N` | identical | **identical** |
| copper-LVS shorts / vacuous | 0 / 0 | 0 / 0 | **0 / 0** |
| bound pads | 244 | 244 | **244** |
| `check_copper_lvs.py --expect-opens` | exit 0 | exit 0 | **exit 0** |
| blocking DRC (`check_routed_drc.py`, jlcpcb, allowlist 8) | **8** | **8** | **8** |
| DRC rule split | `diffpair_length_skew` 4 + `diffpair_routing_continuity` 4 | identical | **identical** |
| raw `kct check` errors | 13 (8 blocking + 5 advisory `connectivity`) | 13 | **13** |
| deltas proposed / kept | 10 / 0 | 10 / 0 | **10 / 0** |
| final-pass rip-up iterations | 10 | 10 | 10 |
| normalized PCB md5 (uuid-stripped, sorted) | `026d5506…` | `1f36faa9…` | `1f36faa9…` |

**Every gated metric is identical.** LVS open set: identical. Routed-DRC count
and rule ids: identical. Nothing regressed.

**On the md5 column** — this is why the control run matters. `B` and `B2` are
the *same code* and produce **different** copper; `B2` and `A` are
**byte-identical** after uuid normalization. So the drift is run-to-run
wall-clock variance on this fixture, not the diff: board 07's stage deadline is
still a 600 s **wall clock** even under `--deterministic-budget` (documented in
the #4770/#4781 sections of the same README), so how much of a rip-up iteration
fits is a function of host load. A normalized log diff between `B` and `A` is 30
lines — all elapsed-time stamps, one zero-overflow-recovery denominator (`0/7`
vs `0/8`), the stranded-pad coordinates of the *same* 5 known-open nets, and a
one-segment orthogonal/45° split shift.

As the curator predicted, board 07 cannot reach this code path at all:
`generate_design.py` drives `--strategy negotiated --no-auto-layers --layers 4`,
so none of the three escalation loops runs, and the engine is the grid
negotiator (only `_negotiate_lattice_netset` reads `_lattice_deadline`). Run and
documented anyway, per the #4802 "insensitive but measured" precedent.

## Additional A/B: board 04 (the board this change can actually reach)

Board 07 is insensitive by construction, so I added the fixture that **does**
run `route_with_layer_escalation` under a wall-clock budget:
`boards/04-stm32-devboard` routes with `--auto-layers --auto-mfr-tier
--deterministic-budget --timeout 600`. It therefore exercises the hoisted
`_attempt_timeout` — which the negotiated arm still receives as its `timeout=`
kwarg — and is the right place to look for any collateral from the hoist. Same
two checkouts, same host, serial:

| | B (`main` @ `33666637`) | A (#4798) |
|---|---|---|
| nets routed | 9/9 | **9/9** |
| routed DRC (`check_routed_drc.py`, jlcpcb-tier1, **strict 0**) | **0** | **0** |
| copper-LVS (`check_copper_lvs.py`, plain clean gate) | clean, exit 0 | **clean, exit 0** |
| recipe verdict | ERC PASS / Routing SUCCESS / DRC PASS / LVS PASS / **Overall PASS** | **identical** |
| normalized PCB md5 (uuid-stripped, sorted) | `4444f351…` | `4444f351…` — **identical artifact** |

Byte-identical copper on the one fixture whose route actually enters an
escalation loop under `--timeout`. Worth stating explicitly since the issue body
claims the hoist "does not change the value": strictly, `_per_attempt_budgeted_timeout`
reads `time.monotonic()` via `_remaining_budget`, so computing it before the
load rather than after makes the slice larger by the load's duration. Board 04
is the empirical answer to whether that matters: it does not.

## Test Plan

```
uv run pytest tests/test_lattice_timeout_forwarding.py tests/test_layer_escalation.py \
  tests/test_mfr_tier_budget.py tests/test_route_cmd_total_timeout.py \
  tests/test_route_deterministic_budget.py \
  tests/test_route_deterministic_budget_load_independence.py \
  tests/test_cli_route_complete_4471.py
→ 234 passed, 1 skipped
```

- `uv run ruff check .` → clean (one pre-existing `MFR001 # noqa` warning in
  `src/kicad_tools/pcb/reinforce.py`, untouched)
- `uv run ruff format --check src/ tests/` → 1726 files already formatted
- `uv run python scripts/ci/check_mypy_baseline.py` → `OK: mypy reports 1470
  error(s), all within the baseline (1472 allowed). No new type errors.` The
  advisory "2 baseline errors no longer occur" is the known native-build
  artifact (nanobind `import-not-found` lines drop in a worktree with the C++
  extension built) — baseline **not** updated, per `CLAUDE.md`.
- Board 07 A/B + board 04 A/B above; recorded in
  `boards/07-matchgroup-test/diagnostic-runs/README.md`.

Closes #4798
