### PR TITLE
feat(cli): add --format json to the five board-improvement driver commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,36 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`--format json` on the 5 board-improvement drivers** (part of #4674,
+  sixth batch of the #4543 machine-output sweep) — `optimize-placement`,
+  `optimize-traces`, `route-auto`, `reason` and `creepage-export-rules` now
+  accept the canonical `--format json` and emit one deterministic document on
+  stdout instead of prose, wired end-to-end (outer parser → shim → inner
+  parser/handler). `optimize-placement` reports the `board` summary, the
+  `initial`/`final` score breakdowns (taken straight off the cost dataclass),
+  `iterations`, `feasible` + `infeasible_detail` and `written_to`;
+  `optimize-traces` reports the enabled `optimizations` and the before/after
+  `stats`; `route-auto` reports one `nets[]` entry per requested net (metrics,
+  written copper, warnings, partial `pads_connected`/`pads_total`, or the
+  failure and its `alternative_strategies`); `reason` reports the board
+  summary, the DRC block and the selected `mode`'s payload (`prompt` /
+  `analysis` / `state` / `auto_route`); `creepage-export-rules` reports the
+  derived `domains`, `rules` and `bridging_exemptions` plus `written`.
+  Commands that can run without writing say so structurally (`saved` /
+  `written` / `written_to: null` under `--dry-run`), failure paths emit
+  `{"error": ..., "success": false}` documents with **exit codes unchanged**
+  (including `route-auto`'s usage exit 2 and `optimize-placement`'s
+  interrupt exit 2), and text-mode output is byte-identical. Two behaviours
+  worth calling out: `kct reason --interactive --format json` is **refused**
+  (exit 2, error document) because a stdin/stdout dialogue has no
+  single-document form; and `route-auto` / `reason --auto-route` now divert
+  the negotiated router's stdout progress log to stderr in JSON mode so the
+  document stays parseable. Audit (`scripts/audit_machine_output.py`):
+  prose-only 13 → 8, format-json 184 → 189 (only `build`, `pipeline` and
+  `stitch` remain actionable). `tests/test_format_json_sweep_drivers.py`
+  guards the new surfaces; `docs/reference/machine-output.md` records the
+  per-command shapes.
+
 - **Placement pad-anchoring audit** (`docs/placement-pad-anchoring-audit.md`,
   part of #4831) — a docs-only, symbol-anchored survey of where the placement
   stack measures distance between component **centres** versus real **pad**

--- a/docs/reference/machine-output.md
+++ b/docs/reference/machine-output.md
@@ -52,13 +52,13 @@ below is issue **#4674** and should build on these helpers.
 Measured by programmatic introspection of the real argparse tree
 (`create_parser()`, recursive walk of `_SubParsersAction` leaves) — not grep:
 
-| Idiom (outer `kct` parser) | Before #4543 | After #4543 | After #4674 b1 | b2 | b3 | b4 | b5 |
-|---|---|---|---|---|---|---|---|
-| `--format` with a `json` choice | 124 | 124 | 148 | 164 | 174 | 179 | 184 |
-| Both `--format json` and legacy `--json` alias | 0 | 2 (`placement refine`, `calibrate`) | 2 | 2 | 2 | 2 | 2 |
-| `--json` boolean only | 2 | **0** | 0 | 0 | 0 | 0 | 0 |
-| `--format` without a `json` choice | 1 (`benchmark report`, `text,markdown`) | 1 | **0** | 0 | 0 | 0 | 0 |
-| Neither (prose-only) | 72 | 72 (backlog for #4674, below) | 49 | 33 | 23 | 18 | 13 |
+| Idiom (outer `kct` parser) | Before #4543 | After #4543 | After #4674 b1 | b2 | b3 | b4 | b5 | b6 |
+|---|---|---|---|---|---|---|---|---|
+| `--format` with a `json` choice | 124 | 124 | 148 | 164 | 174 | 179 | 184 | 189 |
+| Both `--format json` and legacy `--json` alias | 0 | 2 (`placement refine`, `calibrate`) | 2 | 2 | 2 | 2 | 2 | 2 |
+| `--json` boolean only | 2 | **0** | 0 | 0 | 0 | 0 | 0 | 0 |
+| `--format` without a `json` choice | 1 (`benchmark report`, `text,markdown`) | 1 | **0** | 0 | 0 | 0 | 0 | 0 |
+| Neither (prose-only) | 72 | 72 (backlog for #4674, below) | 49 | 33 | 23 | 18 | 13 | 8 |
 
 The first #4674 batch swept the grouped-subcommand families -- `mfr` (7),
 `spec` (5), `placement fix/nudge/snap/align/distribute` (5), `zones
@@ -76,9 +76,13 @@ The fourth batch swept the environment/integration singles -- `config`,
 family outright and finishing `mcp` (`mcp serve` is exempt).
 
 The fifth batch swept the board-artifact producers -- `board-metrics`,
-`create-pcb`, `panel`, `report generate`, `screenshot` (5). The remaining
-13 prose-only leaves (`stitch` and the rest of the long tail, plus the 4
-exempt and the deferred `route`) stay on the #4674 backlog below.
+`create-pcb`, `panel`, `report generate`, `screenshot` (5).
+
+The sixth batch swept the board-improvement / rule-derivation drivers --
+`optimize-placement`, `optimize-traces`, `route-auto`, `reason`,
+`creepage-export-rules` (5). The remaining 8 prose-only leaves (`build`,
+`pipeline`, `stitch`, plus the 4 exempt and the deferred `route`) stay on the
+#4674 backlog below.
 
 Issue #4543 closed the `--json`-only bucket by adding `--format {text,json}`
 alongside the existing `--json` on both commands (outer parser, forwarding
@@ -282,14 +286,44 @@ Three conventions this batch adds:
 
 `tests/test_format_json_sweep_artifacts.py` guards these 5 surfaces.
 
-**Remaining actionable (8)** — the audit's `prose-only` bucket reads 13
+**Done (sixth #4674 batch, 5 surfaces):** the board-improvement /
+rule-derivation drivers — the singles that take an existing board and derive
+an improvement or an enforceable rule set from it: `optimize-placement`,
+`optimize-traces`, `route-auto`, `reason`, `creepage-export-rules`. Shapes:
+
+| Command | Document |
+|---|---|
+| `optimize-placement` | `{"command": "optimize-placement", "pcb", "output", "strategy", "seed_method", "max_iterations", "board": {width_mm, height_mm, components, nets}, "mode": "evaluate"\|"optimize", "scores": {…}, "feasible", "infeasible_detail", "iterations", "wall_time_s", "interrupted", "overlaps_remaining", "allow_infeasible", "dry_run", "saved", "written_to", "success"}` — `scores` is `{"current": …}` under `--dry-run` and `{"initial", "final"}` otherwise; each score is `{total, feasible, breakdown}` with the breakdown taken straight off the cost dataclass |
+| `optimize-traces` | `{"command": "optimize-traces", "pcb", "output", "net_filter", "optimizations": {merge_collinear, eliminate_zigzags, convert_45_corners, chamfer_size_mm}, "drc_aware", "manufacturer", "layers", "copper_oz", "stats": {segments_before/after, corners_before/after, length_before_mm/after_mm, …}, "dry_run", "saved", "written_to", "success"}` |
+| `route-auto` | `{"command": "route-auto", "pcb", "output", "strategy", "dry_run", "nets": [...], "nets_requested", "nets_routed", "success"}` — one `nets[]` entry per requested net in request order: routed entries carry `success`/`partial`/`strategy_used`/`metrics`/`segments_written`/`warnings`/`pads_connected`/`pads_total`/`error`/`alternative_strategies`, `--dry-run` entries carry the preview (`would_route`, `via_drill_mm` + `via_drill_source`, …) |
+| `reason` | `{"command": "reason", "pcb", "output", "dry_run", "warnings", "drc": {ran, source, …}, "board": {…}, "mode": "prompt"\|"analyze"\|"export-state"\|"auto-route", …, "success"}` — plus the mode's own payload: `prompt`, `analysis`, `state` + `state_output`, or `auto_route` (`attempted`/`routed`/`nets[]`) with `saved`/`written_to` |
+| `creepage-export-rules` | `{"command": "creepage-export-rules", "project", "pcb", "dru", "voltage_map", "standard", "pollution_degree", "material_group", "hv_threshold_v", "dru_floor_mm", "domains", "net_domains", "nets_assigned", "rules": [{name, condition, min_mm}], "bridging_exemptions", "dru_block", "dry_run", "written", "skipped_reason", "success"}` — `dru_block` is carried only on the `--dry-run` path (mirroring the prose that prints it instead of writing it) |
+
+Three conventions this batch adds or reinforces:
+
+- **A mode with no single-document form is refused, not half-emitted.**
+  `kct reason --interactive` is a stdin/stdout dialogue; combining it with
+  `--format json` emits `{"error": …}` and exits 2 rather than pretending
+  to have a payload. Prefer this over silently ignoring the flag when only
+  *part* of a command is interactive (a whole-command exemption belongs in
+  the table above instead).
+- **Volatile fields are named, not hidden.** `optimize-placement` reports
+  `wall_time_s`; like `board-metrics`'s `generated_at` it is the one field
+  determinism is asserted modulo.
+- **The `_stdout_to_stderr_when` diversion is now the standard treatment**
+  (third use, after `report generate`): `route-auto` and `reason --auto-route`
+  drive the negotiated router, whose per-iteration progress log goes to
+  **stdout**. It is captured and replayed on stderr so the JSON stream stays
+  parseable. Any leaf that calls the router, a collector or third-party code
+  needs it.
+
+`tests/test_format_json_sweep_drivers.py` guards these 5 surfaces.
+
+**Remaining actionable (3)** — the audit's `prose-only` bucket reads 8
 because it also counts the 4 exempt commands and the deferred `route`
 (sections above):
 
-- `build`, `creepage-export-rules`
-- `optimize-placement`, `optimize-traces`
-- `pipeline`
-- `reason`, `route-auto`
+- `build`, `pipeline` (multi-stage orchestrators)
 - `stitch` (single command, but its 6k-line inner module has a bespoke
   multi-phase report — batch it alone)
 

--- a/src/kicad_tools/cli/commands/creepage_export_rules.py
+++ b/src/kicad_tools/cli/commands/creepage_export_rules.py
@@ -15,6 +15,14 @@ two-engine 0-DRC manufacturability bar).
 This is a NEW SIBLING top-level command (``kct creepage-export-rules``), not a
 subcommand of the flat ``kct creepage <pcb>`` census -- restructuring ``creepage``
 into a group would break its documented flat invocation.
+
+Machine output (``--format json``, issue #4674): one document naming the
+resolved ``project``/``pcb``/``dru`` paths, the derived voltage ``domains``,
+the pairwise ``rules`` and the domain-bridging exemptions, plus ``written``
+(false under ``--dry-run`` and for the two clean no-op paths, so exit 0 can
+never be read as "files were written").  Failures emit
+``{"error": ..., "success": false}`` with the exit code unchanged.  See
+``docs/reference/machine-output.md``.
 """
 
 from __future__ import annotations
@@ -22,6 +30,31 @@ from __future__ import annotations
 import json
 import sys
 from pathlib import Path
+
+from ..format_options import FORMAT_JSON, emit_json
+
+
+def _fail(as_json: bool, project: str, message: str, *, text_lines: list[str] | None = None) -> int:
+    """Report an export failure as a document (JSON) or prose (text).
+
+    ``text_lines`` overrides the conventional single ``Error: <message>`` line
+    for the one failure that prints a follow-up hint, so text-mode output stays
+    byte-identical.
+    """
+    if as_json:
+        emit_json(
+            {
+                "command": "creepage-export-rules",
+                "project": project,
+                "error": message,
+                "written": False,
+                "success": False,
+            }
+        )
+    else:
+        for line in text_lines if text_lines is not None else [f"Error: {message}"]:
+            print(line, file=sys.stderr)
+    return 1
 
 
 def run_creepage_export_rules_command(args) -> int:
@@ -37,16 +70,17 @@ def run_creepage_export_rules_command(args) -> int:
     from kicad_tools.creepage.standards import StandardLookupError
     from kicad_tools.schema.pcb import PCB
 
+    as_json = getattr(args, "format", "text") == FORMAT_JSON
+
     project_path = Path(args.project)
     if not project_path.exists():
-        print(f"Error: project file not found: {project_path}", file=sys.stderr)
-        return 1
+        return _fail(as_json, str(project_path), f"project file not found: {project_path}")
     if project_path.suffix != ".kicad_pro":
-        print(
-            f"Error: expected a .kicad_pro project file, got {project_path.name}",
-            file=sys.stderr,
+        return _fail(
+            as_json,
+            str(project_path),
+            f"expected a .kicad_pro project file, got {project_path.name}",
         )
-        return 1
 
     # Resolve the sibling board (nets + footprints) and the .kicad_dru target.
     pcb_arg = getattr(args, "pcb", None)
@@ -56,37 +90,57 @@ def run_creepage_export_rules_command(args) -> int:
     # No voltage map -> clean no-op (nothing to derive, nothing written).
     vmap_arg = getattr(args, "voltage_map", None)
     if not vmap_arg:
-        print(
+        message = (
             "No --voltage-map supplied: nothing to export "
             "(pairwise HV rules are derived from the voltage map).  No files written."
         )
+        if as_json:
+            emit_json(
+                {
+                    "command": "creepage-export-rules",
+                    "project": str(project_path),
+                    "pcb": str(pcb_path),
+                    "dru": str(dru_path),
+                    "voltage_map": None,
+                    "domains": {},
+                    "nets_assigned": 0,
+                    "rules": [],
+                    "bridging_exemptions": [],
+                    "dry_run": bool(getattr(args, "dry_run", False)),
+                    "written": False,
+                    "skipped_reason": "no-voltage-map",
+                    "success": True,
+                }
+            )
+        else:
+            print(message)
         return 0
 
     vmap_path = Path(vmap_arg)
     if not vmap_path.exists():
-        print(f"Error: voltage-map file not found: {vmap_path}", file=sys.stderr)
-        return 1
+        return _fail(as_json, str(project_path), f"voltage-map file not found: {vmap_path}")
     try:
         intervals, _edge_voltage = voltage_map_from_dict(json.loads(vmap_path.read_text()))
     except json.JSONDecodeError as e:
-        print(f"Error: parsing voltage-map JSON: {e}", file=sys.stderr)
-        return 1
+        return _fail(as_json, str(project_path), f"parsing voltage-map JSON: {e}")
     except (TypeError, ValueError) as e:
-        print(f"Error: invalid voltage-map structure: {e}", file=sys.stderr)
-        return 1
+        return _fail(as_json, str(project_path), f"invalid voltage-map structure: {e}")
 
     # Collapse each net's interval to its worst-case magnitude (the domain model
     # is magnitude-only, matching placement's load_voltage_map).
     voltage_map = {name: max(abs(iv.lo), abs(iv.hi)) for name, iv in intervals.items()}
 
     if not pcb_path.exists():
-        print(f"Error: board file not found: {pcb_path}", file=sys.stderr)
-        print(
-            "  (netclass patterns + domain-bridging exemptions require the .kicad_pcb; "
-            "pass --pcb to point at it explicitly).",
-            file=sys.stderr,
+        return _fail(
+            as_json,
+            str(project_path),
+            f"board file not found: {pcb_path}",
+            text_lines=[
+                f"Error: board file not found: {pcb_path}",
+                "  (netclass patterns + domain-bridging exemptions require the .kicad_pcb; "
+                "pass --pcb to point at it explicitly).",
+            ],
         )
-        return 1
     pcb = PCB.load(pcb_path)
     net_names = [n.name for n in pcb.nets.values() if n.number != 0 and n.name]
 
@@ -111,11 +165,48 @@ def run_creepage_export_rules_command(args) -> int:
         )
     except StandardLookupError as e:
         # Safety-critical: fail LOUD, never emit a guessed number.
-        print(f"Error: standard-table lookup failed: {e}", file=sys.stderr)
-        return 1
+        return _fail(as_json, str(project_path), f"standard-table lookup failed: {e}")
+
+    dry_run = bool(getattr(args, "dry_run", False))
+
+    def _document(*, written: bool, skipped_reason: str | None, dru_body: str | None) -> dict:
+        return {
+            "command": "creepage-export-rules",
+            "project": str(project_path),
+            "pcb": str(pcb_path),
+            "dru": str(dru_path),
+            "voltage_map": str(vmap_path),
+            "standard": getattr(args, "standard", "iec60664") or "iec60664",
+            "pollution_degree": getattr(args, "pollution_degree", 2) or 2,
+            "material_group": getattr(args, "material_group", "IIIa") or "IIIa",
+            "hv_threshold_v": getattr(args, "hv_threshold", 30.0),
+            "dru_floor_mm": plan.dru_floor_mm,
+            "domains": dict(plan.domain_voltages),
+            "nets_assigned": len(plan.net_domains),
+            "net_domains": dict(plan.net_domains),
+            "rules": [
+                {"name": rule.name, "condition": rule.condition, "min_mm": rule.min_mm}
+                for rule in plan.rules
+            ],
+            "bridging_exemptions": [
+                {"domains": [a, b], "references": sorted(refs)}
+                for (a, b), refs in sorted(plan.bridging_by_pair.items())
+            ],
+            # The rendered block is the artifact; it is carried only on the
+            # dry-run path, mirroring the prose that prints it instead of
+            # writing it.
+            "dru_block": dru_body,
+            "dry_run": dry_run,
+            "written": written,
+            "skipped_reason": skipped_reason,
+            "success": True,
+        }
 
     if plan.is_empty:
-        print("No mapped nets matched the board -- nothing to export.  No files written.")
+        if as_json:
+            emit_json(_document(written=False, skipped_reason="no-mapped-nets", dru_body=None))
+        else:
+            print("No mapped nets matched the board -- nothing to export.  No files written.")
         return 0
 
     dru_body = render_dru_block_body(plan)
@@ -124,18 +215,25 @@ def run_creepage_export_rules_command(args) -> int:
         dru_body,
     )
 
-    _print_summary(plan, project_path, pcb_path, dru_path)
+    if not as_json:
+        _print_summary(plan, project_path, pcb_path, dru_path)
 
-    if getattr(args, "dry_run", False):
-        print("\n--- .kicad_dru block (dry run, not written) ---")
-        print(dru_body)
+    if dry_run:
+        if as_json:
+            emit_json(_document(written=False, skipped_reason="dry-run", dru_body=dru_body))
+        else:
+            print("\n--- .kicad_dru block (dry run, not written) ---")
+            print(dru_body)
         return 0
 
     apply_netclass_assignments(project_data, plan)
     save_project(project_data, project_path)
     dru_path.write_text(dru_block)
-    print(f"\nWrote {len(plan.domain_voltages)} netclass(es) -> {project_path.name}")
-    print(f"Wrote {len(plan.rules)} pairwise rule(s) -> {dru_path.name}")
+    if as_json:
+        emit_json(_document(written=True, skipped_reason=None, dru_body=None))
+    else:
+        print(f"\nWrote {len(plan.domain_voltages)} netclass(es) -> {project_path.name}")
+        print(f"Wrote {len(plan.rules)} pairwise rule(s) -> {dru_path.name}")
     return 0
 
 

--- a/src/kicad_tools/cli/commands/optimize_placement.py
+++ b/src/kicad_tools/cli/commands/optimize_placement.py
@@ -1,4 +1,12 @@
-"""optimize-placement command handler."""
+"""optimize-placement command handler.
+
+Machine output (``--format json``, issue #4674): this shim calls the inner
+function directly (no argv re-serialization), so the canonical flag is passed
+through as the ``as_json`` keyword; the document shape lives in
+``optimize_placement_cmd`` and ``docs/reference/machine-output.md``.
+"""
+
+from ..format_options import FORMAT_JSON
 
 __all__ = ["run_optimize_placement_command"]
 
@@ -29,4 +37,5 @@ def run_optimize_placement_command(args) -> int:
         pollution_degree=getattr(args, "pollution_degree", 2),
         material_group=getattr(args, "material_group", "IIIa"),
         hv_threshold=getattr(args, "hv_threshold", 30.0),
+        as_json=getattr(args, "format", "text") == FORMAT_JSON,
     )

--- a/src/kicad_tools/cli/commands/reasoning.py
+++ b/src/kicad_tools/cli/commands/reasoning.py
@@ -1,4 +1,9 @@
-"""Reasoning command handler (LLM-driven PCB layout)."""
+"""Reasoning command handler (LLM-driven PCB layout).
+
+Machine output (``--format json``, issue #4674) is forwarded to the inner
+parser like every other flag; the document shape is described in
+``reason_cmd`` and ``docs/reference/machine-output.md``.
+"""
 
 __all__ = ["run_reason_command"]
 
@@ -28,4 +33,7 @@ def run_reason_command(args) -> int:
         sub_argv.append("--verbose")
     if args.dry_run:
         sub_argv.append("--dry-run")
+    # Machine output (#4674): forward the canonical flag to the inner parser.
+    if getattr(args, "format", "text") != "text":
+        sub_argv.extend(["--format", args.format])
     return reason_main(sub_argv)

--- a/src/kicad_tools/cli/commands/routing.py
+++ b/src/kicad_tools/cli/commands/routing.py
@@ -1,4 +1,18 @@
-"""Routing command handlers (route, route-auto, zones, optimize-traces)."""
+"""Routing command handlers (route, route-auto, zones, optimize-traces).
+
+Machine output (``--format json``, issue #4674): ``route-auto`` emits exactly
+one document describing the run -- the resolved board/output paths and a
+``nets`` array with one entry per requested net (its strategy, metrics,
+written copper and warnings, or the failure that stopped it) -- and
+``optimize-traces`` forwards the canonical flag to its inner parser.  Exit
+codes are unchanged in both cases.  See ``docs/reference/machine-output.md``.
+"""
+
+import contextlib
+import io
+import sys
+
+from ..format_options import FORMAT_JSON, emit_json
 
 __all__ = [
     "run_route_command",
@@ -6,6 +20,29 @@ __all__ = [
     "run_zones_command",
     "run_optimize_command",
 ]
+
+
+@contextlib.contextmanager
+def _stdout_to_stderr_when(active: bool):
+    """Divert stdout to stderr while *active* (i.e. JSON mode owns stdout).
+
+    ``route_net_auto`` drives the negotiated router, which prints a multi-line
+    per-iteration progress log on **stdout** that this module does not own.
+    Under ``--format json`` that would corrupt the single-document contract, so
+    it is captured and replayed on stderr: the log survives, the JSON stream
+    stays parseable.  Same helper as ``report_cmd._stdout_to_stderr_when``
+    (batch 5 of #4674).
+    """
+    if not active:
+        yield
+        return
+    buffer = io.StringIO()
+    try:
+        with contextlib.redirect_stdout(buffer):
+            yield
+    finally:
+        if buffer.getvalue():
+            print(buffer.getvalue(), end="", file=sys.stderr)
 
 
 def run_zones_command(args) -> int:
@@ -161,14 +198,25 @@ def _print_effective_via_geometry(
     print(f"  Via diameter: {_fmt(eff_diameter, override_diameter)}")
 
 
-def _route_auto_one(args, net_name: str, pcb_path: str, output_path: str | None) -> int:
-    """Route a single net via RoutingOrchestrator and print the result.
+def _route_auto_one(
+    args,
+    net_name: str,
+    pcb_path: str,
+    output_path: str | None,
+    *,
+    as_json: bool = False,
+) -> tuple[int, dict]:
+    """Route a single net via RoutingOrchestrator and report the result.
 
     Extracted from ``run_route_auto_command`` (Issue #4322) so the ``--net``
     single-net path and each iteration of the ``--nets`` multi-net loop share
     identical routing + reporting.  ``pcb_path`` / ``output_path`` are passed
     explicitly so the loop can chain outputs (route net N+1 from net N's
-    output, accumulating copper).  Returns the per-net exit code.
+    output, accumulating copper).
+
+    Returns ``(exit_code, document)``.  The document is the per-net entry of
+    the ``--format json`` payload (issue #4674); prose is printed only when
+    *as_json* is false, so text output stays byte-identical.
     """
     import sys
 
@@ -177,36 +225,73 @@ def _route_auto_one(args, net_name: str, pcb_path: str, output_path: str | None)
 
     from kicad_tools.mcp.tools.routing import route_net_auto
 
+    def _error_doc(message: str) -> dict:
+        return {
+            "net": net_name,
+            "success": False,
+            "partial": False,
+            "error": message,
+            "source": pcb_path,
+        }
+
     try:
-        result = route_net_auto(
-            pcb_path=pcb_path,
-            net_name=net_name,
-            output_path=output_path,
-            strategy=args.strategy,
-            enable_repair=not args.no_repair,
-            enable_via_resolution=not args.no_via_resolution,
-            # Issue #4148: spatial routing bound.  Confines the routed net to the
-            # board-relative box and fails if the net has an endpoint outside it.
-            region=getattr(args, "region", None),
-            # Issue #4165: persist partial multi-pad copper only when opted in.
-            allow_partial=getattr(args, "allow_partial", False),
-            # Issue #4247: explicit via-geometry overrides (None => board-derived).
-            via_drill=via_drill,
-            via_diameter=via_diameter,
-        )
+        # The negotiated router logs its per-iteration progress on stdout;
+        # under --format json that chatter is replayed on stderr instead.
+        with _stdout_to_stderr_when(as_json):
+            result = route_net_auto(
+                pcb_path=pcb_path,
+                net_name=net_name,
+                output_path=output_path,
+                strategy=args.strategy,
+                enable_repair=not args.no_repair,
+                enable_via_resolution=not args.no_via_resolution,
+                # Issue #4148: spatial routing bound.  Confines the routed net to
+                # the board-relative box and fails if the net has an endpoint
+                # outside it.
+                region=getattr(args, "region", None),
+                # Issue #4165: persist partial multi-pad copper only when opted in.
+                allow_partial=getattr(args, "allow_partial", False),
+                # Issue #4247: explicit via-geometry overrides (None => board-derived).
+                via_drill=via_drill,
+                via_diameter=via_diameter,
+            )
     except FileNotFoundError as e:
-        print(f"Error: {e}", file=sys.stderr)
-        return 1
+        if not as_json:
+            print(f"Error: {e}", file=sys.stderr)
+        return 1, _error_doc(str(e))
     except ValueError as e:
-        print(f"Error: {e}", file=sys.stderr)
-        return 1
+        if not as_json:
+            print(f"Error: {e}", file=sys.stderr)
+        return 1, _error_doc(str(e))
     except Exception as e:
-        print(f"Error: {e}", file=sys.stderr)
+        if not as_json:
+            print(f"Error: {e}", file=sys.stderr)
         if getattr(args, "verbose", False):
             import traceback
 
             traceback.print_exc()
-        return 1
+        return 1, _error_doc(str(e))
+
+    doc = {
+        "net": result.get("net_name", net_name),
+        "success": bool(result["success"]),
+        "partial": bool(result.get("partial", False)),
+        "strategy_used": result.get("strategy_used"),
+        "metrics": result.get("metrics", {}),
+        "segments_written": result.get("segments_written"),
+        "vias_written": result.get("vias_written"),
+        "warnings": list(result.get("warnings", [])),
+        "output_path": result.get("output_path"),
+        "pads_connected": result.get("pads_connected"),
+        "pads_total": result.get("pads_total"),
+        "error": result.get("error_message"),
+        "alternative_strategies": list(result.get("alternative_strategies", [])),
+        "source": pcb_path,
+    }
+
+    if as_json:
+        # The caller prints the single document; per-net prose is suppressed.
+        return (0 if result["success"] else 1), doc
 
     # Print result
     if result["success"]:
@@ -235,7 +320,7 @@ def _route_auto_one(args, net_name: str, pcb_path: str, output_path: str | None)
             print(f"  Warning: {warning}")
         if result.get("output_path"):
             print(f"  Saved to: {result['output_path']}")
-        return 0
+        return 0, doc
     elif result.get("partial"):
         # Issue #4165: routing produced copper but left some pads of a
         # multi-pad net unconnected.  Report the honest k/n and exit non-zero;
@@ -269,7 +354,7 @@ def _route_auto_one(args, net_name: str, pcb_path: str, output_path: str | None)
             )
         for warning in result.get("warnings", []):
             print(f"  Warning: {warning}", file=sys.stderr)
-        return 1
+        return 1, doc
     else:
         print(f"Routing failed for net '{result['net_name']}'", file=sys.stderr)
         if result.get("error_message"):
@@ -278,53 +363,87 @@ def _route_auto_one(args, net_name: str, pcb_path: str, output_path: str | None)
             strategy_name = alt.get("strategy", "unknown")
             reason = alt.get("reason", "")
             print(f"  Try: {strategy_name} - {reason}", file=sys.stderr)
-        return 1
+        return 1, doc
 
 
-def _route_auto_dry_run(args, net_name: str) -> None:
-    """Print the strategy-selection preview for one net (no routing)."""
+def _route_auto_dry_run(args, net_name: str, *, as_json: bool = False) -> dict:
+    """Preview the strategy selection for one net (no routing).
+
+    Prints the human preview unless *as_json*, and returns the same content as
+    the per-net entry of the ``--format json`` document (issue #4674).
+    """
     via_drill = getattr(args, "via_drill", None)
     via_diameter = getattr(args, "via_diameter", None)
-    print(f"[dry-run] Would route net '{net_name}' on '{args.pcb}' using RoutingOrchestrator")
-    print(f"  Strategy override: {args.strategy}")
-    print(f"  Repair enabled: {not args.no_repair}")
-    print(f"  Via resolution enabled: {not args.no_via_resolution}")
     # Report the effective via geometry that would be used (Issue #4247):
     # an explicit CLI override, or the value derived from the board's
     # net-class via constraints.
     eff_drill, eff_diameter = _effective_via_geometry(args.pcb, via_drill, via_diameter)
-    _print_effective_via_geometry(eff_drill, via_drill, eff_diameter, via_diameter)
-    if args.output:
-        print(f"  Output: {args.output}")
+
+    if not as_json:
+        print(f"[dry-run] Would route net '{net_name}' on '{args.pcb}' using RoutingOrchestrator")
+        print(f"  Strategy override: {args.strategy}")
+        print(f"  Repair enabled: {not args.no_repair}")
+        print(f"  Via resolution enabled: {not args.no_via_resolution}")
+        _print_effective_via_geometry(eff_drill, via_drill, eff_diameter, via_diameter)
+        if args.output:
+            print(f"  Output: {args.output}")
+
+    def _source(value: float | None, override: float | None) -> str | None:
+        if value is None:
+            return None
+        return "explicit override" if override is not None else "board-derived"
+
+    return {
+        "net": net_name,
+        "would_route": True,
+        "strategy": args.strategy,
+        "repair_enabled": not args.no_repair,
+        "via_resolution_enabled": not args.no_via_resolution,
+        "via_drill_mm": eff_drill,
+        "via_drill_source": _source(eff_drill, via_drill),
+        "via_diameter_mm": eff_diameter,
+        "via_diameter_source": _source(eff_diameter, via_diameter),
+        "output_path": args.output,
+    }
 
 
-def _parse_route_auto_targets(args) -> tuple[list[str] | None, int]:
+def _parse_route_auto_targets(args, *, as_json: bool = False) -> tuple[list[str] | None, int]:
     """Resolve the net(s) route-auto should route -- Issue #4322.
 
     Exactly one of ``--net`` (single) / ``--nets`` (comma-separated list) must
     be given.  Returns ``(net_list, rc)``: on success ``net_list`` is the
     ordered, de-duplicated, whitespace-trimmed list of nets and ``rc`` is 0; on
     a usage error ``net_list`` is ``None`` and ``rc`` is a non-zero exit code
-    (an error has already been printed).
+    (the error has already been reported -- as prose, or as the single
+    ``{"error": ...}`` document under *as_json*, issue #4674).
     """
     import sys
+
+    def _usage_error(message: str) -> tuple[None, int]:
+        if as_json:
+            emit_json(
+                {
+                    "command": "route-auto",
+                    "pcb": getattr(args, "pcb", None),
+                    "error": message,
+                    "nets": [],
+                    "success": False,
+                }
+            )
+        else:
+            print(f"Error: {message}", file=sys.stderr)
+        return None, 2
 
     net = getattr(args, "net", None)
     nets_raw = getattr(args, "nets", None)
 
     if net and nets_raw:
-        print(
-            "Error: --net and --nets are mutually exclusive (use --net for a "
-            "single net or --nets for a comma-separated list).",
-            file=sys.stderr,
+        return _usage_error(
+            "--net and --nets are mutually exclusive (use --net for a "
+            "single net or --nets for a comma-separated list)."
         )
-        return None, 2
     if not net and not nets_raw:
-        print(
-            "Error: route-auto requires --net NAME or --nets NAME[,NAME...].",
-            file=sys.stderr,
-        )
-        return None, 2
+        return _usage_error("route-auto requires --net NAME or --nets NAME[,NAME...].")
 
     if net:
         return [net], 0
@@ -333,12 +452,10 @@ def _parse_route_auto_targets(args) -> tuple[list[str] | None, int]:
     # net / neither cases); ``or ""`` keeps the type checker happy.
     parsed = [n.strip() for n in (nets_raw or "").split(",") if n.strip()]
     if not parsed:
-        print(
-            "Error: --nets was given but lists no net names "
-            '(expected a comma-separated list, e.g. --nets "/A,/B").',
-            file=sys.stderr,
+        return _usage_error(
+            "--nets was given but lists no net names "
+            '(expected a comma-separated list, e.g. --nets "/A,/B").'
         )
-        return None, 2
     # De-duplicate while preserving first-seen order.
     seen: set[str] = set()
     ordered: list[str] = []
@@ -357,29 +474,57 @@ def run_route_auto_command(args) -> int:
     the exit code is non-zero if ANY net fails or is left partial; when an
     output path is given, copper accumulates (net N+1 routes from net N's
     output).  The single-net ``--net`` path is unchanged.
+
+    Under ``--format json`` (issue #4674) the per-net prose is replaced by a
+    single document whose ``nets`` array carries one entry per requested net,
+    in request order; the exit code is unchanged.
     """
-    net_list, rc = _parse_route_auto_targets(args)
+    as_json = getattr(args, "format", "text") == FORMAT_JSON
+
+    net_list, rc = _parse_route_auto_targets(args, as_json=as_json)
     if rc != 0:
         return rc
     assert net_list is not None  # rc == 0 guarantees a list
 
+    def _emit(nets: list[dict], overall_rc: int) -> None:
+        emit_json(
+            {
+                "command": "route-auto",
+                "pcb": args.pcb,
+                "output": args.output,
+                "strategy": args.strategy,
+                "dry_run": bool(args.dry_run),
+                "nets": nets,
+                "nets_requested": len(net_list),
+                "nets_routed": sum(1 for entry in nets if entry.get("success")),
+                "success": overall_rc == 0,
+            }
+        )
+
     # Dry-run: preview strategy selection without routing (per net).
     if args.dry_run:
-        for net_name in net_list:
-            _route_auto_dry_run(args, net_name)
+        previews = [_route_auto_dry_run(args, net_name, as_json=as_json) for net_name in net_list]
+        if as_json:
+            # A preview routes nothing, so nets_routed stays 0 while success
+            # reports that the preview itself completed.
+            _emit(previews, 0)
         return 0
 
     output_path = args.output
     overall_rc = 0
+    net_docs: list[dict] = []
     for i, net_name in enumerate(net_list):
         # Chain outputs so multi-net copper accumulates: the first net routes
         # from the original board; subsequent nets route from the prior output
         # (only possible when an output path was given -- otherwise nothing is
         # persisted and each net routes independently against the input).
         source = args.pcb if (i == 0 or not output_path) else output_path
-        net_rc = _route_auto_one(args, net_name, source, output_path)
+        net_rc, net_doc = _route_auto_one(args, net_name, source, output_path, as_json=as_json)
+        net_docs.append(net_doc)
         if net_rc != 0:
             overall_rc = 1
+    if as_json:
+        _emit(net_docs, overall_rc)
     return overall_rc
 
 
@@ -862,4 +1007,7 @@ def run_optimize_command(args) -> int:
         sub_argv.extend(["--layers", str(args.layers)])
     if getattr(args, "copper", 1.0) != 1.0:
         sub_argv.extend(["--copper", str(args.copper)])
+    # Machine output (#4674): forward the canonical flag to the inner parser.
+    if getattr(args, "format", "text") != "text":
+        sub_argv.extend(["--format", args.format])
     return optimize_main(sub_argv)

--- a/src/kicad_tools/cli/optimize_cmd.py
+++ b/src/kicad_tools/cli/optimize_cmd.py
@@ -6,11 +6,41 @@ Usage:
     kct optimize-traces board.kicad_pcb --net "NET8"
     kct optimize-traces board.kicad_pcb -o optimized.kicad_pcb
     kct optimize-traces board.kicad_pcb --drc-aware --mfr jlcpcb --layers 4
+
+Machine output (``--format json``, issue #4674): one deterministic document
+describing the run -- the resolved ``pcb``/``output`` paths, the enabled
+``optimizations``, the before/after ``stats`` and whether the result was
+``saved`` -- or ``{"error": ..., "success": false}`` on any failure, with the
+exit code unchanged.  See ``docs/reference/machine-output.md``.
 """
 
 import argparse
 import sys
 from pathlib import Path
+
+from kicad_tools.cli.format_options import FORMAT_JSON, add_format_flag, emit_json
+
+
+def _fail(as_json: bool, pcb: str, message: str, *, text: str | None = None) -> int:
+    """Report an optimize-traces failure as a document (JSON) or prose (text).
+
+    ``text`` overrides the conventional ``Error: <message>`` prose for the one
+    failure path that deliberately words itself differently (``Error during
+    optimization: ...``); text-mode output stays byte-identical.
+    """
+    if as_json:
+        emit_json(
+            {
+                "command": "optimize-traces",
+                "pcb": pcb,
+                "error": message,
+                "saved": False,
+                "success": False,
+            }
+        )
+    else:
+        print(text if text is not None else f"Error: {message}", file=sys.stderr)
+    return 1
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -103,23 +133,23 @@ Examples:
         default=1.0,
         help="Copper weight in oz for DRC checks (default: 1.0)",
     )
+    add_format_flag(parser)
 
     args = parser.parse_args(argv)
+    as_json = args.format == FORMAT_JSON
 
     # Validate DRC-aware arguments
     if args.drc_aware and not args.mfr:
-        print(
-            "Error: --drc-aware requires --mfr to specify the manufacturer profile "
-            "(e.g., --mfr jlcpcb)",
-            file=sys.stderr,
+        return _fail(
+            as_json,
+            args.pcb,
+            "--drc-aware requires --mfr to specify the manufacturer profile (e.g., --mfr jlcpcb)",
         )
-        return 1
 
     # Check input file exists
     pcb_path = Path(args.pcb)
     if not pcb_path.exists():
-        print(f"Error: PCB file not found: {pcb_path}", file=sys.stderr)
-        return 1
+        return _fail(as_json, str(pcb_path), f"PCB file not found: {pcb_path}")
 
     # Validate manufacturer ID if provided
     if args.mfr:
@@ -127,11 +157,11 @@ Examples:
 
         valid_ids = get_manufacturer_ids()
         if args.mfr not in valid_ids:
-            print(
-                f"Error: Unknown manufacturer '{args.mfr}'. Valid options: {', '.join(valid_ids)}",
-                file=sys.stderr,
+            return _fail(
+                as_json,
+                str(pcb_path),
+                f"Unknown manufacturer '{args.mfr}'. Valid options: {', '.join(valid_ids)}",
             )
-            return 1
 
     # Import here to avoid circular imports
     from kicad_tools.cli.progress import spinner
@@ -140,7 +170,9 @@ Examples:
         TraceOptimizer,
     )
 
-    quiet = args.quiet
+    # JSON mode owns stdout: the banner, the spinner and the results table are
+    # all suppressed so exactly one document is printed.
+    quiet = args.quiet or as_json
 
     # Configure optimizer
     config = OptimizationConfig(
@@ -190,8 +222,51 @@ Examples:
                 dry_run=args.dry_run,
             )
     except Exception as e:
-        print(f"Error during optimization: {e}", file=sys.stderr)
-        return 1
+        return _fail(
+            as_json,
+            str(pcb_path),
+            f"during optimization: {e}",
+            text=f"Error during optimization: {e}",
+        )
+
+    if as_json:
+        emit_json(
+            {
+                "command": "optimize-traces",
+                "pcb": str(pcb_path),
+                "output": args.output,
+                "net_filter": args.net,
+                "optimizations": {
+                    "merge_collinear": config.merge_collinear,
+                    "eliminate_zigzags": config.eliminate_zigzags,
+                    "convert_45_corners": config.convert_45_corners,
+                    "chamfer_size_mm": config.corner_chamfer_size,
+                },
+                "drc_aware": args.drc_aware,
+                "manufacturer": args.mfr,
+                "layers": args.layers,
+                "copper_oz": args.copper,
+                "stats": {
+                    "nets_optimized": stats.nets_optimized,
+                    "nets_rolled_back": stats.nets_rolled_back,
+                    "segments_before": stats.segments_before,
+                    "segments_after": stats.segments_after,
+                    "segment_reduction_pct": stats.segment_reduction,
+                    "corners_before": stats.corners_before,
+                    "corners_after": stats.corners_after,
+                    "length_before_mm": stats.length_before,
+                    "length_after_mm": stats.length_after,
+                    "length_reduction_pct": stats.length_reduction,
+                    "drc_errors_before": stats.drc_errors_before,
+                    "drc_errors_after": stats.drc_errors_after,
+                },
+                "dry_run": args.dry_run,
+                "saved": not args.dry_run,
+                "written_to": None if args.dry_run else (args.output or str(pcb_path)),
+                "success": True,
+            }
+        )
+        return 0
 
     if not quiet:
         # Display results

--- a/src/kicad_tools/cli/optimize_placement_cmd.py
+++ b/src/kicad_tools/cli/optimize_placement_cmd.py
@@ -9,11 +9,19 @@ Usage:
     kct optimize-placement board.kicad_pcb --strategy cmaes --max-iterations 500
     kct optimize-placement board.kicad_pcb --dry-run
     kct optimize-placement board.kicad_pcb --checkpoint ./checkpoints
+
+Machine output (``--format json``, issue #4674): one document carrying the
+board summary, the ``initial``/``final`` score breakdowns, the iteration count
+and whether the result was written -- or ``{"error": ..., "success": false}``
+on failure, with every exit code (0 / 1 / 2-on-interrupt) unchanged.
+``wall_time_s`` is the one deliberately volatile field.  See
+``docs/reference/machine-output.md``.
 """
 
 from __future__ import annotations
 
 import contextlib
+import dataclasses
 import json
 import os
 import signal
@@ -23,6 +31,7 @@ import time
 from pathlib import Path
 from typing import Sequence
 
+from kicad_tools.cli.format_options import emit_json
 from kicad_tools.placement.cost import (
     BoardOutline,
     ComponentPlacement,
@@ -407,6 +416,36 @@ def _generate_seed(
         raise ValueError(f"Unknown seed method: {seed_method!r}. Available: force-directed, random")
 
 
+def _score_document(score: PlacementScore) -> dict:
+    """Render a :class:`PlacementScore` as the JSON score block (issue #4674).
+
+    The breakdown is taken straight from the dataclass, so a new cost axis
+    appears in the machine output without another edit here.
+    """
+    return {
+        "total": score.total,
+        "feasible": bool(score.is_feasible),
+        "breakdown": dataclasses.asdict(score.breakdown),
+    }
+
+
+def _placement_error(pcb_path: str, message: str, *, as_json: bool, text: str | None = None) -> int:
+    """Report an optimize-placement failure as a document (JSON) or prose."""
+    if as_json:
+        emit_json(
+            {
+                "command": "optimize-placement",
+                "pcb": pcb_path,
+                "error": message,
+                "saved": False,
+                "success": False,
+            }
+        )
+    else:
+        print(text if text is not None else f"Error: {message}", file=sys.stderr)
+    return 1
+
+
 def _print_score(label: str, score: PlacementScore) -> None:
     """Print a score summary line."""
     b = score.breakdown
@@ -683,6 +722,7 @@ def run_optimize_placement(
     pollution_degree: int = 2,
     material_group: str = "IIIa",
     hv_threshold: float = 30.0,
+    as_json: bool = False,
 ) -> int:
     """Run placement optimization.
 
@@ -727,6 +767,10 @@ def run_optimize_placement(
         hv_threshold: Minimum cross-domain ``|ΔV|`` (volts) that triggers a
             creepage keepout; lower-difference domain pairs rely on normal DRC
             clearance (avoids over-segregating low-voltage nets).
+        as_json: Emit one machine-readable document on stdout instead of the
+            prose report (issue #4674). Progress/summary chatter is suppressed;
+            exit codes and the ``FATAL:``/``ERROR:`` stderr diagnostics are
+            unchanged.
 
     Returns:
         Exit code:
@@ -738,17 +782,20 @@ def run_optimize_placement(
     # Validate PCB file exists
     pcb_file = Path(pcb_path)
     if not pcb_file.exists():
-        print(f"Error: PCB file not found: {pcb_path}", file=sys.stderr)
-        return 1
+        return _placement_error(pcb_path, f"PCB file not found: {pcb_path}", as_json=as_json)
     if pcb_file.suffix != ".kicad_pcb":
-        print(f"Error: expected .kicad_pcb file, got: {pcb_file.suffix}", file=sys.stderr)
-        return 1
-    if anchor_weight < 0.0:
-        print(
-            f"Error: --anchor-weight must be >= 0 (got {anchor_weight})",
-            file=sys.stderr,
+        return _placement_error(
+            pcb_path, f"expected .kicad_pcb file, got: {pcb_file.suffix}", as_json=as_json
         )
-        return 1
+    if anchor_weight < 0.0:
+        return _placement_error(
+            pcb_path, f"--anchor-weight must be >= 0 (got {anchor_weight})", as_json=as_json
+        )
+
+    # JSON mode owns stdout: every prose site below is already gated on
+    # ``quiet``, so folding as_json into it suppresses the report while
+    # leaving the stderr diagnostics untouched.
+    quiet = quiet or as_json
 
     if output_path is None:
         output_path = pcb_path
@@ -777,16 +824,20 @@ def run_optimize_placement(
             anchor_weight=anchor_weight,
         )
     except Exception as e:
-        print(f"Error reading PCB: {e}", file=sys.stderr)
+        rc = _placement_error(
+            pcb_path,
+            f"reading PCB: {e}",
+            as_json=as_json,
+            text=f"Error reading PCB: {e}",
+        )
         if verbose:
             import traceback
 
             traceback.print_exc()
-        return 1
+        return rc
 
     if not components:
-        print("Error: no components found in PCB", file=sys.stderr)
-        return 1
+        return _placement_error(pcb_path, "no components found in PCB", as_json=as_json)
 
     # Update interrupt state so handler can save intermediate results
     _interrupt_state["components"] = components
@@ -814,8 +865,7 @@ def run_optimize_placement(
             quiet=quiet,
         )
     except (ValueError, FileNotFoundError) as e:
-        print(f"Error: {e}", file=sys.stderr)
-        return 1
+        return _placement_error(pcb_path, str(e), as_json=as_json)
 
     # Derived-tap auto-exemption (issue #4373 Phase 3, auto). Only the
     # voltage-map path carries the per-net voltages the detector needs; the
@@ -841,6 +891,23 @@ def run_optimize_placement(
 
     # Compute bounds
     placement_bounds = bounds(board_outline, components)
+
+    # The run-level fields every JSON document carries, whichever path exits.
+    base_document = {
+        "command": "optimize-placement",
+        "pcb": pcb_path,
+        "output": output_path,
+        "strategy": strategy_name,
+        "seed_method": seed_method,
+        "max_iterations": max_iterations,
+        "board": {
+            "width_mm": board_outline.width,
+            "height_mm": board_outline.height,
+            "components": len(components),
+            "nets": len(nets),
+        },
+        "dry_run": bool(dry_run),
+    }
 
     # --dry-run: evaluate the CURRENT on-disk placement (issue #3940).
     # Previously this generated a fresh force-directed seed and scored that,
@@ -879,14 +946,30 @@ def run_optimize_placement(
                 "bbox-clearance DRC), NOT the `kct placement check` metric "
                 "(courtyard polygons / KiCad DRC). See docs/placement-scoring.md."
             )
+        if as_json:
+            emit_json(
+                {
+                    **base_document,
+                    "mode": "evaluate",
+                    "scores": {"current": _score_document(score)},
+                    "feasible": bool(score.is_feasible),
+                    "saved": False,
+                    "written_to": None,
+                    "objective": (
+                        "optimizer objective (bbox overlap area / bbox-clearance DRC), "
+                        "NOT the `kct placement check` metric "
+                        "(courtyard polygons / KiCad DRC)"
+                    ),
+                    "success": True,
+                }
+            )
         return 0
 
     # Create strategy
     try:
         strategy = _create_strategy(strategy_name)
     except (ValueError, ImportError) as e:
-        print(f"Error: {e}", file=sys.stderr)
-        return 1
+        return _placement_error(pcb_path, str(e), as_json=as_json)
 
     # Check for checkpoint to resume from
     resumed = False
@@ -1067,8 +1150,9 @@ def run_optimize_placement(
             best_vec_now, _ = strategy.best()
             _interrupt_state["best_vector"] = best_vec_now
 
-            # Progress reporting
-            if progress_interval > 0 and iteration % progress_interval == 0:
+            # Progress reporting (suppressed in JSON mode: stdout carries
+            # exactly one document)
+            if progress_interval > 0 and iteration % progress_interval == 0 and not as_json:
                 best_vec, best_score = strategy.best()
                 elapsed = time.monotonic() - start_time
                 print(f"  [{iteration:>5d}] score={best_score:.4f} elapsed={elapsed:.1f}s")
@@ -1203,19 +1287,51 @@ def run_optimize_placement(
             pcb_path, output_path, best_vector, components, board_origin
         )
     except Exception as e:
-        print(f"Error writing output: {e}", file=sys.stderr)
+        rc = _placement_error(
+            pcb_path,
+            f"writing output: {e}",
+            as_json=as_json,
+            text=f"Error writing output: {e}",
+        )
         if verbose:
             import traceback
 
             traceback.print_exc()
-        return 1
+        return rc
 
     if not quiet:
         print("Done.")
 
+    def _finish(rc: int, *, infeasible_detail: str | None = None) -> int:
+        """Emit the single JSON document (if asked) and return *rc* unchanged."""
+        if as_json:
+            emit_json(
+                {
+                    **base_document,
+                    "mode": "optimize",
+                    "scores": {
+                        "initial": _score_document(seed_score),
+                        "final": _score_document(final_score),
+                    },
+                    "feasible": bool(final_score.is_feasible),
+                    "infeasible_detail": infeasible_detail,
+                    "iterations": iteration,
+                    "wall_time_s": elapsed,
+                    "interrupted": bool(_interrupt_state["interrupted"]),
+                    "overlaps_remaining": (
+                        post_slide_result.overlaps_remaining if post_slide_result is not None else 0
+                    ),
+                    "allow_infeasible": bool(allow_infeasible),
+                    "saved": True,
+                    "written_to": output_path,
+                    "success": rc == 0,
+                }
+            )
+        return rc
+
     # Exit code 2 when interrupted (partial result saved).
     if _interrupt_state["interrupted"]:
-        return 2
+        return _finish(2)
 
     # Issue #2821: gate exit code on full feasibility, not just pad-pad
     # slide-off failures. If the final placement has overlap > 0 OR
@@ -1248,7 +1364,11 @@ def run_optimize_placement(
                 f"Pass --allow-infeasible to suppress this error.",
                 file=sys.stderr,
             )
-            return 1
+            # ``detail`` is the joined string built above; ``str(...)`` only
+            # satisfies the type checker, which still types this name from the
+            # earlier ``for detail in ...overlap_details`` loop (the shadowing
+            # is a pre-existing baseline entry, not something to fix here).
+            return _finish(1, infeasible_detail=str(detail))
         elif not quiet:
             print(
                 f"\n  WARNING: final placement is infeasible ({detail}); "
@@ -1265,6 +1385,6 @@ def run_optimize_placement(
     if has_unresolved_overlaps and not allow_infeasible:
         pad_overlaps = [d for d in post_slide_result.overlap_details if d.actual_clearance_mm < 0]
         if pad_overlaps:
-            return 1
+            return _finish(1, infeasible_detail=f"{len(pad_overlaps)} pad-pad overlap(s) remain")
 
-    return 0
+    return _finish(0)

--- a/src/kicad_tools/cli/parser.py
+++ b/src/kicad_tools/cli/parser.py
@@ -677,6 +677,7 @@ def _add_creepage_export_rules_parser(subparsers) -> None:
         action="store_true",
         help="Print the derived netclasses + rules without writing any files.",
     )
+    add_format_flag(p)
 
 
 def _add_check_parser(subparsers) -> None:
@@ -4752,6 +4753,7 @@ def _add_route_auto_parser(subparsers) -> None:
         action="store_true",
         help="Show full traceback on error",
     )
+    add_format_flag(route_auto_parser)
 
 
 def _add_reason_parser(subparsers) -> None:
@@ -4789,6 +4791,7 @@ def _add_reason_parser(subparsers) -> None:
     reason_parser.add_argument("--drc", help="Path to DRC report file")
     reason_parser.add_argument("-v", "--verbose", action="store_true")
     reason_parser.add_argument("--dry-run", action="store_true", help="Don't write output")
+    add_format_flag(reason_parser)
 
 
 def _add_optimize_parser(subparsers) -> None:
@@ -4839,6 +4842,7 @@ def _add_optimize_parser(subparsers) -> None:
         default=1.0,
         help="Copper weight in oz for DRC checks (default: 1.0)",
     )
+    add_format_flag(optimize_parser)
 
 
 def _add_validate_footprints_parser(subparsers) -> None:
@@ -6005,6 +6009,7 @@ def _add_optimize_placement_parser(subparsers) -> None:
     )
     op_parser.add_argument("-v", "--verbose", action="store_true")
     op_parser.add_argument("-q", "--quiet", action="store_true", help="Suppress progress output")
+    add_format_flag(op_parser)
 
 
 def _add_interactive_parser(subparsers) -> None:

--- a/src/kicad_tools/cli/reason_cmd.py
+++ b/src/kicad_tools/cli/reason_cmd.py
@@ -6,14 +6,74 @@ Provides command-line access to the reasoning module for LLM-assisted layout:
     kct reason board.kicad_pcb --export-state
     kct reason board.kicad_pcb --interactive
     kct reason board.kicad_pcb --analyze
+
+Machine output (``--format json``, issue #4674): one document carrying the
+board summary, the DRC block and the selected ``mode``'s own payload
+(``state`` / ``analysis`` / ``auto_route`` / ``prompt``), or
+``{"error": ..., "success": false}`` on failure with the exit code unchanged.
+``--interactive`` is a stdin/stdout dialogue with no single-document form, so
+combining it with ``--format json`` is refused structurally rather than
+half-emitted.  See ``docs/reference/machine-output.md``.
 """
 
 import argparse
+import contextlib
+import io
 import json
 import sys
 from pathlib import Path
 
+from kicad_tools.cli.format_options import FORMAT_JSON, add_format_flag, emit_json
 from kicad_tools.manufacturers import get_manufacturer_ids
+
+
+@contextlib.contextmanager
+def _stdout_to_stderr_when(active: bool):
+    """Divert stdout to stderr while *active* (i.e. JSON mode owns stdout).
+
+    ``--auto-route`` drives the router, which prints a multi-line progress log
+    on **stdout** that this module does not own; under ``--format json`` that
+    would corrupt the single-document contract, so it is captured and replayed
+    on stderr.  Same helper as ``report_cmd._stdout_to_stderr_when`` (batch 5
+    of #4674).
+    """
+    if not active:
+        yield
+        return
+    buffer = io.StringIO()
+    try:
+        with contextlib.redirect_stdout(buffer):
+            yield
+    finally:
+        if buffer.getvalue():
+            print(buffer.getvalue(), end="", file=sys.stderr)
+
+
+def _fail(
+    as_json: bool,
+    pcb: str,
+    message: str,
+    *,
+    text: str | None = None,
+    code: int = 1,
+) -> int:
+    """Report a reason failure as a document (JSON) or prose (text).
+
+    ``text`` overrides the conventional ``Error: <message>`` prose for the
+    paths that word themselves differently, so text mode stays byte-identical.
+    """
+    if as_json:
+        emit_json(
+            {
+                "command": "reason",
+                "pcb": pcb,
+                "error": message,
+                "success": False,
+            }
+        )
+    else:
+        print(text if text is not None else f"Error: {message}", file=sys.stderr)
+    return code
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -92,17 +152,22 @@ def main(argv: list[str] | None = None) -> int:
         action="store_true",
         help="Show what would be done without writing output",
     )
+    add_format_flag(parser)
 
     args = parser.parse_args(argv)
+    as_json = args.format == FORMAT_JSON
 
     # Validate input
     pcb_path = Path(args.pcb)
     if not pcb_path.exists():
-        print(f"Error: File not found: {pcb_path}", file=sys.stderr)
-        return 1
+        return _fail(as_json, str(pcb_path), f"File not found: {pcb_path}")
 
+    warnings: list[str] = []
     if pcb_path.suffix != ".kicad_pcb":
-        print(f"Warning: Expected .kicad_pcb file, got {pcb_path.suffix}")
+        message = f"Expected .kicad_pcb file, got {pcb_path.suffix}"
+        warnings.append(message)
+        if not as_json:
+            print(f"Warning: {message}")
 
     # Determine output path
     if args.output:
@@ -110,29 +175,47 @@ def main(argv: list[str] | None = None) -> int:
     else:
         output_path = pcb_path.with_stem(pcb_path.stem + "_reasoned")
 
+    # --interactive is a stdin/stdout dialogue: there is no single document to
+    # emit, so refuse the combination rather than printing a half-truth.
+    if as_json and args.interactive:
+        return _fail(
+            as_json,
+            str(pcb_path),
+            "--interactive is a stdin/stdout dialogue and has no single-document "
+            "form; use --export-state, --analyze or --auto-route with --format json",
+            code=2,
+        )
+
     # Import reasoning module
     from kicad_tools.reasoning import PCBReasoningAgent
 
     # Print header
-    print("=" * 60)
-    print("KiCad LLM-Driven PCB Reasoning")
-    print("=" * 60)
-    print(f"Input: {pcb_path}")
+    if not as_json:
+        print("=" * 60)
+        print("KiCad LLM-Driven PCB Reasoning")
+        print("=" * 60)
+        print(f"Input: {pcb_path}")
 
-    # Create agent
-    print("\n--- Loading PCB ---")
+        # Create agent
+        print("\n--- Loading PCB ---")
     try:
         agent = PCBReasoningAgent.from_pcb(
             str(pcb_path),
             drc_path=args.drc,
         )
     except Exception as e:
-        print(f"Error loading PCB: {e}", file=sys.stderr)
-        return 1
+        return _fail(
+            as_json,
+            str(pcb_path),
+            f"loading PCB: {e}",
+            text=f"Error loading PCB: {e}",
+        )
 
     # Run automatic DRC checks if no external DRC report provided
+    drc_block: dict = {"ran": False, "source": "report" if args.drc else "skipped"}
     if not args.drc and not args.no_drc:
-        print("\n--- Running DRC Checks ---")
+        if not as_json:
+            print("\n--- Running DRC Checks ---")
         try:
             from kicad_tools.schema.pcb import PCB
             from kicad_tools.validate import DRCChecker
@@ -141,44 +224,81 @@ def main(argv: list[str] | None = None) -> int:
             checker = DRCChecker(pcb, manufacturer=args.mfr, layers=args.layers)
             drc_results = checker.check_all()
             agent.update_violations_from_checker(drc_results)
-            print(f"  Manufacturer: {args.mfr.upper()}")
-            print(f"  Rules checked: {drc_results.rules_checked}")
+            drc_block = {
+                "ran": True,
+                "source": "checker",
+                "manufacturer": args.mfr,
+                "layers": args.layers,
+                "rules_checked": drc_results.rules_checked,
+            }
+            if not as_json:
+                print(f"  Manufacturer: {args.mfr.upper()}")
+                print(f"  Rules checked: {drc_results.rules_checked}")
         except Exception as e:
+            drc_block = {"ran": False, "source": "checker", "error": str(e)}
             print(f"  Warning: DRC check failed: {e}", file=sys.stderr)
-            print("  Use --no-drc to skip DRC checks")
+            if not as_json:
+                print("  Use --no-drc to skip DRC checks")
 
     state = agent.get_state()
-    print("\n--- Board Summary ---")
-    print(f"  Board size: {state.outline.width:.1f}mm x {state.outline.height:.1f}mm")
-    print(f"  Components: {len(state.components)}")
-    print(f"  Nets total: {len(state.routed_nets) + len(state.unrouted_nets)}")
-    print(f"  Nets routed: {len(state.routed_nets)}")
-    print(f"  Nets unrouted: {len(state.unrouted_nets)}")
-    print(f"  Violations: {len(state.violations)}")
+    if not as_json:
+        print("\n--- Board Summary ---")
+        print(f"  Board size: {state.outline.width:.1f}mm x {state.outline.height:.1f}mm")
+        print(f"  Components: {len(state.components)}")
+        print(f"  Nets total: {len(state.routed_nets) + len(state.unrouted_nets)}")
+        print(f"  Nets routed: {len(state.routed_nets)}")
+        print(f"  Nets unrouted: {len(state.unrouted_nets)}")
+        print(f"  Violations: {len(state.violations)}")
+
+    envelope = {
+        "command": "reason",
+        "pcb": str(pcb_path),
+        "output": str(output_path),
+        "dry_run": bool(args.dry_run),
+        "warnings": warnings,
+        "drc": drc_block,
+        "board": {
+            "width_mm": state.outline.width,
+            "height_mm": state.outline.height,
+            "components": len(state.components),
+            "nets_total": len(state.routed_nets) + len(state.unrouted_nets),
+            "nets_routed": len(state.routed_nets),
+            "nets_unrouted": len(state.unrouted_nets),
+            "violations": len(state.violations),
+        },
+    }
 
     # Handle different modes
     if args.export_state:
-        return _export_state(agent, args)
-
-    if args.analyze:
-        return _analyze(agent, args)
-
-    if args.interactive:
+        rc, payload = _export_state(agent, args, as_json=as_json)
+    elif args.analyze:
+        rc, payload = _analyze(agent, args, as_json=as_json)
+    elif args.interactive:
+        # Unreachable under --format json (refused above).
         return _interactive_loop(agent, output_path, args)
+    elif args.auto_route:
+        rc, payload = _auto_route(agent, output_path, args, as_json=as_json)
+    else:
+        # Default: show the prompt and exit
+        payload = {"mode": "prompt", "prompt": agent.get_prompt()}
+        rc = 0
+        if not as_json:
+            print("\n--- Current State Prompt ---")
+            print(agent.get_prompt())
+            print("\n" + "=" * 60)
+            print("Use --export-state, --interactive, --analyze, or --auto-route")
 
-    if args.auto_route:
-        return _auto_route(agent, output_path, args)
-
-    # Default: show prompt and exit
-    print("\n--- Current State Prompt ---")
-    print(agent.get_prompt())
-    print("\n" + "=" * 60)
-    print("Use --export-state, --interactive, --analyze, or --auto-route")
-    return 0
+    if as_json:
+        emit_json({**envelope, **payload, "success": rc == 0})
+    return rc
 
 
-def _export_state(agent, args) -> int:
-    """Export state as JSON for external LLM processing."""
+def _export_state(agent, args, *, as_json: bool = False) -> tuple[int, dict]:
+    """Export state as JSON for external LLM processing.
+
+    Returns ``(exit_code, payload)``; the payload is merged into the
+    ``--format json`` envelope by :func:`main` (issue #4674).
+    """
     state = agent.get_state()
 
     # Build state dictionary
@@ -225,18 +345,28 @@ def _export_state(agent, args) -> int:
 
     if args.state_output:
         Path(args.state_output).write_text(json_str)
-        print(f"\n--- State exported to {args.state_output} ---")
-    else:
+        if not as_json:
+            print(f"\n--- State exported to {args.state_output} ---")
+    elif not as_json:
         print("\n--- State JSON ---")
         print(json_str)
 
-    return 0
+    # The exported state is the artifact; the envelope carries it under
+    # ``state`` (and names the file it was written to) rather than making the
+    # caller parse a second document out of the stream.
+    return 0, {
+        "mode": "export-state",
+        "state": state_dict,
+        "state_output": args.state_output,
+    }
 
 
-def _analyze(agent, args) -> int:
-    """Print detailed analysis of PCB state."""
-    print("\n" + agent.analyze_current_state())
-    return 0
+def _analyze(agent, args, *, as_json: bool = False) -> tuple[int, dict]:
+    """Print detailed analysis of PCB state (prose), or return it as data."""
+    analysis = agent.analyze_current_state()
+    if not as_json:
+        print("\n" + analysis)
+    return 0, {"mode": "analyze", "analysis": analysis}
 
 
 def _interactive_loop(agent, output_path: Path, args) -> int:
@@ -305,28 +435,68 @@ def _interactive_loop(agent, output_path: Path, args) -> int:
     return 0
 
 
-def _auto_route(agent, output_path: Path, args) -> int:
-    """Auto-route priority nets without LLM."""
-    print(f"\n--- Auto-routing up to {args.max_nets} priority nets ---")
+def _auto_route(agent, output_path: Path, args, *, as_json: bool = False) -> tuple[int, dict]:
+    """Auto-route priority nets without LLM.
 
-    results = agent.route_priority_nets(max_nets=args.max_nets)
+    Returns ``(exit_code, payload)``; the payload names every attempted net and
+    whether the result was written, so a machine caller never has to infer
+    "did it save?" from the exit code alone (issue #4674).
+    """
+    if not as_json:
+        print(f"\n--- Auto-routing up to {args.max_nets} priority nets ---")
+
+    # ``route_priority_nets`` walks the unrouted nets in priority order and
+    # returns one result per net in that same order, but ``CommandResult``
+    # itself carries no net name -- so capture the target order up front to
+    # label the per-net entries (missing labels degrade to ``null`` rather
+    # than mis-attributing a result).
+    targets = [
+        net.name for net in sorted(agent.get_state().unrouted_nets, key=lambda n: n.priority)
+    ][: args.max_nets]
+
+    with _stdout_to_stderr_when(as_json):
+        results = agent.route_priority_nets(max_nets=args.max_nets)
 
     successful = sum(1 for r in results if r.success)
-    print(f"\nRouted {successful}/{len(results)} nets")
+    if not as_json:
+        print(f"\nRouted {successful}/{len(results)} nets")
 
-    # Show final progress
-    progress = agent.get_progress()
-    print(progress.to_prompt())
+        # Show final progress
+        progress = agent.get_progress()
+        print(progress.to_prompt())
 
     # Save
     if args.dry_run:
-        print("\n--- Dry run - not saving ---")
+        if not as_json:
+            print("\n--- Dry run - not saving ---")
     else:
-        print(f"\n--- Saving to {output_path} ---")
+        if not as_json:
+            print(f"\n--- Saving to {output_path} ---")
         agent.save(str(output_path))
-        print(f"Saved to {output_path}")
+        if not as_json:
+            print(f"Saved to {output_path}")
 
-    return 0 if successful == len(results) else 1
+    payload = {
+        "mode": "auto-route",
+        "auto_route": {
+            "max_nets": args.max_nets,
+            "attempted": len(results),
+            "routed": successful,
+            "nets": [
+                {
+                    "net": targets[i] if i < len(targets) else None,
+                    "success": bool(r.success),
+                    "message": r.message,
+                    "vias_added": getattr(r, "vias_added", 0),
+                    "trace_length_mm": getattr(r, "trace_length", 0.0),
+                }
+                for i, r in enumerate(results)
+            ],
+        },
+        "saved": not args.dry_run,
+        "written_to": None if args.dry_run else str(output_path),
+    }
+    return (0 if successful == len(results) else 1), payload
 
 
 if __name__ == "__main__":

--- a/tests/test_cli_route_nets_flag.py
+++ b/tests/test_cli_route_nets_flag.py
@@ -372,9 +372,10 @@ def test_route_auto_nets_loop_aggregates_exit_code(monkeypatch):
 
     calls: list[str] = []
 
-    def fake_one(args, net_name, pcb_path, output_path):
+    def fake_one(args, net_name, pcb_path, output_path, **kwargs):
+        # Issue #4674: the helper now returns (exit_code, per-net document).
         calls.append(net_name)
-        return 0 if net_name == "/A" else 1  # /B "fails"
+        return (0 if net_name == "/A" else 1), {"net": net_name}  # /B "fails"
 
     monkeypatch.setattr(routing, "_route_auto_one", fake_one)
 
@@ -388,7 +389,7 @@ def test_route_auto_nets_loop_aggregates_exit_code(monkeypatch):
 def test_route_auto_nets_all_success_returns_zero(monkeypatch):
     from kicad_tools.cli.commands import routing
 
-    monkeypatch.setattr(routing, "_route_auto_one", lambda *a, **k: 0)
+    monkeypatch.setattr(routing, "_route_auto_one", lambda *a, **k: (0, {}))
 
     args = _auto_args(nets="/A,/B", dry_run=False, output=None, pcb="board.kicad_pcb")
     assert routing.run_route_auto_command(args) == 0
@@ -400,9 +401,9 @@ def test_route_auto_nets_chains_output(monkeypatch):
 
     sources: list[str] = []
 
-    def fake_one(args, net_name, pcb_path, output_path):
+    def fake_one(args, net_name, pcb_path, output_path, **kwargs):
         sources.append(pcb_path)
-        return 0
+        return 0, {"net": net_name}
 
     monkeypatch.setattr(routing, "_route_auto_one", fake_one)
 

--- a/tests/test_format_json_sweep_drivers.py
+++ b/tests/test_format_json_sweep_drivers.py
@@ -1,0 +1,865 @@
+"""Tests for the #4674 machine-output sweep (board-improvement drivers batch).
+
+Issue #4674 (mechanical follow-up to #4543) adds the canonical
+``--format json`` idiom to the prose-only subcommands.  Batch 1 swept the
+grouped families (``tests/test_format_json_sweep.py``), batch 2 the 16
+mutating ``sch`` leaves (``tests/test_format_json_sweep_sch.py``), batch 3 the
+four families' holdouts (``tests/test_format_json_sweep_families.py``), batch 4
+the environment/integration singles (``tests/test_format_json_sweep_env.py``)
+and batch 5 the board-artifact producers
+(``tests/test_format_json_sweep_artifacts.py``).
+
+**This batch sweeps the board-improvement / rule-derivation drivers** -- the
+singles that take an existing board and derive an improvement or an
+enforceable rule set from it:
+
+* ``optimize-placement``      -- CMA-ES placement optimization
+* ``optimize-traces``         -- trace geometry cleanup
+* ``route-auto``              -- orchestrator-driven per-net routing
+* ``reason``                  -- LLM-oriented board state / analysis / auto-route
+* ``creepage-export-rules``   -- voltage-domain netclasses + pairwise DRU rules
+
+Same conventions as the five sibling modules (a separate file per batch so
+concurrent batches never conflict on a shared ``SWEPT_SURFACES`` literal):
+
+* Outer-parser surface: every swept leaf accepts ``--format`` with a ``json``
+  choice, and the default stays ``text``.
+* Shim threading: the outer ``--format json`` reaches the inner parser argv
+  (``optimize-traces``, ``reason``) or the inner keyword
+  (``optimize-placement``), and the default (text) invocation must NOT.
+* Emission: a single valid JSON document on stdout, deterministic across two
+  runs on the same input, structure assertions rather than byte-golden
+  payloads, ``{"error": ...}`` documents on failure with exit codes unchanged.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from kicad_tools.cli.parser import create_parser
+
+FIXTURES = Path(__file__).parent / "fixtures"
+BOARD = FIXTURES / "routing-diagnostic.kicad_pcb"
+
+# Every subcommand swept by this batch, as (command path, minimal extra argv).
+SWEPT_SURFACES: dict[str, list[str]] = {
+    "creepage-export-rules": ["board.kicad_pro"],
+    "optimize-placement": ["board.kicad_pcb"],
+    "optimize-traces": ["board.kicad_pcb"],
+    "reason": ["board.kicad_pcb"],
+    "route-auto": ["board.kicad_pcb", "--net", "GND"],
+}
+
+
+def _iter_leaves(parser, path=()):
+    subactions = [a for a in parser._actions if isinstance(a, argparse._SubParsersAction)]
+    if not subactions:
+        yield path, parser
+        return
+    for subaction in subactions:
+        for name, sub in subaction.choices.items():
+            yield from _iter_leaves(sub, (*path, name))
+
+
+@pytest.fixture(scope="module")
+def leaves():
+    return {" ".join(path): leaf for path, leaf in _iter_leaves(create_parser())}
+
+
+@pytest.fixture
+def board(tmp_path):
+    """A writable copy of the small routing fixture board."""
+    pcb = tmp_path / "board.kicad_pcb"
+    pcb.write_text(BOARD.read_text())
+    return pcb
+
+
+# ---------------------------------------------------------------------------
+# Outer-parser surface guard
+# ---------------------------------------------------------------------------
+
+
+class TestOuterSurface:
+    @pytest.mark.parametrize("command", sorted(SWEPT_SURFACES))
+    def test_leaf_has_format_json_choice(self, leaves, command):
+        """Each swept leaf declares --format with a json choice."""
+        leaf = leaves.get(command)
+        assert leaf is not None, f"outer parser has no leaf {command!r}"
+        for action in leaf._actions:
+            if "--format" in action.option_strings:
+                assert action.choices and "json" in action.choices, (
+                    f"kct {command} has --format without a 'json' choice "
+                    f"(choices={action.choices}); regresses #4674"
+                )
+                break
+        else:
+            pytest.fail(f"kct {command} lost its --format flag (regresses #4674)")
+
+    @pytest.mark.parametrize("command", sorted(SWEPT_SURFACES))
+    def test_parse_accepts_format_json(self, command):
+        """`kct <command> ... --format json` parses on the real outer parser."""
+        argv = [*command.split(), *SWEPT_SURFACES[command], "--format", "json"]
+        args = create_parser().parse_args(argv)
+        assert args.format == "json"
+
+    @pytest.mark.parametrize("command", sorted(SWEPT_SURFACES))
+    def test_default_format_is_text(self, command):
+        """The default stays text, so no existing invocation changes shape."""
+        args = create_parser().parse_args([*command.split(), *SWEPT_SURFACES[command]])
+        assert args.format == "text"
+
+
+# ---------------------------------------------------------------------------
+# Shim threading (outer --format json must reach the inner surface)
+# ---------------------------------------------------------------------------
+
+
+class TestShimThreading:
+    def test_optimize_traces_shim_forwards_format(self):
+        from kicad_tools.cli.commands.routing import run_optimize_command
+
+        args = create_parser().parse_args(
+            ["optimize-traces", "board.kicad_pcb", "--format", "json"]
+        )
+        with patch("kicad_tools.cli.optimize_cmd.main", return_value=0) as inner:
+            assert run_optimize_command(args) == 0
+        sub_argv = inner.call_args[0][0]
+        assert "--format" in sub_argv, f"optimize-traces shim dropped --format: {sub_argv}"
+        assert sub_argv[sub_argv.index("--format") + 1] == "json"
+
+    def test_optimize_traces_shim_omits_format_for_text_default(self):
+        from kicad_tools.cli.commands.routing import run_optimize_command
+
+        args = create_parser().parse_args(["optimize-traces", "board.kicad_pcb"])
+        with patch("kicad_tools.cli.optimize_cmd.main", return_value=0) as inner:
+            assert run_optimize_command(args) == 0
+        assert "--format" not in inner.call_args[0][0]
+
+    def test_reason_shim_forwards_format(self):
+        from kicad_tools.cli.commands.reasoning import run_reason_command
+
+        args = create_parser().parse_args(["reason", "board.kicad_pcb", "--format", "json"])
+        with patch("kicad_tools.cli.reason_cmd.main", return_value=0) as inner:
+            assert run_reason_command(args) == 0
+        sub_argv = inner.call_args[0][0]
+        assert sub_argv[sub_argv.index("--format") + 1] == "json"
+
+    def test_reason_shim_omits_format_for_text_default(self):
+        from kicad_tools.cli.commands.reasoning import run_reason_command
+
+        args = create_parser().parse_args(["reason", "board.kicad_pcb"])
+        with patch("kicad_tools.cli.reason_cmd.main", return_value=0) as inner:
+            assert run_reason_command(args) == 0
+        assert "--format" not in inner.call_args[0][0]
+
+    def test_optimize_placement_shim_passes_as_json(self):
+        """This shim calls the inner function directly, so it passes a keyword."""
+        from kicad_tools.cli.commands.optimize_placement import run_optimize_placement_command
+
+        args = create_parser().parse_args(
+            ["optimize-placement", "board.kicad_pcb", "--format", "json"]
+        )
+        with patch(
+            "kicad_tools.cli.optimize_placement_cmd.run_optimize_placement", return_value=0
+        ) as inner:
+            assert run_optimize_placement_command(args) == 0
+        assert inner.call_args.kwargs["as_json"] is True
+
+    def test_optimize_placement_shim_defaults_to_text(self):
+        from kicad_tools.cli.commands.optimize_placement import run_optimize_placement_command
+
+        args = create_parser().parse_args(["optimize-placement", "board.kicad_pcb"])
+        with patch(
+            "kicad_tools.cli.optimize_placement_cmd.run_optimize_placement", return_value=0
+        ) as inner:
+            assert run_optimize_placement_command(args) == 0
+        assert inner.call_args.kwargs["as_json"] is False
+
+
+# ---------------------------------------------------------------------------
+# optimize-traces emission
+# ---------------------------------------------------------------------------
+
+
+def _run_optimize_traces(argv, capsys):
+    from kicad_tools.cli.commands.routing import run_optimize_command
+
+    rc = run_optimize_command(create_parser().parse_args(argv))
+    return rc, capsys.readouterr().out
+
+
+class TestOptimizeTracesEmission:
+    def test_dry_run_document(self, board, capsys):
+        rc, out = _run_optimize_traces(
+            ["optimize-traces", str(board), "--dry-run", "--format", "json"], capsys
+        )
+        assert rc == 0
+        payload = json.loads(out)
+        assert payload["command"] == "optimize-traces"
+        assert payload["pcb"] == str(board)
+        assert payload["dry_run"] is True
+        assert payload["saved"] is False, "--dry-run must not claim a written file"
+        assert payload["written_to"] is None
+        assert payload["success"] is True
+        assert payload["optimizations"] == {
+            "merge_collinear": True,
+            "eliminate_zigzags": True,
+            "convert_45_corners": True,
+            "chamfer_size_mm": 0.5,
+        }
+        assert "segments_before" in payload["stats"]
+        assert "length_after_mm" in payload["stats"]
+
+    def test_write_document_names_the_target(self, board, capsys):
+        rc, out = _run_optimize_traces(["optimize-traces", str(board), "--format", "json"], capsys)
+        assert rc == 0
+        payload = json.loads(out)
+        assert payload["saved"] is True
+        assert payload["written_to"] == str(board)
+
+    def test_disabled_passes_are_reported(self, board, capsys):
+        rc, out = _run_optimize_traces(
+            ["optimize-traces", str(board), "--dry-run", "--no-45", "--format", "json"], capsys
+        )
+        assert rc == 0
+        assert json.loads(out)["optimizations"]["convert_45_corners"] is False
+
+    def test_document_is_deterministic(self, board, capsys):
+        argv = ["optimize-traces", str(board), "--dry-run", "--format", "json"]
+        _, first = _run_optimize_traces(argv, capsys)
+        _, second = _run_optimize_traces(argv, capsys)
+        assert first == second
+
+    def test_missing_board_is_error_document(self, tmp_path, capsys):
+        rc, out = _run_optimize_traces(
+            ["optimize-traces", str(tmp_path / "nope.kicad_pcb"), "--format", "json"], capsys
+        )
+        assert rc == 1
+        payload = json.loads(out)
+        assert payload["command"] == "optimize-traces"
+        assert payload["success"] is False
+        assert payload["saved"] is False
+        assert "not found" in payload["error"]
+
+    def test_drc_aware_without_mfr_is_error_document(self, board, capsys):
+        rc, out = _run_optimize_traces(
+            ["optimize-traces", str(board), "--drc-aware", "--format", "json"], capsys
+        )
+        assert rc == 1
+        assert "--mfr" in json.loads(out)["error"]
+
+    def test_text_mode_is_not_json(self, board, capsys):
+        rc, out = _run_optimize_traces(["optimize-traces", str(board), "--dry-run"], capsys)
+        assert rc == 0
+        assert "Trace Optimization" in out
+        with pytest.raises(json.JSONDecodeError):
+            json.loads(out)
+
+
+# ---------------------------------------------------------------------------
+# optimize-placement emission
+# ---------------------------------------------------------------------------
+
+
+def _run_optimize_placement(argv, capsys):
+    from kicad_tools.cli.commands.optimize_placement import run_optimize_placement_command
+
+    rc = run_optimize_placement_command(create_parser().parse_args(argv))
+    return rc, capsys.readouterr().out
+
+
+def _strip_volatile(payload: dict) -> dict:
+    """Drop the deliberately volatile wall-clock field before comparing."""
+    stripped = json.loads(json.dumps(payload))
+    stripped.pop("wall_time_s", None)
+    return stripped
+
+
+class TestOptimizePlacementEmission:
+    def test_dry_run_document(self, board, capsys):
+        rc, out = _run_optimize_placement(
+            ["optimize-placement", str(board), "--dry-run", "--format", "json"], capsys
+        )
+        assert rc == 0
+        payload = json.loads(out)
+        assert payload["command"] == "optimize-placement"
+        assert payload["mode"] == "evaluate"
+        assert payload["dry_run"] is True
+        assert payload["saved"] is False, "--dry-run must not claim a written file"
+        assert payload["written_to"] is None
+        assert payload["board"]["components"] == 4
+        current = payload["scores"]["current"]
+        assert isinstance(current["total"], float)
+        assert isinstance(current["feasible"], bool)
+        # The breakdown comes straight off the cost dataclass.
+        assert {"wirelength", "overlap", "boundary", "drc", "area"} <= set(current["breakdown"])
+
+    def test_optimize_document_reports_both_scores(self, board, capsys):
+        rc, out = _run_optimize_placement(
+            [
+                "optimize-placement",
+                str(board),
+                "--max-iterations",
+                "3",
+                "--allow-infeasible",
+                "--format",
+                "json",
+            ],
+            capsys,
+        )
+        assert rc == 0
+        payload = json.loads(out)
+        assert payload["mode"] == "optimize"
+        assert set(payload["scores"]) == {"initial", "final"}
+        assert payload["iterations"] >= 1
+        assert payload["saved"] is True
+        assert payload["written_to"] == str(board)
+        assert payload["interrupted"] is False
+        assert isinstance(payload["wall_time_s"], float)
+
+    def test_infeasible_exit_carries_the_detail(self, board, capsys):
+        """Without --allow-infeasible an infeasible result exits 1 and says why."""
+        rc, out = _run_optimize_placement(
+            ["optimize-placement", str(board), "--max-iterations", "3", "--format", "json"],
+            capsys,
+        )
+        payload = json.loads(out)
+        assert payload["command"] == "optimize-placement"
+        if rc == 0:
+            assert payload["success"] is True
+            assert payload["feasible"] is True
+        else:
+            assert rc == 1
+            assert payload["success"] is False
+            assert payload["feasible"] is False
+            assert payload["infeasible_detail"]
+
+    def test_document_is_deterministic(self, board, capsys):
+        argv = ["optimize-placement", str(board), "--dry-run", "--format", "json"]
+        _, first = _run_optimize_placement(argv, capsys)
+        _, second = _run_optimize_placement(argv, capsys)
+        assert _strip_volatile(json.loads(first)) == _strip_volatile(json.loads(second))
+
+    def test_missing_board_is_error_document(self, tmp_path, capsys):
+        rc, out = _run_optimize_placement(
+            ["optimize-placement", str(tmp_path / "nope.kicad_pcb"), "--format", "json"], capsys
+        )
+        assert rc == 1
+        payload = json.loads(out)
+        assert payload["success"] is False
+        assert payload["saved"] is False
+        assert "not found" in payload["error"]
+
+    def test_bad_anchor_weight_is_error_document(self, board, capsys):
+        rc, out = _run_optimize_placement(
+            ["optimize-placement", str(board), "--anchor-weight", "-1", "--format", "json"],
+            capsys,
+        )
+        assert rc == 1
+        assert "anchor-weight" in json.loads(out)["error"]
+
+    def test_text_mode_is_not_json(self, board, capsys):
+        rc, out = _run_optimize_placement(["optimize-placement", str(board), "--dry-run"], capsys)
+        assert rc == 0
+        assert "Reading board" in out
+        with pytest.raises(json.JSONDecodeError):
+            json.loads(out)
+
+
+# ---------------------------------------------------------------------------
+# route-auto emission
+# ---------------------------------------------------------------------------
+
+
+def _run_route_auto(argv, capsys):
+    from kicad_tools.cli.commands.routing import run_route_auto_command
+
+    rc = run_route_auto_command(create_parser().parse_args(argv))
+    return rc, capsys.readouterr().out
+
+
+def _fake_route_result(net_name: str, **overrides):
+    result = {
+        "success": True,
+        "net_name": net_name,
+        "strategy_used": "GLOBAL_WITH_REPAIR",
+        "metrics": {"total_length_mm": 12.5, "via_count": 1},
+        "segments_written": 3,
+        "vias_written": 1,
+        "warnings": [],
+        "output_path": None,
+    }
+    result.update(overrides)
+    return result
+
+
+class TestRouteAutoEmission:
+    def test_dry_run_document(self, board, capsys):
+        rc, out = _run_route_auto(
+            ["route-auto", str(board), "--net", "NET1", "--dry-run", "--format", "json"], capsys
+        )
+        assert rc == 0
+        payload = json.loads(out)
+        assert payload["command"] == "route-auto"
+        assert payload["dry_run"] is True
+        assert payload["nets_requested"] == 1
+        assert payload["nets_routed"] == 0, "a preview routes nothing"
+        entry = payload["nets"][0]
+        assert entry["net"] == "NET1"
+        assert entry["would_route"] is True
+        assert entry["via_drill_source"] in {"board-derived", "explicit override", None}
+
+    def test_dry_run_reports_explicit_via_override(self, board, capsys):
+        rc, out = _run_route_auto(
+            [
+                "route-auto",
+                str(board),
+                "--net",
+                "NET1",
+                "--dry-run",
+                "--via-drill",
+                "0.25",
+                "--format",
+                "json",
+            ],
+            capsys,
+        )
+        assert rc == 0
+        entry = json.loads(out)["nets"][0]
+        assert entry["via_drill_mm"] == 0.25
+        assert entry["via_drill_source"] == "explicit override"
+
+    def test_multi_net_document_has_one_entry_per_net(self, board, capsys):
+        with patch(
+            "kicad_tools.mcp.tools.routing.route_net_auto",
+            side_effect=lambda net_name, **kw: _fake_route_result(net_name),
+        ):
+            rc, out = _run_route_auto(
+                ["route-auto", str(board), "--nets", "NET1,NET2", "--format", "json"], capsys
+            )
+        assert rc == 0
+        payload = json.loads(out)
+        assert [entry["net"] for entry in payload["nets"]] == ["NET1", "NET2"]
+        assert payload["nets_routed"] == 2
+        assert payload["success"] is True
+        assert payload["nets"][0]["metrics"]["total_length_mm"] == 12.5
+
+    def test_failed_net_document_keeps_exit_code(self, board, capsys):
+        failure = _fake_route_result(
+            "NET1",
+            success=False,
+            error_message="no corridor",
+            alternative_strategies=[{"strategy": "HIERARCHICAL", "reason": "try wider"}],
+        )
+        with patch("kicad_tools.mcp.tools.routing.route_net_auto", return_value=failure):
+            rc, out = _run_route_auto(
+                ["route-auto", str(board), "--net", "NET1", "--format", "json"], capsys
+            )
+        assert rc == 1
+        payload = json.loads(out)
+        assert payload["success"] is False
+        assert payload["nets"][0]["error"] == "no corridor"
+        assert payload["nets"][0]["alternative_strategies"][0]["strategy"] == "HIERARCHICAL"
+
+    def test_partial_net_is_flagged(self, board, capsys):
+        partial = _fake_route_result(
+            "NET1", success=False, partial=True, pads_connected=2, pads_total=3
+        )
+        with patch("kicad_tools.mcp.tools.routing.route_net_auto", return_value=partial):
+            rc, out = _run_route_auto(
+                ["route-auto", str(board), "--net", "NET1", "--format", "json"], capsys
+            )
+        assert rc == 1
+        entry = json.loads(out)["nets"][0]
+        assert entry["partial"] is True
+        assert entry["pads_connected"] == 2
+        assert entry["pads_total"] == 3
+
+    def test_router_exception_is_error_document(self, board, capsys):
+        with patch(
+            "kicad_tools.mcp.tools.routing.route_net_auto",
+            side_effect=ValueError("net 'NOPE' not found"),
+        ):
+            rc, out = _run_route_auto(
+                ["route-auto", str(board), "--net", "NOPE", "--format", "json"], capsys
+            )
+        assert rc == 1
+        entry = json.loads(out)["nets"][0]
+        assert entry["success"] is False
+        assert "not found" in entry["error"]
+
+    def test_router_stdout_chatter_does_not_corrupt_the_document(self, board, capsys):
+        """Third-party progress logs are replayed on stderr, not stdout."""
+
+        def chatty(net_name, **kw):
+            print("=== Negotiated Congestion Routing ===")
+            return _fake_route_result(net_name)
+
+        with patch("kicad_tools.mcp.tools.routing.route_net_auto", side_effect=chatty):
+            from kicad_tools.cli.commands.routing import run_route_auto_command
+
+            rc = run_route_auto_command(
+                create_parser().parse_args(
+                    ["route-auto", str(board), "--net", "NET1", "--format", "json"]
+                )
+            )
+        captured = capsys.readouterr()
+        assert rc == 0
+        assert json.loads(captured.out)["command"] == "route-auto"
+        assert "Negotiated Congestion Routing" in captured.err
+
+    def test_missing_net_selector_is_error_document(self, board, capsys):
+        rc, out = _run_route_auto(["route-auto", str(board), "--format", "json"], capsys)
+        assert rc == 2, "usage exit code is unchanged"
+        payload = json.loads(out)
+        assert payload["success"] is False
+        assert payload["nets"] == []
+        assert "requires --net" in payload["error"]
+
+    def test_mutually_exclusive_selectors_are_error_document(self, board, capsys):
+        rc, out = _run_route_auto(
+            ["route-auto", str(board), "--net", "NET1", "--nets", "NET2", "--format", "json"],
+            capsys,
+        )
+        assert rc == 2
+        assert "mutually exclusive" in json.loads(out)["error"]
+
+    def test_document_is_deterministic(self, board, capsys):
+        argv = ["route-auto", str(board), "--net", "NET1", "--dry-run", "--format", "json"]
+        _, first = _run_route_auto(argv, capsys)
+        _, second = _run_route_auto(argv, capsys)
+        assert first == second
+
+    def test_text_mode_is_not_json(self, board, capsys):
+        rc, out = _run_route_auto(["route-auto", str(board), "--net", "NET1", "--dry-run"], capsys)
+        assert rc == 0
+        assert "[dry-run] Would route net" in out
+        with pytest.raises(json.JSONDecodeError):
+            json.loads(out)
+
+
+# ---------------------------------------------------------------------------
+# reason emission
+# ---------------------------------------------------------------------------
+
+
+def _run_reason(argv, capsys):
+    from kicad_tools.cli.commands.reasoning import run_reason_command
+
+    rc = run_reason_command(create_parser().parse_args(argv))
+    return rc, capsys.readouterr()
+
+
+class TestReasonEmission:
+    def test_default_prompt_document(self, board, capsys):
+        rc, captured = _run_reason(["reason", str(board), "--format", "json"], capsys)
+        assert rc == 0
+        payload = json.loads(captured.out)
+        assert payload["command"] == "reason"
+        assert payload["mode"] == "prompt"
+        assert payload["prompt"]
+        assert payload["board"]["components"] == 4
+        assert payload["drc"]["ran"] is True
+        assert payload["success"] is True
+
+    def test_analyze_document_carries_the_analysis(self, board, capsys):
+        rc, captured = _run_reason(["reason", str(board), "--analyze", "--format", "json"], capsys)
+        assert rc == 0
+        payload = json.loads(captured.out)
+        assert payload["mode"] == "analyze"
+        assert "PCB Analysis" in payload["analysis"]
+
+    def test_export_state_document_embeds_the_state(self, board, capsys):
+        rc, captured = _run_reason(
+            ["reason", str(board), "--export-state", "--format", "json"], capsys
+        )
+        assert rc == 0
+        payload = json.loads(captured.out)
+        assert payload["mode"] == "export-state"
+        assert payload["state_output"] is None
+        assert len(payload["state"]["components"]) == 4
+        assert "prompt" in payload["state"]
+
+    def test_export_state_to_file_names_the_artifact(self, board, tmp_path, capsys):
+        state_path = tmp_path / "state.json"
+        rc, captured = _run_reason(
+            [
+                "reason",
+                str(board),
+                "--export-state",
+                "--state-output",
+                str(state_path),
+                "--format",
+                "json",
+            ],
+            capsys,
+        )
+        assert rc == 0
+        payload = json.loads(captured.out)
+        assert payload["state_output"] == str(state_path)
+        assert json.loads(state_path.read_text())["outline"]["width"] > 0
+
+    def test_auto_route_document(self, board, tmp_path, capsys):
+        from kicad_tools.reasoning import PCBReasoningAgent
+        from kicad_tools.reasoning.commands import CommandResult, CommandType
+
+        results = [
+            CommandResult(
+                success=True,
+                command_type=CommandType.ROUTE_NET,
+                message="Routed NET1",
+                trace_length=8.0,
+                vias_added=1,
+            )
+        ]
+        out_path = tmp_path / "reasoned.kicad_pcb"
+        with (
+            patch.object(PCBReasoningAgent, "route_priority_nets", return_value=results),
+            patch.object(PCBReasoningAgent, "save") as save,
+        ):
+            rc, captured = _run_reason(
+                [
+                    "reason",
+                    str(board),
+                    "--auto-route",
+                    "--max-nets",
+                    "1",
+                    "-o",
+                    str(out_path),
+                    "--format",
+                    "json",
+                ],
+                capsys,
+            )
+        assert rc == 0
+        payload = json.loads(captured.out)
+        assert payload["mode"] == "auto-route"
+        assert payload["auto_route"]["attempted"] == 1
+        assert payload["auto_route"]["routed"] == 1
+        assert payload["auto_route"]["nets"][0]["vias_added"] == 1
+        assert payload["saved"] is True
+        assert payload["written_to"] == str(out_path)
+        save.assert_called_once()
+
+    def test_auto_route_dry_run_writes_nothing(self, board, capsys):
+        from kicad_tools.reasoning import PCBReasoningAgent
+
+        with (
+            patch.object(PCBReasoningAgent, "route_priority_nets", return_value=[]),
+            patch.object(PCBReasoningAgent, "save") as save,
+        ):
+            rc, captured = _run_reason(
+                ["reason", str(board), "--auto-route", "--dry-run", "--format", "json"], capsys
+            )
+        assert rc == 0
+        payload = json.loads(captured.out)
+        assert payload["saved"] is False
+        assert payload["written_to"] is None
+        save.assert_not_called()
+
+    def test_interactive_is_refused_structurally(self, board, capsys):
+        """--interactive is a dialogue: it has no single-document form."""
+        rc, captured = _run_reason(
+            ["reason", str(board), "--interactive", "--format", "json"], capsys
+        )
+        assert rc == 2
+        payload = json.loads(captured.out)
+        assert payload["success"] is False
+        assert "--interactive" in payload["error"]
+
+    def test_missing_board_is_error_document(self, tmp_path, capsys):
+        rc, captured = _run_reason(
+            ["reason", str(tmp_path / "nope.kicad_pcb"), "--format", "json"], capsys
+        )
+        assert rc == 1
+        payload = json.loads(captured.out)
+        assert payload["command"] == "reason"
+        assert payload["success"] is False
+        assert "not found" in payload["error"]
+
+    def test_document_is_deterministic(self, board, capsys):
+        argv = ["reason", str(board), "--analyze", "--format", "json"]
+        _, first = _run_reason(argv, capsys)
+        _, second = _run_reason(argv, capsys)
+        assert first.out == second.out
+
+    def test_text_mode_is_not_json(self, board, capsys):
+        rc, captured = _run_reason(["reason", str(board), "--analyze"], capsys)
+        assert rc == 0
+        assert "KiCad LLM-Driven PCB Reasoning" in captured.out
+        with pytest.raises(json.JSONDecodeError):
+            json.loads(captured.out)
+
+
+# ---------------------------------------------------------------------------
+# creepage-export-rules emission
+# ---------------------------------------------------------------------------
+
+_CREEPAGE_BOARD = """\
+(kicad_pcb (version 20240108) (generator "test")
+  (layers
+    (0 "F.Cu" signal)
+    (31 "B.Cu" signal)
+    (37 "F.SilkS" user)
+    (44 "Edge.Cuts" user)
+  )
+  (setup (pad_to_mask_clearance 0))
+  (net 0 "")
+  (net 1 "AC_LINE")
+  (net 2 "GND")
+  (gr_line (start 100 100) (end 160 100) (layer "Edge.Cuts") (width 0.1))
+  (gr_line (start 160 100) (end 160 130) (layer "Edge.Cuts") (width 0.1))
+  (gr_line (start 160 130) (end 100 130) (layer "Edge.Cuts") (width 0.1))
+  (gr_line (start 100 130) (end 100 100) (layer "Edge.Cuts") (width 0.1))
+  (footprint "test:fp" (layer "F.Cu") (at 110 110)
+    (property "Reference" "P1" (at 0 0 0) (layer "F.SilkS"))
+    (fp_rect (start -1 -1) (end 1 1)
+      (stroke (width 0.05) (type solid)) (fill none) (layer "F.CrtYd"))
+    (pad "1" smd rect (at 0 0) (size 1 1) (layers "F.Cu")
+      (net 1 "AC_LINE"))
+  )
+  (footprint "test:fp" (layer "F.Cu") (at 150 125)
+    (property "Reference" "P2" (at 0 0 0) (layer "F.SilkS"))
+    (fp_rect (start -1 -1) (end 1 1)
+      (stroke (width 0.05) (type solid)) (fill none) (layer "F.CrtYd"))
+    (pad "1" smd rect (at 0 0) (size 1 1) (layers "F.Cu")
+      (net 2 "GND"))
+  )
+)
+"""
+
+
+@pytest.fixture
+def creepage_project(tmp_path):
+    """A .kicad_pro + sibling .kicad_pcb + voltage map with two HV domains."""
+    from kicad_tools.core.project_file import create_minimal_project, save_project
+
+    pro = tmp_path / "board.kicad_pro"
+    save_project(create_minimal_project("board.kicad_pro"), pro)
+    (tmp_path / "board.kicad_pcb").write_text(_CREEPAGE_BOARD)
+    vmap = tmp_path / "voltages.json"
+    vmap.write_text(json.dumps({"AC_LINE": 150.0, "GND": 0.0}))
+    return pro, vmap
+
+
+def _run_creepage_export(argv, capsys):
+    from kicad_tools.cli.commands.creepage_export_rules import (
+        run_creepage_export_rules_command,
+    )
+
+    rc = run_creepage_export_rules_command(create_parser().parse_args(argv))
+    return rc, capsys.readouterr().out
+
+
+class TestCreepageExportRulesEmission:
+    def test_dry_run_document(self, creepage_project, capsys):
+        pro, vmap = creepage_project
+        rc, out = _run_creepage_export(
+            [
+                "creepage-export-rules",
+                str(pro),
+                "--voltage-map",
+                str(vmap),
+                "--dry-run",
+                "--format",
+                "json",
+            ],
+            capsys,
+        )
+        assert rc == 0
+        payload = json.loads(out)
+        assert payload["command"] == "creepage-export-rules"
+        assert payload["project"] == str(pro)
+        assert payload["voltage_map"] == str(vmap)
+        assert payload["dry_run"] is True
+        assert payload["written"] is False, "--dry-run must not claim written files"
+        assert payload["skipped_reason"] == "dry-run"
+        assert payload["standard"] == "iec60664"
+        assert payload["domains"] == {"kct_0V": 0.0, "kct_150V": 150.0}
+        assert payload["net_domains"] == {"AC_LINE": "kct_150V", "GND": "kct_0V"}
+        assert payload["nets_assigned"] == 2
+        assert payload["rules"], "a 150 V vs 0 V pair must produce a rule"
+        assert payload["dru_block"] and "(rule " in payload["dru_block"]
+        assert not pro.with_suffix(".kicad_dru").exists()
+
+    def test_write_document_reports_written(self, creepage_project, capsys):
+        pro, vmap = creepage_project
+        rc, out = _run_creepage_export(
+            ["creepage-export-rules", str(pro), "--voltage-map", str(vmap), "--format", "json"],
+            capsys,
+        )
+        assert rc == 0
+        payload = json.loads(out)
+        assert payload["written"] is True
+        assert payload["skipped_reason"] is None
+        assert payload["dru_block"] is None, "the written block is the file, not the document"
+        assert pro.with_suffix(".kicad_dru").is_file()
+
+    def test_no_voltage_map_is_a_documented_no_op(self, creepage_project, capsys):
+        pro, _vmap = creepage_project
+        rc, out = _run_creepage_export(
+            ["creepage-export-rules", str(pro), "--format", "json"], capsys
+        )
+        assert rc == 0
+        payload = json.loads(out)
+        assert payload["success"] is True
+        assert payload["written"] is False
+        assert payload["skipped_reason"] == "no-voltage-map"
+        assert payload["rules"] == []
+
+    def test_missing_project_is_error_document(self, tmp_path, capsys):
+        rc, out = _run_creepage_export(
+            ["creepage-export-rules", str(tmp_path / "nope.kicad_pro"), "--format", "json"],
+            capsys,
+        )
+        assert rc == 1
+        payload = json.loads(out)
+        assert payload["success"] is False
+        assert payload["written"] is False
+        assert "not found" in payload["error"]
+
+    def test_missing_voltage_map_is_error_document(self, creepage_project, tmp_path, capsys):
+        pro, _vmap = creepage_project
+        rc, out = _run_creepage_export(
+            [
+                "creepage-export-rules",
+                str(pro),
+                "--voltage-map",
+                str(tmp_path / "nope.json"),
+                "--format",
+                "json",
+            ],
+            capsys,
+        )
+        assert rc == 1
+        assert "voltage-map file not found" in json.loads(out)["error"]
+
+    def test_document_is_deterministic(self, creepage_project, capsys):
+        pro, vmap = creepage_project
+        argv = [
+            "creepage-export-rules",
+            str(pro),
+            "--voltage-map",
+            str(vmap),
+            "--dry-run",
+            "--format",
+            "json",
+        ]
+        _, first = _run_creepage_export(argv, capsys)
+        _, second = _run_creepage_export(argv, capsys)
+        assert first == second
+
+    def test_text_mode_is_not_json(self, creepage_project, capsys):
+        pro, vmap = creepage_project
+        rc, out = _run_creepage_export(
+            ["creepage-export-rules", str(pro), "--voltage-map", str(vmap), "--dry-run"], capsys
+        )
+        assert rc == 0
+        assert "kct creepage-export-rules" in out
+        with pytest.raises(json.JSONDecodeError):
+            json.loads(out)


### PR DESCRIPTION
## Summary

Sixth batch of the #4543 machine-output sweep (issue #4674): the **board-improvement / rule-derivation drivers** — the prose-only singles that take an existing board and derive an *improvement* or an *enforceable rule set* from it. Each now accepts the canonical `--format json` and prints exactly one deterministic document on stdout, wired end-to-end (outer parser → shim → inner parser/handler).

**Covered by this batch (5):** `optimize-placement`, `optimize-traces`, `route-auto`, `reason`, `creepage-export-rules`.

**Remaining after this batch (3 actionable):** `build`, `pipeline` (the two multi-stage orchestrators) and `stitch` (single command, but its 6k-line inner module has a bespoke multi-phase report — still worth batching alone). The audit's `prose-only` bucket reads 8 because it also counts the 4 exempt commands (`interactive`, `mcp serve`, `run`, `footprint generate`) and the deferred `route`.

Audit (`scripts/audit_machine_output.py`) at PR head, base `12810532`: **prose-only 13 → 8, format-json 184 → 189.**

`tests/test_cli_parser_drift.py` is untouched — no route/check parser changes; the `route --format` promotion still belongs to the route workstream per the design note.

## Changes

- `src/kicad_tools/cli/parser.py` — `add_format_flag` on the five outer leaves (+5 lines, nothing else touched).
- Threading: `commands/routing.py` (`optimize-traces` shim forwards `--format json` into the inner argv; `route-auto`'s handler lives here), `commands/reasoning.py` (argv forwarding), `commands/optimize_placement.py` (this shim calls the inner function directly, so it passes `as_json=` instead of argv).
- Emission: `optimize_cmd.py`, `optimize_placement_cmd.py`, `reason_cmd.py`, `commands/routing.py`, `commands/creepage_export_rules.py`.
- `tests/test_format_json_sweep_drivers.py` — **new**, 63 tests. A *sibling* of the batch-1/2/3/4/5 modules, per the convention established in #4759, so concurrent batches never conflict on a shared `SWEPT_SURFACES` literal.
- `tests/test_cli_route_nets_flag.py` — the three fakes that monkeypatch `_route_auto_one` follow its `(exit_code, document)` return (see below). No assertions changed.
- `docs/reference/machine-output.md` inventory row for b6 + per-command shapes; `CHANGELOG.md` under `[Unreleased] ### Added`.

## JSON schema (this batch)

| Command | Document |
|---|---|
| `optimize-placement` | `{"command", "pcb", "output", "strategy", "seed_method", "max_iterations", "board": {width_mm, height_mm, components, nets}, "mode": "evaluate"\|"optimize", "scores", "feasible", "infeasible_detail", "iterations", "wall_time_s", "interrupted", "overlaps_remaining", "allow_infeasible", "dry_run", "saved", "written_to", "success"}` — `scores` is `{"current": …}` under `--dry-run`, `{"initial", "final"}` otherwise; each score is `{total, feasible, breakdown}` and the breakdown is taken straight off the cost dataclass (`dataclasses.asdict`), so a new cost axis appears in the machine output without another edit here. |
| `optimize-traces` | `{"command", "pcb", "output", "net_filter", "optimizations": {merge_collinear, eliminate_zigzags, convert_45_corners, chamfer_size_mm}, "drc_aware", "manufacturer", "layers", "copper_oz", "stats": {segments_before/after, corners_before/after, length_before_mm/after_mm, segment/length_reduction_pct, drc_errors_before/after, nets_optimized, nets_rolled_back}, "dry_run", "saved", "written_to", "success"}` |
| `route-auto` | `{"command", "pcb", "output", "strategy", "dry_run", "nets": [...], "nets_requested", "nets_routed", "success"}` — one `nets[]` entry per requested net, **in request order**: routed entries carry `success`/`partial`/`strategy_used`/`metrics`/`segments_written`/`vias_written`/`warnings`/`pads_connected`/`pads_total`/`error`/`alternative_strategies`/`source`; `--dry-run` entries carry the preview (`would_route`, `via_drill_mm` + `via_drill_source`, `via_diameter_mm` + `via_diameter_source`, `repair_enabled`, …). |
| `reason` | `{"command", "pcb", "output", "dry_run", "warnings", "drc": {ran, source, manufacturer, rules_checked \| error}, "board": {…}, "mode": "prompt"\|"analyze"\|"export-state"\|"auto-route", …, "success"}` — plus the mode's own payload: `prompt`, `analysis`, `state` + `state_output`, or `auto_route` (`max_nets`/`attempted`/`routed`/`nets[]`) with `saved`/`written_to`. |
| `creepage-export-rules` | `{"command", "project", "pcb", "dru", "voltage_map", "standard", "pollution_degree", "material_group", "hv_threshold_v", "dru_floor_mm", "domains", "net_domains", "nets_assigned", "rules": [{name, condition, min_mm}], "bridging_exemptions", "dru_block", "dry_run", "written", "skipped_reason", "success"}` — `dru_block` is carried only on the `--dry-run` path (mirroring the prose that prints the block instead of writing it) and is `null` once the file exists. |

Every failure path emits `{"command": …, "error": …, "success": false}` with the **exit code unchanged** — including `route-auto`'s usage exit **2** and `optimize-placement`'s interrupt exit **2**.

### Three things this batch establishes / reinforces

1. **A mode with no single-document form is refused, not half-emitted.** `kct reason --interactive --format json` emits `{"error": …}` and exits 2 rather than pretending to have a payload: `--interactive` is a stdin/stdout dialogue. A *whole-command* exemption belongs on #4543's exemption list; this is the per-mode analogue, and it is the first one the sweep has hit.
2. **Volatile fields are named, not hidden.** `optimize-placement` reports `wall_time_s`; like `board-metrics`'s `generated_at` (batch 5) it is the one field the determinism test compares modulo.
3. **`_stdout_to_stderr_when` is now the standard treatment (third use).** `route-auto` and `reason --auto-route` drive the negotiated router, whose multi-page per-iteration progress log goes to **stdout** — it reproduces on any real board and would corrupt the single-document contract. Those regions run under the diversion, so the log is replayed on stderr and the JSON stream stays parseable. There are now three copies (`report_cmd.py`, `commands/routing.py`, `reason_cmd.py`); a follow-up could promote it into `format_options.py`, deliberately not done here to keep a formatting-only batch formatting-only.

### One signature change worth reviewer attention

`_route_auto_one(...)` now returns `(exit_code, per_net_document)` instead of a bare exit code, so `run_route_auto_command` can accumulate one envelope for the `--nets` loop. That is the only non-additive change in the diff; the three fakes in `tests/test_cli_route_nets_flag.py` were updated to match (and now take `**kwargs`), with their assertions untouched.

## Acceptance Criteria Verification

Per-PR criteria from #4674's curated body:

- [x] **One coherent batch** — the board-improvement / rule-derivation drivers.
- [x] **Outer parser + shim + inner emission all threaded** — no inner-only flags (the `mfr rules` dead-surface trap). The two argv-reserializing shims (`optimize-traces`, `reason`) are tested for both forwarding and *non*-forwarding in the text default; `optimize-placement`'s direct-call shim is tested for `as_json=True/False`.
- [x] **JSON deterministic** — `emit_json` sorts keys; per-net collections keep request order (semantic), everything else is emitted in a fixed order. Byte-identical-across-two-runs tests for all five surfaces (`optimize-placement` modulo `wall_time_s`).
- [x] **`tests/test_cli_parser_drift.py` untouched and green.**
- [x] **Per-surface `--format json` tests** — structure assertions, not byte-golden: outer-surface guard, default-stays-text, shim threading, success documents, `{"error": …}` documents with unchanged exit codes, `--dry-run` writes nothing, and a "text mode is still prose" pin per surface.
- [x] **Family JSON schema documented** — table above plus `docs/reference/machine-output.md` (+ module docstrings on all five touched modules).
- [x] **Text mode unchanged** — verified by diffing stdout+stderr+exit code against the `main` checkout for all five surfaces on both success and failure paths (`optimize-traces` dry-run and missing-board, `optimize-placement` dry-run, `route-auto` dry-run and the "requires --net" usage error, `reason --analyze`, `creepage-export-rules --dry-run`): **byte-identical**.

## Test Plan

| Gate | Result |
|---|---|
| `pytest tests/test_format_json_sweep_drivers.py` | **63 passed** |
| `pytest` on `test_optimize_cmd*.py`, `test_optimize_placement_cmd.py`, `test_cli_route_nets_flag.py`, the four `test_route_auto_*.py`, `tests/creepage/`, `test_mcp_optimize_placement.py`, `test_build_parser_parity.py` | **434 passed** (8m26s — real routing) |
| `pytest tests/test_cli_parser_drift.py` + all six sweep modules | **509 passed** |
| `pytest tests/test_cli.py tests/test_cli_commands.py tests/test_pipeline_cmd.py tests/test_build_placement_step.py tests/test_mcp_routing.py tests/test_mcp_registry.py` | **454 passed** |
| `ruff check` / `ruff format --check` on the changed files | clean |
| `scripts/ci/check_mypy_baseline.py` (cold, `rm -rf .mypy_cache`) | **1470 errors, all within the 1472 baseline — no new type errors.** The `2 baseline errors no longer occur` warning is the known environment artifact (nanobind `import-not-found` from a natively-built worktree + a `net_status_cmd.py` line), reproduces on `main`, and is **not** in this diff, so the baseline was deliberately left untightened. |
| `scripts/audit_machine_output.py` | prose-only 13 → 8, format-json 184 → 189 |
| Manual smoke | all five surfaces exercised on real inputs (including a live `route-auto` route and a live `reason --auto-route`) plus every error path; each produced exactly one parseable document. |

Part of #4674
