### PR TITLE
perf(router): cache the pure-Python pairwise widening bitmap across route() calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -537,6 +537,55 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **The pure-Python router's pairwise (HV-isolation) widening bitmap is now
+  cached across `route()` calls** (#4794) —
+  `Router._pairwise_expanded_blocked` (the search-time bitmap the pure-Python
+  fallback A* ORs into its hot-loop mask) recomputed a **full-grid `np.isin`
+  plus a full-grid `binary_dilation` per non-dormant foreign domain, on every
+  single `route()` call**, even when nothing about the foreign copper had
+  changed since the previous call. The per-domain dilated masks are now
+  memoized per `(foreign_dom, pair_r)`. The routed net's own class width
+  needs no separate key component because it is already folded into `pair_r`
+  (post-#4793 the width is resolved per net class), so two classes that widen
+  to the same cell radius share a byte-identical mask and two that do not
+  land on different keys. The #4506 attach-zone waiver is re-applied per call
+  on a copy, never baked into a cached entry, and a result that would alias a
+  cache entry is copied before it is returned, so no caller can mutate cached
+  state. C++-backed routing is unaffected — the C++ kernels walk a bounded
+  annulus per query and never materialize a whole-grid bitmap, so there is
+  nothing to cache there.
+
+  **Invalidation** uses a new global monotonic counter,
+  `RoutingGrid.occupancy_generation` (public, with
+  `RoutingGrid.bump_occupancy_generation()` for code that writes the planes
+  directly): every write to `grid._blocked` / `grid._net` anywhere advances
+  it, and a cache entry is discarded when the counter, the grid object, or
+  the pairwise projection has changed since it was computed. This is the
+  deliberately conservative option — any write anywhere invalidates every
+  entry, mirroring the safety property the existing `_via_cache` already
+  relies on — because a stale mask means the search treats committed foreign
+  copper as absent, which is strictly worse than the recomputation the cache
+  removes. Completeness is enforced mechanically:
+  `tests/router/test_grid_occupancy_generation.py` AST-scans all of
+  `src/kicad_tools` for assignments into `_blocked`/`_net` (plus `np.copyto`
+  into them) and fails when any enclosing function does not bump. That scan
+  found two write sites outside `grid.py` that this change also fixes —
+  `Autorouter.route_all_negotiated`'s thread-safe grid rebuild and
+  `route_all_multi_resolution`'s trial-ordering rollback, both of which
+  replace the occupancy planes wholesale.
+
+  Measured on a 2-domain (150 V vs 0 V) 40×30 mm board at 0.1 mm with the
+  pure-Python fallback, 24 `_pairwise_expanded_blocked` calls (full-grid
+  dilation count is the deterministic figure; wall clock is the noisier
+  one): a burst of `route()` attempts with no intervening commit (retries,
+  `route_bidirectional`, negotiated iterations) goes **144 → 6 dilations,
+  1.8 s → 0.07 s (~25×)**; a mixed session committing copper every fourth
+  call goes **144 → 42 dilations, ~1.9 s → 0.7-1.5 s (1.4-2.9×)**. A session
+  that commits after *every* call sees no benefit (144 → 138) by design —
+  that is the known ceiling of a global counter, and the per-domain counters
+  that would lift it are deliberately left as a follow-up rather than shipped
+  with a silent-staleness risk.
+
 - **`kct route` now runs a topology-preserving collinear consolidation pass
   after the DRC nudge** (#4732, slice 2 — follows the slice-1
   `--report-stage-quality` instrumentation in #4746) — the post-route

--- a/src/kicad_tools/router/core.py
+++ b/src/kicad_tools/router/core.py
@@ -9501,6 +9501,10 @@ class Autorouter:
                 self.grid._pad_blocked = old_grid._pad_blocked.copy()
                 self.grid._original_net = old_grid._original_net.copy()
                 self.grid._pads = old_grid._pads.copy()
+                # Issue #4794: the occupancy planes were replaced wholesale
+                # after construction -- bump so occupancy-derived caches
+                # (e.g. the pairwise widening bitmaps) recompute.
+                self.grid.bump_occupancy_generation()
                 # Update router to use new grid
                 self.router.grid = self.grid
                 neg_router = NegotiatedRouter(
@@ -19200,11 +19204,15 @@ class Autorouter:
                     fine_grid._blocked = blocked_snapshot
                     fine_grid._net = net_snapshot
                     fine_grid.routes = routes_snapshot
+                    # Issue #4794: a rollback changes occupancy just as much
+                    # as a commit does -- invalidate derived caches.
+                    fine_grid.bump_occupancy_generation()
                 else:
                     # Trial produced no improvement: roll back
                     fine_grid._blocked = blocked_snapshot
                     fine_grid._net = net_snapshot
                     fine_grid.routes = routes_snapshot
+                    fine_grid.bump_occupancy_generation()  # Issue #4794
 
             if best_routes:
                 fine_grid_nets_count += 1

--- a/src/kicad_tools/router/grid.py
+++ b/src/kicad_tools/router/grid.py
@@ -491,6 +491,7 @@ class RoutedNetsUnblocker:
         # Clear those cells
         self._grid._blocked[routed_mask] = False
         self._grid._net[routed_mask] = 0
+        self._grid.bump_occupancy_generation()  # Issue #4794
 
         return self
 
@@ -500,6 +501,9 @@ class RoutedNetsUnblocker:
             np.copyto(self._grid._blocked, self._saved_blocked)
         if self._saved_net is not None:
             np.copyto(self._grid._net, self._saved_net)
+        # Issue #4794: the restore is itself an occupancy change (the grid
+        # inside the ``with`` body was NOT the grid outside it).
+        self._grid.bump_occupancy_generation()
 
 
 class _CellView:
@@ -532,6 +536,11 @@ class _CellView:
     @blocked.setter
     def blocked(self, value: bool) -> None:
         self._grid._blocked[self._layer, self._y, self._x] = value
+        # Issue #4794: this setter is THE per-cell choke point for
+        # ``mark_route``/``unmark_route``/``add_pad`` -- bump inline (rather
+        # than calling ``bump_occupancy_generation``) to keep the marking
+        # loops free of an extra Python-level call.
+        self._grid._occupancy_generation += 1
 
     @property
     def net(self) -> int:
@@ -540,6 +549,7 @@ class _CellView:
     @net.setter
     def net(self, value: int) -> None:
         self._grid._net[self._layer, self._y, self._x] = value
+        self._grid._occupancy_generation += 1  # Issue #4794
 
     @property
     def cost(self) -> float:
@@ -1021,6 +1031,41 @@ class RoutingGrid:
         # sub-clearance copper (routing-diagnostic fixture: NET3 through
         # J1-1's halo at 0.127mm actual vs 0.200mm required).
         self._static_blocked: np.ndarray | None = None
+        # Issue #4794: monotonic occupancy generation.  Allocating (or
+        # re-allocating) the planes is itself an occupancy change -- the new
+        # buffers share none of the old contents -- so bump rather than reset,
+        # which keeps the counter strictly monotonic for the lifetime of the
+        # grid object (a consumer that stamped a cache with the pre-realloc
+        # value can never see its stamp again).
+        self._occupancy_generation: int = getattr(self, "_occupancy_generation", 0) + 1
+
+    @property
+    def occupancy_generation(self) -> int:
+        """Monotonic counter bumped by every ``_blocked``/``_net`` write (#4794).
+
+        Consumers that cache a value *derived* from grid occupancy (e.g.
+        ``Router._pairwise_expanded_blocked``'s dilated foreign-domain
+        bitmaps) stamp their entry with this counter and recompute whenever
+        it has advanced.  The counter is deliberately **global** (any write
+        anywhere invalidates every derived cache) rather than per-net or
+        per-domain: a missed bump is a silent staleness bug, so the cheap,
+        mechanically auditable option wins.
+
+        Invariant enforced by ``tests/router/test_grid_occupancy_generation.py``:
+        every site in ``src/`` that assigns into ``_blocked``/``_net`` sits in
+        a function that also bumps this counter.  Code that mutates those
+        arrays directly (test fixtures poking ``grid._blocked[...] = True``)
+        must call :meth:`bump_occupancy_generation` itself.
+        """
+        return self._occupancy_generation
+
+    def bump_occupancy_generation(self) -> None:
+        """Record that ``_blocked``/``_net`` changed (Issue #4794).
+
+        Public so out-of-module writers (test fixtures, ad-hoc tooling that
+        pokes the occupancy planes) can keep occupancy-derived caches honest.
+        """
+        self._occupancy_generation += 1
 
     def _ensure_static_blockage_snapshot(self) -> None:
         """Capture the static blocked bitmap before the first route mark.
@@ -1093,6 +1138,7 @@ class RoutingGrid:
         self._via_rtree = None
         self._via_rtree_items = {}
         self._via_rtree_count = 0
+        self.bump_occupancy_generation()  # Issue #4794 (planes replaced)
 
     def sync_to_cpu(self) -> None:
         """Transfer GPU arrays to CPU for A* operations.
@@ -1122,6 +1168,10 @@ class RoutingGrid:
         self._gpu_dirty = False
         self._backend_type = BackendType.CPU
         self._backend = np
+        # Issue #4794: the ``_blocked``/``_net`` attributes now point at
+        # different array objects (host copies) -- any cache holding a
+        # derived bitmap must recompute.
+        self.bump_occupancy_generation()
 
     def sync_to_gpu(self) -> None:
         """Transfer CPU arrays to GPU for bulk operations.
@@ -1168,6 +1218,9 @@ class RoutingGrid:
             self._backend = backend
         except Exception as e:
             logger.warning(f"Failed to sync to GPU: {e}")
+        # Issue #4794: bump unconditionally -- a partial transfer that raised
+        # midway still leaves ``_blocked``/``_net`` pointing at new arrays.
+        self.bump_occupancy_generation()
 
     @property
     def backend_type(self) -> BackendType:
@@ -2263,6 +2316,7 @@ class RoutingGrid:
                         # pathfinder ``_is_trace_blocked`` and
                         # ``allow_sharing`` paths).
                         self._blocked[layer_idx, gy, gx] = True
+                        self.bump_occupancy_generation()  # Issue #4794
                     else:
                         # Cell already owned by a routable signal net
                         # (almost certainly a neighbour pad's clearance
@@ -2535,6 +2589,7 @@ class RoutingGrid:
                             # checks).  Preserve cell.net.
                             self._blocked[layer_idx, gy, gx] = True
                             self._is_obstacle[layer_idx, gy, gx] = True
+                            self.bump_occupancy_generation()  # Issue #4794
                         elif cell_net == 0:
                             # Bucket B: unclaimed cell.  Re-block it
                             # with the standard static-obstacle
@@ -2549,6 +2604,7 @@ class RoutingGrid:
                             # nuance for the negotiated-mode shared
                             # net flow).
                             self._blocked[layer_idx, gy, gx] = True
+                            self.bump_occupancy_generation()  # Issue #4794
                         else:
                             # Bucket C: foreign component / foreign
                             # net already owns this cell.  Leave it
@@ -2698,6 +2754,7 @@ class RoutingGrid:
 
                         # Unblock the cell so A* can route through
                         self._blocked[layer_idx, gy, gx] = False
+                        self.bump_occupancy_generation()  # Issue #4794
                         # Issue #3545: record that this component's
                         # corridor was relaxed so the same-component
                         # validator carve-out stays available for it
@@ -5864,6 +5921,7 @@ class RoutingGrid:
 
                 # Clear nets where applicable
                 self._net[layer_idx] = np.where(clear_net_mask, 0, self._net[layer_idx])
+                self.bump_occupancy_generation()  # Issue #4794
 
                 # Clear zone flags
                 self._is_zone[layer_idx] = False
@@ -6329,6 +6387,10 @@ class RoutingGrid:
             if 0 <= center_gx < self.cols and 0 <= center_gy < self.rows:
                 self._net[layer_idx, center_gy, center_gx] = pad.net
                 self._original_net[layer_idx, center_gy, center_gx] = pad.net
+
+            # Issue #4794: one bump per layer covers the three writes above
+            # (``_blocked`` halo, ``_net`` metal, ``_net`` centre cell).
+            self.bump_occupancy_generation()
 
     def get_grid_statistics(self) -> dict:
         """Get statistics about grid usage and memory.

--- a/src/kicad_tools/router/pathfinder.py
+++ b/src/kicad_tools/router/pathfinder.py
@@ -95,6 +95,16 @@ class _PairwiseSearchState:
     id_to_name: dict[int, str]
 
 
+# Issue #4794: hard cap on ``Router._pairwise_extra_cache`` entries.  Each
+# entry is a full-grid bool bitmap, so an unbounded cache would trade a CPU
+# problem for a memory one.  The natural population is
+# ``non-dormant foreign domains x distinct pair radii`` -- single digits on
+# every board in the fleet -- so the cap only ever bites on a pathological
+# table, where it degrades to the pre-#4794 recompute-every-call behaviour
+# rather than growing without bound.
+_PAIRWISE_MASK_CACHE_MAX = 64
+
+
 @dataclass(frozen=True)
 class _SegmentAdapter:
     """Adapter exposing :class:`Segment` with the ``start_x/start_y/end_x/end_y``
@@ -444,6 +454,21 @@ class Router:
         # invalidated by ``set_net_name_to_id`` (the projection is keyed by
         # net id).
         self._pairwise_search_cache: tuple[object, _PairwiseSearchState | None] | None = None
+
+        # Issue #4794: dilated foreign-domain bitmaps for
+        # ``_pairwise_expanded_blocked``, keyed by ``(foreign_dom, pair_r)``
+        # -- everything else that shapes a per-domain mask is either in that
+        # key (the routed net's class width folds into ``pair_r``) or in the
+        # validity stamp below.  ``None`` values memoize "this domain has no
+        # copper on the grid right now", which is just as cache-worthy as a
+        # mask.  The stamp is ``(grid, state, occupancy_generation)``: the
+        # entries are discarded wholesale when the grid object changes, when
+        # the pairwise projection is rebuilt, or when ANY write to
+        # ``grid._blocked`` / ``grid._net`` advances the generation counter.
+        # Strong references (``is`` comparison, not ``id()``) so a recycled
+        # address can never impersonate a live object.
+        self._pairwise_extra_cache: dict[tuple[int, int], np.ndarray | None] = {}
+        self._pairwise_extra_cache_stamp: tuple[object, object, int] | None = None
 
         # Issue #2929: Per-A*-call wall-clock instrumentation.  When
         # ``_per_call_timing_enabled`` is True, every ``route()`` invocation
@@ -2164,6 +2189,22 @@ class Router:
         more permissive than the per-cell kernel, the post-route
         ``route_pairwise_violation`` gate stays authoritative.
 
+        Issue #4794 (caching): the per-foreign-domain dilated masks are the
+        expensive part (a full-grid ``np.isin`` plus a full-grid dilation per
+        non-dormant domain, every ``route()`` call) and they depend on only
+        three things -- the foreign domain's net-id set, the pair radius, and
+        the current grid occupancy.  They are therefore memoized in
+        ``_pairwise_extra_cache`` keyed by ``(foreign_dom, pair_r)`` and
+        stamped with ``(grid, state, grid.occupancy_generation)``; ANY write
+        to ``grid._blocked``/``grid._net`` advances that counter and discards
+        the whole cache (see ``RoutingGrid.occupancy_generation``).  The
+        routed net's own class width does not need its own key component
+        because it is already folded into ``pair_r``: two classes that widen
+        to the same cell radius produce byte-identical masks, two that do not
+        land on different keys.  The #4506 attach-zone clearing is applied
+        per-call on a COPY, never baked into (or mutated into) a cached
+        entry, so a board with zones still gets a per-net-correct waiver.
+
         Returns ``None`` when dormant (no table, no projection, or ``net``
         participates in no widening pair) -- the caller then uses the scalar
         bitmap unchanged, byte-identical to pre-#4507 behaviour.
@@ -2193,7 +2234,12 @@ class Router:
             if domain >= 0:
                 net_ids_by_domain.setdefault(domain, []).append(net_id)
 
+        cache = self._pairwise_mask_cache(state)
         extra: np.ndarray | None = None
+        # True while ``extra`` still ALIASES a cache entry -- such a result is
+        # copied before it leaves this method so no caller can mutate a
+        # cached mask in place.
+        extra_aliases_cache = False
         for foreign_dom, required in enumerate(state.matrix[dom]):
             if foreign_dom == dom or required <= 0.0:
                 continue
@@ -2203,10 +2249,27 @@ class Router:
             foreign_ids = net_ids_by_domain.get(foreign_dom)
             if not foreign_ids:
                 continue
-            foreign_mask = self.grid._blocked & np.isin(self.grid._net, foreign_ids)
-            if not bool(np.any(foreign_mask)):
+            cache_key = (foreign_dom, pair_r)
+            pair_base: np.ndarray | None
+            if cache is not None and cache_key in cache:
+                pair_base = cache[cache_key]
+            else:
+                foreign_mask = self.grid._blocked & np.isin(self.grid._net, foreign_ids)
+                # ``None`` memoizes "this domain has no copper on the grid at
+                # this generation" -- as reusable as a mask, and it is the
+                # common case early in a routing session.
+                pair_base = (
+                    self._dilate_zero_padded(foreign_mask, pair_r)
+                    if bool(np.any(foreign_mask))
+                    else None
+                )
+                if cache is not None and len(cache) < _PAIRWISE_MASK_CACHE_MAX:
+                    cache[cache_key] = pair_base
+            if pair_base is None:
                 continue
-            pair_extra = self._dilate_zero_padded(foreign_mask, pair_r)
+            # The cached entry is the PRE-waiver base; the attach-zone
+            # clearing below is per-net, so it must land on a copy.
+            pair_extra = pair_base.copy() if self._attach_zones else pair_base
             if self._attach_zones:
                 foreign_keys = {
                     _norm_net_key(state.id_to_name.get(net_id, "")) for net_id in foreign_ids
@@ -2237,8 +2300,38 @@ class Router:
                         if not any(zone.covers_layer(key, layer_obj) for key in member_keys):
                             continue
                         pair_extra[layer_idx, gy1 : gy2 + 1, gx1 : gx2 + 1] = False
-            extra = pair_extra if extra is None else (extra | pair_extra)
+            if extra is None:
+                extra = pair_extra
+                extra_aliases_cache = pair_extra is pair_base and cache is not None
+            else:
+                extra = extra | pair_extra  # fresh array; no longer an alias
+                extra_aliases_cache = False
+        if extra is not None and extra_aliases_cache:
+            return np.array(extra, copy=True)
         return extra
+
+    def _pairwise_mask_cache(
+        self, state: _PairwiseSearchState
+    ) -> dict[tuple[int, int], np.ndarray | None] | None:
+        """Return the live ``(foreign_dom, pair_r)`` mask cache, or ``None``.
+
+        Issue #4794.  The cache is valid only for one
+        ``(grid, pairwise projection, occupancy generation)`` triple; any
+        change to any of the three drops every entry.  Returns ``None`` --
+        caching disabled, always recompute -- when the grid does not expose
+        an ``occupancy_generation`` counter (a stand-in / stub grid in a
+        test), so an object that cannot report mutation can never serve a
+        stale mask.
+        """
+        grid = self.grid
+        generation = getattr(grid, "occupancy_generation", None)
+        if not isinstance(generation, int):
+            return None
+        stamp = self._pairwise_extra_cache_stamp
+        if stamp is None or stamp[0] is not grid or stamp[1] is not state or stamp[2] != generation:
+            self._pairwise_extra_cache = {}
+            self._pairwise_extra_cache_stamp = (grid, state, generation)
+        return self._pairwise_extra_cache
 
     def _dilate_zero_padded(self, mask: np.ndarray, radius: int) -> np.ndarray:
         """Euclidean-disc dilation of ``mask`` treating out-of-bounds as EMPTY.

--- a/tests/router/test_grid_occupancy_generation.py
+++ b/tests/router/test_grid_occupancy_generation.py
@@ -1,0 +1,236 @@
+"""``RoutingGrid.occupancy_generation`` and its completeness (Issue #4794).
+
+The pure-Python pairwise (HV-isolation) widening bitmap
+(``Router._pairwise_expanded_blocked``) caches full-grid dilated masks across
+``route()`` calls.  That cache is only safe if EVERY mutation of
+``grid._blocked`` / ``grid._net`` advances the grid's occupancy generation --
+a missed bump means a search consults a bitmap in which foreign copper
+committed since the last call is simply absent, which is strictly worse than
+the recomputation the cache removes.
+
+Two layers of guard live here:
+
+* **Mechanical completeness** -- an AST scan of ``src/kicad_tools`` that finds
+  every assignment into a ``_blocked``/``_net`` array (and every
+  ``np.copyto`` into one) and asserts the enclosing function also bumps the
+  counter.  This is the check that fails when a future change adds a new
+  write site and forgets the bump.
+* **Behavioural** -- the production commit/rip-up/pad paths actually move the
+  counter.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+from kicad_tools.router.grid import RoutedNetsUnblocker, RoutingGrid
+from kicad_tools.router.layers import Layer, LayerStack
+from kicad_tools.router.primitives import Pad, Route, Segment
+from kicad_tools.router.rules import DesignRules
+
+SRC_ROOT = Path(__file__).resolve().parents[2] / "src" / "kicad_tools"
+
+# The two occupancy planes the pairwise cache is derived from.  Sibling planes
+# (``_pad_blocked``, ``_original_net``, ``_is_obstacle``, ...) are deliberately
+# NOT tracked: no occupancy-derived cache reads them.
+OCCUPANCY_ARRAYS = frozenset({"_blocked", "_net"})
+BUMP_METHOD = "bump_occupancy_generation"
+COUNTER_ATTR = "_occupancy_generation"
+
+
+def _attr_base(node: ast.expr) -> ast.Attribute | None:
+    """Peel subscripts off an assignment target, returning the attribute."""
+    while isinstance(node, ast.Subscript):
+        node = node.value
+    return node if isinstance(node, ast.Attribute) else None
+
+
+def _bumps(func: ast.AST) -> bool:
+    """True when ``func``'s body advances the occupancy generation."""
+    for node in ast.walk(func):
+        if isinstance(node, ast.Call):
+            callee = node.func
+            if isinstance(callee, ast.Attribute) and callee.attr == BUMP_METHOD:
+                return True
+        if isinstance(node, ast.AugAssign):
+            base = _attr_base(node.target)
+            if base is not None and base.attr == COUNTER_ATTR:
+                return True
+        if isinstance(node, ast.Assign):
+            for target in node.targets:
+                base = _attr_base(target)
+                if base is not None and base.attr == COUNTER_ATTR:
+                    return True
+        if isinstance(node, ast.AnnAssign):
+            base = _attr_base(node.target)
+            if base is not None and base.attr == COUNTER_ATTR:
+                return True
+    return False
+
+
+def _write_sites(path: Path) -> list[tuple[int, str, bool]]:
+    """Return ``(lineno, function, function_bumps)`` for occupancy writes."""
+    tree = ast.parse(path.read_text())
+    functions = [
+        node for node in ast.walk(tree) if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+    ]
+
+    def enclosing(lineno: int) -> ast.FunctionDef | ast.AsyncFunctionDef | None:
+        best = None
+        for func in functions:
+            end = func.end_lineno or func.lineno
+            if func.lineno <= lineno <= end and (best is None or func.lineno > best.lineno):
+                best = func
+        return best
+
+    writes: list[int] = []
+    for node in ast.walk(tree):
+        targets: list[ast.expr] = []
+        if isinstance(node, ast.Assign):
+            targets = list(node.targets)
+        elif isinstance(node, (ast.AugAssign, ast.AnnAssign)):
+            targets = [node.target]
+        for target in targets:
+            base = _attr_base(target)
+            if base is not None and base.attr in OCCUPANCY_ARRAYS:
+                writes.append(node.lineno)
+        # ``np.copyto(grid._blocked, saved)`` mutates without an assignment.
+        if isinstance(node, ast.Call):
+            callee = node.func
+            if isinstance(callee, ast.Attribute) and callee.attr == "copyto" and node.args:
+                base = _attr_base(node.args[0])
+                if base is not None and base.attr in OCCUPANCY_ARRAYS:
+                    writes.append(node.lineno)
+
+    sites: list[tuple[int, str, bool]] = []
+    for lineno in sorted(set(writes)):
+        func = enclosing(lineno)
+        if func is None:  # module level -- no such site exists today
+            sites.append((lineno, "<module>", False))
+        else:
+            sites.append((lineno, func.name, _bumps(func)))
+    return sites
+
+
+def test_every_occupancy_write_site_bumps_the_generation() -> None:
+    """Invalidation-completeness check for the Option-A global counter.
+
+    Mechanical, and deliberately over-broad: it flags any function anywhere in
+    ``src/kicad_tools`` that writes ``_blocked``/``_net`` without bumping,
+    including C++-mirrored commit paths (``Autorouter._mark_route`` and
+    friends) that reach the Python planes.
+    """
+    offenders: list[str] = []
+    seen = 0
+    for path in sorted(SRC_ROOT.rglob("*.py")):
+        for lineno, func, bumps in _write_sites(path):
+            seen += 1
+            if not bumps:
+                offenders.append(f"{path.relative_to(SRC_ROOT)}:{lineno} in {func}()")
+
+    assert seen > 0, "AST scan found no occupancy write sites -- scanner is broken"
+    assert not offenders, (
+        "occupancy write site(s) that do not bump RoutingGrid.occupancy_generation "
+        "(a cached pairwise widening bitmap would go stale here -- see Issue #4794):\n  "
+        + "\n  ".join(offenders)
+    )
+
+
+def test_scanner_would_catch_a_missing_bump() -> None:
+    """Negative control: the scan is not vacuously passing."""
+    source = (
+        "class G:\n"
+        "    def sneaky(self):\n"
+        "        self._blocked[0, 0, 0] = True\n"
+        "    def honest(self):\n"
+        "        self._net[0, 0, 0] = 1\n"
+        "        self.bump_occupancy_generation()\n"
+    )
+    tmp = Path(__file__).parent / "_occupancy_scan_probe.py.txt"
+    tmp.write_text(source)
+    try:
+        sites = _write_sites(tmp)
+    finally:
+        tmp.unlink()
+    assert [(func, bumps) for _line, func, bumps in sites] == [
+        ("sneaky", False),
+        ("honest", True),
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Behavioural: the production paths move the counter
+# ---------------------------------------------------------------------------
+
+
+def _grid() -> RoutingGrid:
+    rules = DesignRules(
+        trace_width=0.2,
+        trace_clearance=0.2,
+        via_diameter=0.6,
+        via_clearance=0.2,
+        grid_resolution=0.1,
+    )
+    return RoutingGrid(width=10.0, height=10.0, rules=rules, layer_stack=LayerStack.two_layer())
+
+
+def _route(net: int = 1) -> Route:
+    return Route(
+        net=net,
+        net_name="N1",
+        segments=[
+            Segment(
+                x1=2.0,
+                y1=5.0,
+                x2=8.0,
+                y2=5.0,
+                width=0.2,
+                layer=Layer.F_CU,
+                net=net,
+                net_name="N1",
+            )
+        ],
+    )
+
+
+def test_fresh_grid_reports_a_generation() -> None:
+    grid = _grid()
+    assert isinstance(grid.occupancy_generation, int)
+    before = grid.occupancy_generation
+    grid.bump_occupancy_generation()
+    assert grid.occupancy_generation == before + 1
+
+
+def test_mark_and_unmark_route_bump_the_generation() -> None:
+    grid = _grid()
+    route = _route()
+    before = grid.occupancy_generation
+    grid.mark_route(route)
+    after_mark = grid.occupancy_generation
+    assert after_mark > before
+    grid.unmark_route(route)
+    assert grid.occupancy_generation > after_mark
+
+
+def test_add_pad_paths_bump_the_generation() -> None:
+    grid = _grid()
+    before = grid.occupancy_generation
+    grid.add_pad(Pad(x=3.0, y=3.0, width=1.0, height=1.0, net=1, net_name="N1", layer=Layer.F_CU))
+    after_pad = grid.occupancy_generation
+    assert after_pad > before
+
+    grid.add_pad_vectorized(
+        Pad(x=7.0, y=7.0, width=1.0, height=1.0, net=2, net_name="N2", layer=Layer.F_CU)
+    )
+    assert grid.occupancy_generation > after_pad
+
+
+def test_routed_nets_unblocker_bumps_on_entry_and_exit() -> None:
+    grid = _grid()
+    grid.mark_route(_route())
+    before = grid.occupancy_generation
+    with RoutedNetsUnblocker(grid):
+        inside = grid.occupancy_generation
+        assert inside > before
+    assert grid.occupancy_generation > inside

--- a/tests/router/test_pairwise_python_search.py
+++ b/tests/router/test_pairwise_python_search.py
@@ -39,7 +39,7 @@ from kicad_tools.router.pairwise_clearance import (
     route_pairwise_violation,
 )
 from kicad_tools.router.pathfinder import Router
-from kicad_tools.router.primitives import Pad
+from kicad_tools.router.primitives import Pad, Route, Segment
 from kicad_tools.router.rules import DesignRules, NetClassRouting
 
 # IEC 60664-1, PD2, material group IIIa @ 150 V -> 1.6 mm (same constant the
@@ -484,3 +484,184 @@ def test_cpp_backend_setter_forwards_name_map_to_fallback_router() -> None:
     backend._py_router = router
     CppPathfinder.set_net_name_to_id(backend, NET_NAMES)
     assert router._net_name_to_id == NET_NAMES
+
+
+# ---------------------------------------------------------------------------
+# Hot-loop bitmap cache (Issue #4794)
+# ---------------------------------------------------------------------------
+#
+# ``_pairwise_expanded_blocked`` used to pay a full-grid ``np.isin`` plus a
+# full-grid dilation *per non-dormant foreign domain, per route() call*, even
+# though nothing about the foreign copper had changed between calls.  The
+# masks are now memoized per ``(foreign_dom, pair_r)`` and stamped with
+# ``RoutingGrid.occupancy_generation``, which every write to
+# ``grid._blocked``/``grid._net`` advances.
+#
+# The tests below pin the three things that make that safe: the cache is a
+# real hit (no recompute), it is DROPPED the moment foreign copper is
+# committed through the production commit path, and its key separates net
+# classes whose resolved widths differ.
+
+
+class _DilationCounter:
+    """Wrap ``Router._dilate_zero_padded`` to count real recomputations."""
+
+    def __init__(self, router: Router) -> None:
+        self.calls = 0
+        self._inner = router._dilate_zero_padded
+        router._dilate_zero_padded = self._wrapped  # type: ignore[method-assign]
+
+    def _wrapped(self, mask: np.ndarray, radius: int) -> np.ndarray:
+        self.calls += 1
+        return self._inner(mask, radius)
+
+
+def _lv_trace(y: float = 5.0) -> Route:
+    """A committed LV trace far from the wall, at ``y`` on F.Cu."""
+    return Route(
+        net=LV_NET,
+        net_name="LV",
+        segments=[
+            Segment(
+                x1=3.0,
+                y1=y,
+                x2=7.0,
+                y2=y,
+                width=TRACE_WIDTH,
+                layer=Layer.F_CU,
+                net=LV_NET,
+                net_name="LV",
+            )
+        ],
+    )
+
+
+def test_bitmap_cache_serves_repeat_calls_without_recomputing() -> None:
+    router, _grid = _router_with_lv_wall()
+    radius = router._trace_half_width_cells
+    counter = _DilationCounter(router)
+
+    first = router._pairwise_expanded_blocked(HV_NET, radius)
+    assert first is not None
+    assert counter.calls == 1
+
+    second = router._pairwise_expanded_blocked(HV_NET, radius)
+    assert second is not None
+    assert counter.calls == 1, "second call recomputed instead of hitting the cache"
+    assert bool(np.array_equal(first, second))
+
+
+def test_bitmap_cache_is_invalidated_by_a_foreign_route_commit() -> None:
+    """Stale-mask regression guard -- the whole point of Issue #4794.
+
+    Commits go through ``grid.mark_route`` (what ``Autorouter._mark_route``
+    calls in production), NOT a hand-poked array write, so this test fails on
+    a cache with no invalidation and passes on the shipped one.
+    """
+    router, grid = _router_with_lv_wall()
+    radius = router._trace_half_width_cells
+    probe_x, probe_y = _grid_pos(grid, 5.0, 5.0)  # ~11 mm from the wall
+
+    before = router._pairwise_expanded_blocked(HV_NET, radius)
+    assert before is not None
+    assert bool(before[0, probe_y, probe_x]) is False
+
+    generation_before = grid.occupancy_generation
+    grid.mark_route(_lv_trace())
+    assert grid.occupancy_generation > generation_before
+
+    after = router._pairwise_expanded_blocked(HV_NET, radius)
+    assert after is not None
+    assert bool(after[0, probe_y, probe_x]) is True, "served a stale pairwise mask"
+    assert not bool(np.array_equal(before, after))
+
+
+def test_bitmap_cache_key_separates_two_classes_in_one_domain() -> None:
+    """HV (1.0 mm class) and HV_TAP (global 0.2 mm) share a domain, not a mask."""
+    gx, gy = _grid_pos(_router_with_lv_wall()[1], 15.0, _WIDE_TRACE_PROBE_Y)
+
+    router, _grid = _router_with_lv_wall(net_class_map=_wide_class())
+    wide = router._pairwise_expanded_blocked(HV_NET, 3)
+    narrow = router._pairwise_expanded_blocked(HV_TAP_NET, 3)
+    assert wide is not None and narrow is not None
+    assert bool(wide[0, gy, gx]) is True
+    assert bool(narrow[0, gy, gx]) is False
+
+    # Order must not matter: whichever class populates the cache first, the
+    # other still gets its own radius.
+    reversed_router, _g = _router_with_lv_wall(net_class_map=_wide_class())
+    narrow_first = reversed_router._pairwise_expanded_blocked(HV_TAP_NET, 3)
+    wide_second = reversed_router._pairwise_expanded_blocked(HV_NET, 3)
+    assert narrow_first is not None and wide_second is not None
+    assert bool(np.array_equal(narrow, narrow_first))
+    assert bool(np.array_equal(wide, wide_second))
+
+
+def test_bitmap_cache_matches_a_forced_recompute_across_a_full_sequence() -> None:
+    """Parity over hit / class-miss / invalidation, cached vs uncached."""
+    cached_router, cached_grid = _router_with_lv_wall(net_class_map=_wide_class())
+    plain_router, plain_grid = _router_with_lv_wall(net_class_map=_wide_class())
+    # Force every call on ``plain_router`` to recompute from the live grid.
+    plain_router._pairwise_mask_cache = lambda state: None  # type: ignore[assignment,method-assign]
+
+    def _compare(net: int, radius: int) -> None:
+        cached = cached_router._pairwise_expanded_blocked(net, radius)
+        plain = plain_router._pairwise_expanded_blocked(net, radius)
+        assert cached is not None and plain is not None
+        assert bool(np.array_equal(cached, plain))
+
+    _compare(HV_NET, 3)  # cold
+    _compare(HV_NET, 3)  # cache hit
+    _compare(HV_TAP_NET, 3)  # miss: different resolved class width
+    _compare(HV_NET, 4)  # miss: different scalar radius
+    for grid in (cached_grid, plain_grid):
+        grid.mark_route(_lv_trace())
+    _compare(HV_NET, 3)  # invalidated by the commit above
+    _compare(HV_TAP_NET, 3)
+
+
+def test_bitmap_cache_is_untouched_on_the_dormant_paths() -> None:
+    """``pairwise_clearance is None`` (and friends) add zero bookkeeping."""
+    no_table, _grid = _router_with_lv_wall(with_table=False)
+    assert no_table._pairwise_expanded_blocked(HV_NET, no_table._trace_half_width_cells) is None
+    assert no_table._pairwise_extra_cache == {}
+    assert no_table._pairwise_extra_cache_stamp is None
+
+    domainless, _g2 = _router_with_lv_wall(name_map={"HV": HV_NET, "LV": LV_NET, "OTHER": 7})
+    assert domainless._pairwise_expanded_blocked(7, domainless._trace_half_width_cells) is None
+    assert domainless._pairwise_extra_cache == {}
+    assert domainless._pairwise_extra_cache_stamp is None
+
+
+def test_bitmap_result_is_never_a_live_cache_entry() -> None:
+    """A caller mutating the returned bitmap must not poison the cache."""
+    router, _grid = _router_with_lv_wall()
+    radius = router._trace_half_width_cells
+    first = router._pairwise_expanded_blocked(HV_NET, radius)
+    assert first is not None
+    first[:] = True
+
+    second = router._pairwise_expanded_blocked(HV_NET, radius)
+    assert second is not None
+    assert not bool(np.all(second))
+
+
+def test_bitmap_cache_does_not_bake_in_the_attach_zone_waiver() -> None:
+    """The zone waiver is per-net; the cached base mask is not.
+
+    HV and HV_TAP share a domain AND (no class map) a resolved width, so they
+    share a cache entry -- but only HV is named in the zone, so only HV may
+    see the widening waived.
+    """
+    router, grid = _router_with_lv_wall()
+    router.set_attach_zones((_zone(),))  # licenses HV <-> LV only
+    radius = router._trace_half_width_cells
+    gx, gy = _grid_pos(grid, 15.0, 9.0)
+
+    waived = router._pairwise_expanded_blocked(HV_NET, radius)
+    assert waived is not None
+    assert bool(waived[0, gy, gx]) is False
+
+    unwaived = router._pairwise_expanded_blocked(HV_TAP_NET, radius)
+    assert unwaived is not None
+    assert bool(unwaived[0, gy, gx]) is True


### PR DESCRIPTION
## Summary

`Router._pairwise_expanded_blocked` — the search-time pairwise (HV-isolation)
widening bitmap the **pure-Python fallback A\*** ORs into its hot-loop mask —
recomputed a full-grid `np.isin` **plus** a full-grid `binary_dilation` per
non-dormant foreign domain, on **every** `route()` call, with no cache. The
domain matrix and net→domain assignment are stable for a session, so most of
that work was pure repetition.

This PR memoizes the per-foreign-domain dilated masks and adds the
invalidation signal that makes the memoization safe.

**Option A (global grid-generation counter) was chosen**, as the curated issue
recommends, and the choice is documented below with its measured ceiling. A
stale mask means the search treats committed foreign copper as *absent* —
strictly worse than the recomputation removed — so the conservative option
wins until Option B can be plumbed with the same level of proof.

C++-backed routing is untouched: the C++ kernels walk a bounded annulus per
query and never materialize a whole-grid bitmap, so there is nothing to cache
there (`cpp_backend.py` unchanged).

## Changes

**Cache** (`router/pathfinder.py`)

- New `Router._pairwise_extra_cache`, keyed `(foreign_dom, pair_r)`, plus
  `_pairwise_mask_cache()` which validates/drops it against a
  `(grid, pairwise-projection, occupancy-generation)` stamp.
- **Key design.** The routed net's resolved copper half-width (post-#4840
  `_get_trace_width_for_net(own_name) / 2.0`) needs no separate key component
  because it is already folded into `pair_r = ceil((half_mm + required)/res)`:
  two classes that widen to the same cell radius produce byte-identical masks
  and may share; two that do not land on different keys. Pinned by a test with
  two classes of different width **in the same domain** (`HV` wide-class vs
  `HV_TAP` global-width), asserted in both call orders.
- **Attach zones (#4506) are never baked in.** The cached entry is the
  pre-waiver base; the per-net zone clearing is applied per call on a copy, so
  `own_key`-dependence stays out of the key (and out of the entry).
- **No cache entry ever escapes.** A result that would alias a cached mask is
  copied on the way out, so a caller mutating the returned bitmap cannot
  poison the cache (regression-tested).
- Entry count is capped (`_PAIRWISE_MASK_CACHE_MAX = 64`); past the cap the
  behaviour degrades to the pre-PR recompute instead of growing without bound.
- The dormant fast paths (`pairwise_clearance is None`, no projection,
  domainless net) return `None` **before** any cache bookkeeping — zero added
  overhead on the common non-HV board.
- Caching is *disabled* (always recompute) when the grid does not expose an
  `occupancy_generation` counter, so an object that cannot report mutation can
  never serve a stale mask.

**Invalidation** (`router/grid.py`, `router/core.py`)

- New `RoutingGrid.occupancy_generation` (read-only property) +
  `bump_occupancy_generation()` (public, for code that writes the planes
  directly, e.g. test fixtures). Every write to `_blocked`/`_net` bumps it;
  the two per-cell `_CellView` setters — the choke point for
  `mark_route`/`unmark_route`/`add_pad` — bump inline to avoid an extra
  Python-level call in the marking loops.
- Bumped at: the `_CellView.blocked`/`.net` setters, `RoutedNetsUnblocker`
  enter **and** exit (the `np.copyto` restore is an occupancy change too),
  `_init_arrays` / `release_arrays` / `sync_to_cpu` / `sync_to_gpu` (planes
  replaced), `_apply_stitch_via_halo`, `_apply_narrow_channel_halo`,
  `_relax_same_component_clearance`, `clear_zones`,
  `_add_pad_vectorized_unsafe`.
- **The completeness audit found two write sites outside `grid.py`**, both now
  fixed: `Autorouter.route_all_negotiated`'s thread-safe grid rebuild and
  `route_all_multi_resolution`'s trial-ordering rollback, which replace the
  occupancy planes wholesale (the rollback is on the *same* grid object, so it
  is a genuine staleness source, not just a defensive bump).
- `Autorouter._mark_route` / `_mark_route_on_cpp_grid` and the
  `diffpair_routing.py` commit points need no change: they reach the Python
  planes only through `grid.mark_route()` → `_CellView`, which is verified
  mechanically (below) rather than assumed.

## Invalidation completeness (the AC that matters)

`tests/router/test_grid_occupancy_generation.py` AST-scans **all of
`src/kicad_tools`** for assignments into a `_blocked`/`_net` array (subscript,
whole-array rebind, augmented) *and* for `np.copyto` into one, resolves the
enclosing function, and fails when that function does not bump the counter.
It carries a negative control so it cannot pass vacuously, and it is what
found the two `core.py` sites above.

Verified by sabotage (both reverted):

- Removing the bump from `_CellView.net` →
  `test_every_occupancy_write_site_bumps_the_generation` fails with
  `router/grid.py:551 in net()`.
- Making the cache stamp ignore the generation (i.e. "cache with no
  invalidation") → `test_bitmap_cache_is_invalidated_by_a_foreign_route_commit`
  and `test_bitmap_cache_matches_a_forced_recompute_across_a_full_sequence`
  fail; everything else still passes.

Known, documented limitation: a direct `grid._blocked[...] = True` poke from
outside the module (some test fixtures do this) does not bump — hence the
public `bump_occupancy_generation()` and the note on the property's docstring.

## Measured before/after (pure-Python fallback)

2 domains (150 V vs 0 V → 1.6 mm), 12 nets, 40×30 mm @ 0.1 mm, 2 layers
(241,402 cells), 24 `_pairwise_expanded_blocked` calls. Dilation count is the
deterministic figure; wall clock is the noisy one (two runs shown where they
differ). Benchmark script in the scratchpad, not committed.

| scenario | uncached | cached | speedup |
|---|---|---|---|
| retry / bidirectional / negotiated-iteration (no commit between calls) | 144 dilations, 1.8 s | **6 dilations, 0.07 s** | ~25× |
| mixed session (copper committed every 4th call) | 144 dilations, ~1.9 s | **42 dilations, 0.7–1.5 s** | 1.4–2.9× |
| commit after every call (worst case for a global counter) | 144 dilations, 2.3 s | 138 dilations, 2.3 s | ~1.0× |

**Honest reading of row 3.** With a *global* counter, any commit invalidates
every entry, so a session whose every call is followed by a commit gets
nothing. The win is real where `route()` runs repeatedly without an
intervening grid write — retries, `route_bidirectional`, negotiated
iterations, failed attempts — which is exactly the budget-burning pattern
#4507's search-time gate exists to fix. Lifting row 3 (many nets routed
consecutively *within* one domain not invalidating cross-domain entries) is
what per-domain counters (Option B) would buy, at the cost of resolving
net→domain at every mutation site; a missed or mis-mapped site there is a
silent wrong-domain staleness bug, so it is deliberately left as a follow-up
rather than shipped here.

## Acceptance criteria

- [x] Cache key includes the routed net's resolved copper half-width (via
      `pair_r`) — pinned with two classes of different trace width in one
      domain, in both call orders
      (`test_bitmap_cache_key_separates_two_classes_in_one_domain`).
- [x] Stale-mask regression test using the production commit path
      (`grid.mark_route`, what `Autorouter._mark_route` calls), verified to
      fail on a no-invalidation cache
      (`test_bitmap_cache_is_invalidated_by_a_foreign_route_commit`).
- [x] Invalidation-completeness check (Option A): mechanical AST scan of
      every `_blocked`/`_net` write site + `np.copyto`, with a negative
      control (`test_every_occupancy_write_site_bumps_the_generation`).
- [x] Parity: cached vs force-recomputed bitmaps `np.array_equal` across a
      sequence exercising a hit, a class miss, a scalar-radius miss and an
      invalidation
      (`test_bitmap_cache_matches_a_forced_recompute_across_a_full_sequence`).
- [x] `pairwise_clearance is None` still returns `None` immediately with no
      cache bookkeeping (`test_bitmap_cache_is_untouched_on_the_dormant_paths`).
- [x] Documented before/after timing on a pairwise-enabled multi-domain board
      via the pure-Python path (table above).
- [x] No behaviour change when there is no table, one domain, or every class
      shares the global width — the pre-existing #4793/#4840 no-op pins
      (`test_class_width_equal_to_global_is_a_no_op`, dormancy tests) still
      pass unchanged.
- [x] C++ backend unchanged (never materializes the bitmap).

## Test Plan

```
uv run kct build-native                      # C++ extension built in this worktree
uv run pytest tests/router/test_pairwise_python_search.py \
              tests/router/test_pairwise_cpp_parity.py \
              tests/router/test_grid_occupancy_generation.py   # 94 passed
uv run pytest tests/router tests/perf tests/test_router_grid.py \
              tests/test_grid_cpp_parity.py tests/test_grid_narrow_channel_guard.py \
              tests/test_grid_plane_net_halo.py tests/test_adaptive_grid.py \
              tests/test_bidirectional_astar.py                # green
uv run ruff check . && uv run ruff format --check .            # clean
rm -rf .mypy_cache && uv run python scripts/ci/check_mypy_baseline.py
#   OK: 1470 errors, all within the baseline (1472 allowed). No new type errors.
```

Closes #4794
