### PR TITLE
feat(router): mirror the C++ soft HV-avoidance gradient in the pure-Python fallback A*

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   guards the new surfaces; `docs/reference/machine-output.md` records the
   per-command shapes.
 
+- **Soft HV-avoidance gradient in the pure-Python fallback A\*** (part of
+  #4507, epic #4431 Phase 2b) — `Router._pairwise_avoidance_cost` mirrors the
+  C++ `Pathfinder::pairwise_avoidance_cost` (#4511 Scope 2) cell-for-cell, so
+  both engines now price the same bounded nudge just beyond the hard
+  cross-domain block instead of only the C++ search doing so. The fallback's
+  hard blocking landed in #4791; without the soft term it ran flush against
+  the pairwise limit, and copper that merely *meets* a creepage requirement is
+  one rip-up or one `--lattice-optimize` nudge away from violating it. The A\*
+  hot loop consults a pre-dilated band bitmap (one bool lookup per neighbour)
+  and calls the exact kernel only for cells near cross-domain copper. Strictly
+  dormant without `--voltage-map` (one `is None` test per neighbour,
+  byte-identical g-scores). The mirror reproduces the reference's **two-level**
+  break, including the conditional outer one (`if (cost > 0.0f) break;`): a
+  qualifying cell exactly on the halo circle prices `frac == 0` and lets the
+  scan run on into later rows rather than ending it, which matters because the
+  first cell every scan visits (`dy = -halo_r, dx = 0`) always sits on that
+  circle. New Python↔C++ parity tests pin the *value*, not just the sign: the
+  whole band, off-axis distances, board-edge-clipped scan windows,
+  per-net-class widths, the multi-cell case that proves both engines stop on
+  the same candidate cell, and the zero-`frac` cases (an on-circle cell paired
+  with a later priced one, and a single contiguous foreign bar whose topmost
+  row touches the halo).
+
 - **Placement pad-anchoring audit** (`docs/placement-pad-anchoring-audit.md`,
   part of #4831) — a docs-only, symbol-anchored survey of where the placement
   stack measures distance between component **centres** versus real **pad**

--- a/src/kicad_tools/router/pathfinder.py
+++ b/src/kicad_tools/router/pathfinder.py
@@ -470,6 +470,20 @@ class Router:
         self._pairwise_extra_cache: dict[tuple[int, int], np.ndarray | None] = {}
         self._pairwise_extra_cache_stamp: tuple[object, object, int] | None = None
 
+        # Issue #4507: memo for the per-domain "which foreign net ids widen
+        # against me" lists the soft-gradient kernel and its hot-loop band
+        # gate share.  Identity-checked against the ``_PairwiseSearchState``
+        # it was built from, so it expires with the projection above.
+        self._pairwise_widening_ids_cache: (
+            tuple[_PairwiseSearchState, dict[int, tuple[list[int], np.ndarray]]] | None
+        ) = None
+        # Cached ``(dist_sq, band_mask)`` scan window for the soft gradient,
+        # keyed by ``(hard_radius, band)`` -- pure geometry, so it survives
+        # every copper change.
+        self._pairwise_band_kernel_cache: tuple[tuple[int, int], np.ndarray, np.ndarray] | None = (
+            None
+        )
+
         # Issue #2929: Per-A*-call wall-clock instrumentation.  When
         # ``_per_call_timing_enabled`` is True, every ``route()`` invocation
         # appends a dict to ``_per_call_timings`` recording the elapsed wall
@@ -2373,6 +2387,224 @@ class Router:
                         expanded |= padded[:, dy : dy + rows, dx : dx + cols]
             return expanded
 
+    # ------------------------------------------------------------------
+    # Soft cross-domain (HV) avoidance gradient (Issue #4507)
+    # ------------------------------------------------------------------
+    #
+    # Python mirror of ``Pathfinder::pairwise_avoidance_cost`` (#4511
+    # Scope 2).  The hard kernels above restore the search<->gate mirror;
+    # this bounded *soft* cost is what stops the search from hugging the
+    # hard limit: a candidate cell that clears the widened radius by a hair
+    # is legal but fragile -- the next rip-up/re-route or a
+    # ``--lattice-optimize`` nudge pushes it back under, and the negotiator
+    # thrashes.  The C++ search has priced that margin since #4511; the
+    # pure-Python fallback (#4791 armed only its hard blocking) did not, so
+    # the two engines converged on measurably different HV routes.
+    #
+    # Mirror notes vs. ``Pathfinder::pairwise_avoidance_cost``:
+    # * Same band geometry: ``[hard_radius, hard_radius + band]`` where
+    #   ``band = ceil(max_widen * 0.5 / res)`` -- half the widest pairwise
+    #   requirement of slack beyond the hard block.
+    # * Same linear decay scaled to ``cost_straight`` (strongest just
+    #   outside the hard radius, zero at the band edge), so a cell hugging
+    #   the limit costs about one extra step of detour -- enough to steer,
+    #   not enough to distort the optimum away from a clean lane.
+    # * Same "one cross-domain neighbour is enough" rule, and same TWO-LEVEL
+    #   break -- the detail #4849's review caught.  The C++ kernel's inner
+    #   ``break`` fires at the first qualifying cell of a ROW (so a cell
+    #   flanked by a long HV run is not over-penalised), but the outer break
+    #   is CONDITIONAL: ``if (cost > 0.0f) break;``.  A qualifying cell
+    #   sitting exactly on the halo circle (``dist_sq == halo_r^2``) prices
+    #   ``frac == 0``, leaves ``cost`` at zero, and so lets the scan run on
+    #   into later rows and price a different cell.  That is not exotic: the
+    #   very first cell the scan visits (``dy = -halo_r, dx = 0``) is always
+    #   exactly on the circle, so any foreign copper whose topmost band cell
+    #   lands in the candidate's own column trips it.  An unconditional
+    #   return at the first qualifying cell would return 0.0 where C++
+    #   returns a full-magnitude cost, so the mirror below tracks the row it
+    #   priced (skipping that row's remaining cells, the inner break) and
+    #   stops only once the accumulated cost is strictly positive.  Because
+    #   every pre-stop contribution is exactly zero, accumulating and
+    #   returning at the first positive term is identical to the C++ sum.
+    #   ``np.nonzero`` yields C (row-major) order, so the entry it stops on
+    #   is the same cell the C++ scan stops on (clipping the scan window at
+    #   the board edge removes whole leading rows/columns and so preserves
+    #   row-major order among the remaining cells).  Scan-order dependence is
+    #   a wart of the reference implementation, mirrored deliberately: parity
+    #   first -- two engines agreeing on an arbitrary-but-bounded nudge beats
+    #   two engines disagreeing about which candidate is cheap.  Changing the
+    #   semantics is #4848's job (both engines together, with a
+    #   ``ROUTER_CPP_BUILD_VERSION`` bump), never a silent divergence here.
+    # * ``half_mm`` is the ROUTED net's class trace width (#4793), exactly as
+    #   in the hard kernels.
+    # * NO #4506 attach-zone waiver, mirroring the C++ kernel: this is a
+    #   soft nudge, never a block, so a rated footprint's attach path stays
+    #   reachable -- it is merely priced.
+
+    def _pairwise_widening_net_ids(
+        self, state: _PairwiseSearchState, dom: int
+    ) -> tuple[list[int], np.ndarray]:
+        """Foreign net ids whose domain pair with ``dom`` requires widening.
+
+        Returns both forms the two consumers want: the id list (for the
+        once-per-route ``np.isin`` band mask) and a boolean lookup array
+        indexed by net id (for the per-cell kernel, where a fancy-index of
+        the scan window is much cheaper than ``np.isin``).  Net 0 is excluded
+        -- the pour / unconnected convention never carries a domain, mirroring
+        the C++ kernels' ``cell.net == 0`` skip.  Memoised per domain against
+        the projection identity (the projection is pure net-id data, so it
+        cannot go stale while copper moves).
+        """
+        cached = self._pairwise_widening_ids_cache
+        if cached is None or cached[0] is not state:
+            cached = (state, {})
+            self._pairwise_widening_ids_cache = cached
+        entry = cached[1].get(dom)
+        if entry is None:
+            row = state.matrix[dom] if 0 <= dom < len(state.matrix) else []
+            ids = [
+                net_id
+                for net_id, domain in enumerate(state.net_to_domain)
+                if net_id != 0 and 0 <= domain < len(row) and row[domain] > 0.0
+            ]
+            lut = np.zeros(max(1, len(state.net_to_domain)), dtype=np.bool_)
+            if ids:
+                lut[ids] = True
+            entry = (ids, lut)
+            cached[1][dom] = entry
+        return entry
+
+    def _pairwise_gradient_geometry(self, net: int) -> tuple[_PairwiseSearchState, int, int] | None:
+        """``(state, hard_radius, band)`` for ``net``, or ``None`` when dormant.
+
+        Shared by the per-cell gradient kernel and the hot-loop band gate so
+        the two can never size the band differently.
+        """
+        table = getattr(self.rules, "pairwise_clearance", None)
+        if table is None:
+            return None
+        state = self._pairwise_search_state(table)
+        if state is None:
+            return None
+        net_to_domain = state.net_to_domain
+        dom = net_to_domain[net] if 0 <= net < len(net_to_domain) else -1
+        if dom < 0:
+            return None
+        res = self.grid.resolution
+        own_name = state.id_to_name.get(net, "")
+        half_mm = self._get_trace_width_for_net(own_name) / 2.0
+        # Issue #864 rounding idiom (round before ceil), as in the hard kernels.
+        hard_r = max(1, math.ceil(round((half_mm + state.max_widen) / res, 6)))
+        band = max(1, math.ceil(round(state.max_widen * 0.5 / res, 6)))
+        return state, hard_r, band
+
+    def _pairwise_avoidance_cost(self, gx: int, gy: int, layer: int, net: int) -> float:
+        """Soft HV-avoidance cost for one candidate cell (0.0 when dormant).
+
+        Python mirror of ``Pathfinder::pairwise_avoidance_cost``; see the
+        block comment above for the mirror contract.  Returns a bounded
+        additive A* cost in ``cost_straight`` units.
+        """
+        geometry = self._pairwise_gradient_geometry(net)
+        if geometry is None:
+            return 0.0
+        state, hard_r, band = geometry
+        dom = state.net_to_domain[net]
+        foreign_ids, widen_lut = self._pairwise_widening_net_ids(state, dom)
+        if not foreign_ids:
+            return 0.0
+
+        halo_r = hard_r + band
+        x1 = max(0, gx - halo_r)
+        y1 = max(0, gy - halo_r)
+        x2 = min(self.grid.cols, gx + halo_r + 1)
+        y2 = min(self.grid.rows, gy + halo_r + 1)
+        if x1 >= x2 or y1 >= y2:
+            return 0.0
+
+        blocked_region = self.grid._blocked[layer, y1:y2, x1:x2]
+        if not bool(np.any(blocked_region)):
+            return 0.0
+        net_region = self.grid._net[layer, y1:y2, x1:x2]
+
+        # The scan window's squared-distance / band geometry depends only on
+        # the radii, so it is built once and sliced here (the window is the
+        # full kernel unless the board edge clipped it).
+        dist_full, band_full = self._pairwise_band_kernel(hard_r, band)
+        off_y = y1 - (gy - halo_r)
+        off_x = x1 - (gx - halo_r)
+        dist_sq = dist_full[off_y : off_y + (y2 - y1), off_x : off_x + (x2 - x1)]
+        band_mask = band_full[off_y : off_y + (y2 - y1), off_x : off_x + (x2 - x1)]
+
+        candidates = blocked_region & band_mask & (net_region != net)
+        if not bool(np.any(candidates)):
+            return 0.0
+
+        # Mirror the C++ kernel's TWO-LEVEL break (see the block comment
+        # above).  ``np.nonzero`` yields C (row-major) order, so walking it
+        # visits cells in the reference's scan order; ``priced_row`` replays
+        # the inner ``break`` (the rest of a row is skipped once that row has
+        # priced a cell) and the ``cost > 0.0`` test replays the CONDITIONAL
+        # outer break -- a cell exactly on the halo circle prices 0.0 and the
+        # scan continues into later rows, exactly as the C++ scan does.
+        cost = 0.0
+        priced_row = -1  # no row index is negative, so this never matches
+        for row, col in zip(*np.nonzero(candidates), strict=True):
+            if row == priced_row:
+                continue  # the C++ inner break already left this row
+            foreign_net = int(net_region[row, col])
+            if foreign_net <= 0 or foreign_net >= widen_lut.size:
+                continue
+            if not widen_lut[foreign_net]:
+                continue  # same domain / no widening for this pair
+            priced_row = int(row)
+            distance = math.sqrt(float(dist_sq[row, col]))
+            # Linear decay: strongest just outside the hard radius, zero at
+            # the band edge, scaled to ``cost_straight``.
+            frac = (halo_r - distance) / band
+            frac = min(1.0, max(0.0, frac))
+            cost += self.rules.cost_straight * frac
+            if cost > 0.0:
+                break
+        return cost
+
+    def _pairwise_band_kernel(self, hard_r: int, band: int) -> tuple[np.ndarray, np.ndarray]:
+        """Cached ``(dist_sq, band_mask)`` window for the gradient scan."""
+        cached = self._pairwise_band_kernel_cache
+        if cached is not None and cached[0] == (hard_r, band):
+            return cached[1], cached[2]
+        halo_r = hard_r + band
+        offsets = np.arange(-halo_r, halo_r + 1)
+        dist_sq = (offsets * offsets)[:, None] + (offsets * offsets)[None, :]
+        band_mask = (dist_sq > hard_r * hard_r) & (dist_sq <= halo_r * halo_r)
+        self._pairwise_band_kernel_cache = ((hard_r, band), dist_sq, band_mask)
+        return dist_sq, band_mask
+
+    def _pairwise_gradient_band(self, net: int) -> np.ndarray | None:
+        """Cells where :meth:`_pairwise_avoidance_cost` can be non-zero.
+
+        Issue #4507: the Python A* hot loop cannot afford a band scan per
+        neighbour, so ``_route_impl`` pre-computes this conservative superset
+        (foreign widening copper dilated by the halo radius) and consults the
+        exact kernel only for cells it flags.  ``None`` when dormant -- the
+        hot loop then adds no cost at all and stays byte-identical to
+        pre-#4507 behaviour.
+        """
+        geometry = self._pairwise_gradient_geometry(net)
+        if geometry is None:
+            return None
+        state, hard_r, band = geometry
+        dom = state.net_to_domain[net]
+        foreign_ids, _widen_lut = self._pairwise_widening_net_ids(state, dom)
+        if not foreign_ids:
+            return None
+        foreign_mask = self.grid._blocked & np.isin(self.grid._net, foreign_ids)
+        if not bool(np.any(foreign_mask)):
+            return None
+        # Out-of-bounds is EMPTY here for the same reason the widening ring
+        # uses it (#4791): the C++ band scan skips out-of-bounds cells.
+        return self._dilate_zero_padded(foreign_mask, hard_r + band)
+
     def _grid_layer_object(self, layer: int) -> Layer | None:
         """Grid layer index -> :class:`Layer` enum member (or ``None``).
 
@@ -3168,6 +3400,18 @@ class Router:
         if pairwise_extra is not None:
             expanded_blocked = expanded_blocked | pairwise_extra
 
+        # Issue #4507: soft cross-domain (HV) avoidance gradient -- the C++
+        # ``pairwise_avoidance_cost`` mirror.  The band gate is a cheap
+        # superset bitmap (one bool lookup per neighbour); the exact kernel
+        # runs only for the handful of cells near HV copper.  ``None`` when
+        # dormant, so a board without a voltage map pays one ``is None``
+        # test per neighbour and keeps byte-identical g-scores.
+        pairwise_band = self._pairwise_gradient_band(start.net)
+        # Per-call memo: the copper the gradient measures against cannot move
+        # during one A* call (the same assumption ``expanded_blocked`` makes),
+        # and a cell is typically relaxed from several parents.
+        pairwise_cost_cache: dict[tuple[int, int, int], float] = {}
+
         # Issue #2430: Build crossing grid index if routed segments exist.
         if self.rules.crossing_penalty > 0.0 and self._routed_segments:
             self._build_crossing_grid()
@@ -3619,6 +3863,22 @@ class Router:
                     self.rules.cost_corridor_attractor,
                 )
 
+                # Issue #4507: soft cross-domain (HV) avoidance gradient
+                # (mirrors ``Pathfinder::pairwise_avoidance_cost``).  Zero
+                # unless a widening pairwise matrix is installed AND foreign
+                # HV copper sits in the thin band just beyond the hard-block
+                # radius -- steers A* to keep isolation margin before the
+                # hard block bites, so an HV board converges instead of
+                # hugging the limit and thrashing the negotiator.
+                pairwise_cost = 0.0
+                if pairwise_band is not None and pairwise_band[nlayer, ny, nx]:
+                    cache_key = (nlayer, ny, nx)
+                    cached_cost = pairwise_cost_cache.get(cache_key)
+                    if cached_cost is None:
+                        cached_cost = self._pairwise_avoidance_cost(nx, ny, nlayer, start.net)
+                        pairwise_cost_cache[cache_key] = cached_cost
+                    pairwise_cost = cached_cost
+
                 positive_step_cost = (
                     neighbor_cost_mult * self.rules.cost_straight * layer_pref_mult
                     + turn_cost
@@ -3628,6 +3888,7 @@ class Router:
                     + crossing_cost
                     + layer_util_cost
                     + corridor_cost
+                    + pairwise_cost
                 )
                 if attractor_bonus > 0.0:
                     positive_step_cost = max(0.0, positive_step_cost - attractor_bonus)

--- a/tests/router/test_pairwise_cpp_parity.py
+++ b/tests/router/test_pairwise_cpp_parity.py
@@ -1386,9 +1386,16 @@ _WIDE_TRACE_WIDTH = 1.0  # vs the 0.2 mm global default
 _WIDE_VIA_SIZE = 1.2  # vs the 0.6 mm global default
 
 
-def _py_router_with_foreign_cell(dy: int, net_class_map):
-    """A Python Router on a 20x20 board with ONE foreign LV cell ``dy`` above.
+def _py_router_with_foreign_cells(
+    cells,
+    net_class_map=None,
+    *,
+    origin: tuple[int, int] = (100, 100),
+    with_table: bool = True,
+):
+    """A Python Router on a 20x20 board with foreign LV cells at ``cells``.
 
+    ``cells`` are ``(dy, dx)`` offsets from ``origin`` (the probe point).
     Cell-exact mirror of the C++ fixtures' ``Grid3D.mark_blocked`` (there is no
     public single-cell setter on ``RoutingGrid``; the search kernels read these
     arrays directly).
@@ -1403,24 +1410,42 @@ def _py_router_with_foreign_cell(dy: int, net_class_map):
         via_clearance=DRU,
         grid_resolution=0.1,
     )
-    rules.pairwise_clearance = _table()
+    if with_table:
+        rules.pairwise_clearance = _table()
     grid = RoutingGrid(width=20.0, height=20.0, rules=rules, layer_stack=LayerStack.two_layer())
-    grid._blocked[0, 100 + dy, 100] = True
-    grid._net[0, 100 + dy, 100] = LV_NET
+    for dy, dx in cells:
+        grid._blocked[0, origin[1] + dy, origin[0] + dx] = True
+        grid._net[0, origin[1] + dy, origin[0] + dx] = LV_NET
     router = Router(grid, rules, diagonal_routing=True, net_class_map=net_class_map)
     router.set_net_name_to_id(dict(NET_NAMES))
     return router
 
 
-def _cpp_pathfinder_with_foreign_cell(dy: int, half_trace_mm: float, half_via_mm: float):
+def _py_router_with_foreign_cell(dy: int, net_class_map=None, *, with_table: bool = True):
+    """Single-cell form of :func:`_py_router_with_foreign_cells` (``dx = 0``)."""
+    return _py_router_with_foreign_cells(((dy, 0),), net_class_map, with_table=with_table)
+
+
+def _cpp_pathfinder_with_foreign_cells(
+    cells,
+    half_trace_mm: float = TRACE_WIDTH / 2.0,
+    half_via_mm: float = 0.3,
+    *,
+    origin: tuple[int, int] = (100, 100),
+):
     grid = _cpp_grid()
     _install_domains(grid)
     from kicad_tools.router import router_cpp
 
     pf = router_cpp.Pathfinder(grid, _cpp_rules(), True)
     pf.set_search_pair_widths(half_trace_mm, half_via_mm)
-    grid.mark_blocked(100, 100 + dy, 0, LV_NET, False, False)
+    for dy, dx in cells:
+        grid.mark_blocked(origin[0] + dx, origin[1] + dy, 0, LV_NET, False, False)
     return pf
+
+
+def _cpp_pathfinder_with_foreign_cell(dy: int, half_trace_mm: float, half_via_mm: float):
+    return _cpp_pathfinder_with_foreign_cells(((dy, 0),), half_trace_mm, half_via_mm)
 
 
 # Trace: global half 0.10 -> r 17 cells; class half 0.50 -> r 21 cells.
@@ -1455,6 +1480,187 @@ def test_trace_annulus_class_width_parity(net_class_map, half_trace_mm, half_via
     # The sweep must actually straddle the boundary (otherwise agreement is
     # vacuous -- e.g. every probe outside both radii).
     assert True in verdicts and False in verdicts
+
+
+# At the 1.6 mm requirement and 0.1 mm resolution the global-width hard radius
+# is 17 cells and the soft band is ceil(1.6 * 0.5 / 0.1) = 8 cells beyond it.
+_GRADIENT_HARD_R = 17
+_GRADIENT_BAND = 8
+
+
+@requires_cpp
+def test_avoidance_gradient_parity_across_the_band() -> None:
+    """Python and C++ price the soft gradient identically, cell for cell.
+
+    Issue #4507: #4511 Scope 2 armed only the C++ search with the soft
+    avoidance gradient; the Python fallback (#4791 shipped its hard blocking
+    only) charged nothing, so the two engines hugged the hard limit
+    differently on the same HV board.  This sweeps the whole band --
+    inside the hard radius, every priced cell, and past the band edge -- and
+    pins agreement on the *value*, not just the sign.
+    """
+    costs = []
+    for dy in range(_GRADIENT_HARD_R - 3, _GRADIENT_HARD_R + _GRADIENT_BAND + 4):
+        py = _py_router_with_foreign_cell(dy)
+        cpp = _cpp_pathfinder_with_foreign_cell(dy, TRACE_WIDTH / 2.0, 0.3)
+        py_cost = py._pairwise_avoidance_cost(100, 100, 0, HV_NET)
+        cpp_cost = cpp.pairwise_avoidance_cost(100, 100, 0, HV_NET)
+        assert py_cost == pytest.approx(cpp_cost, abs=1e-6), f"backends disagree at dy={dy}"
+        costs.append(py_cost)
+    # Not vacuous: the sweep must straddle both edges of the band.
+    assert any(cost > 0.0 for cost in costs)
+    assert costs[0] == 0.0 and costs[-1] == 0.0
+
+
+@requires_cpp
+def test_avoidance_gradient_parity_off_axis() -> None:
+    """Parity holds for diagonal offsets (the sqrt of a non-square distance)."""
+    for dy, dx in ((15, 15), (-20, 3), (0, 22), (-14, -14), (20, -20), (-19, 6)):
+        py = _py_router_with_foreign_cells(((dy, dx),))
+        cpp = _cpp_pathfinder_with_foreign_cells(((dy, dx),))
+        assert py._pairwise_avoidance_cost(100, 100, 0, HV_NET) == pytest.approx(
+            cpp.pairwise_avoidance_cost(100, 100, 0, HV_NET), abs=1e-6
+        ), f"backends disagree at (dy={dy}, dx={dx})"
+
+
+@requires_cpp
+def test_avoidance_gradient_parity_picks_the_same_cell() -> None:
+    """With several band cells, both engines stop on the SAME one.
+
+    The C++ kernel breaks at its first row-major hit rather than taking the
+    nearest ("one cross-domain neighbour is enough"), so the priced value is
+    scan-order dependent -- a Python mirror that took the nearest instead
+    would disagree here while agreeing on every single-cell probe.
+    """
+    for cells in (
+        ((18, 0), (-24, 0)),
+        ((-18, 0), (24, 0)),
+        ((-24, -3), (18, 2), (19, -1)),
+        ((-20, -20), (-19, 0), (21, 21)),
+    ):
+        py = _py_router_with_foreign_cells(cells)
+        cpp = _cpp_pathfinder_with_foreign_cells(cells)
+        assert py._pairwise_avoidance_cost(100, 100, 0, HV_NET) == pytest.approx(
+            cpp.pairwise_avoidance_cost(100, 100, 0, HV_NET), abs=1e-6
+        ), f"backends disagree for {cells}"
+
+
+@requires_cpp
+def test_avoidance_gradient_parity_zero_frac_cell_does_not_stop_the_scan() -> None:
+    """A cell exactly ON the halo circle prices 0 and the scan CONTINUES.
+
+    Issue #4849 (review of the #4507 mirror): the C++ kernel's break is
+    two-level and the outer one is conditional -- ``if (cost > 0.0f) break;``
+    -- so a qualifying cell at exactly ``halo_r`` (``frac == 0``) leaves the
+    accumulated cost at zero and lets the scan run on into later rows, where
+    it can price a different cell.  A Python mirror that returned
+    unconditionally at the first qualifying cell returned 0.0 where C++
+    returned a full-magnitude cost.
+
+    This is not an exotic corner: the first cell the scan ever visits
+    (``dy = -halo_r, dx = 0``) sits exactly on the circle, so ANY foreign
+    copper whose topmost band cell lands in the candidate's own column trips
+    it -- and A* evaluates a candidate at every grid position, so an HV blob
+    produces a whole row of cells the two engines would price differently.
+    """
+    halo_r = _GRADIENT_HARD_R + _GRADIENT_BAND  # 25
+    for cells, expected in (
+        (((-halo_r, 0), (18, 0)), 0.875),
+        (((-halo_r, 0), (-18, 0)), 0.875),
+        (((-halo_r, 0), (0, 20)), 0.625),
+        (((-20, -15), (18, 0)), 0.875),  # the (20, 15, 25) Pythagorean triple
+    ):
+        py = _py_router_with_foreign_cells(cells)
+        cpp = _cpp_pathfinder_with_foreign_cells(cells)
+        py_cost = py._pairwise_avoidance_cost(100, 100, 0, HV_NET)
+        cpp_cost = cpp.pairwise_avoidance_cost(100, 100, 0, HV_NET)
+        assert py_cost == pytest.approx(cpp_cost, abs=1e-6), f"backends disagree for {cells}"
+        # Non-vacuous: the zero-frac cell must NOT have swallowed the price
+        # (the pre-#4849 Python mirror returned exactly 0.0 for every case
+        # here, so an equality-only assertion could pass on a mutual zero).
+        assert py_cost == pytest.approx(expected, abs=1e-6), f"wrong magnitude for {cells}"
+
+
+@requires_cpp
+def test_avoidance_gradient_parity_contiguous_bar_touching_the_halo() -> None:
+    """One contiguous foreign bar whose nearest row sits exactly at the halo.
+
+    The zero-frac divergence above needs no artificial two-blob fixture: a
+    single solid bar of foreign copper is enough, because its topmost band
+    row contributes only the on-circle cell in the candidate's own column.
+    Sliding the same bar one row nearer must price identically -- the
+    on-circle row was worth nothing in either engine.
+    """
+    halo_r = _GRADIENT_HARD_R + _GRADIENT_BAND  # 25
+    costs = []
+    for top in (-halo_r, -halo_r + 1):
+        cells = tuple((dy, dx) for dy in range(top, top + 5) for dx in range(-4, 5))
+        py = _py_router_with_foreign_cells(cells)
+        cpp = _cpp_pathfinder_with_foreign_cells(cells)
+        py_cost = py._pairwise_avoidance_cost(100, 100, 0, HV_NET)
+        cpp_cost = cpp.pairwise_avoidance_cost(100, 100, 0, HV_NET)
+        assert py_cost == pytest.approx(cpp_cost, abs=1e-6), f"backends disagree for bar at {top}"
+        costs.append(py_cost)
+    # Both bars price the row at dy = -24, dx = -4: sqrt(576 + 16) = 24.331,
+    # frac = (25 - 24.331) / 8.
+    assert costs[0] == pytest.approx(costs[1], abs=1e-6)
+    assert costs[0] == pytest.approx(0.0836189, abs=1e-6)
+
+
+@requires_cpp
+def test_avoidance_gradient_parity_at_the_board_edge() -> None:
+    """A clipped scan window keeps parity (out-of-bounds is EMPTY, not blocked).
+
+    The Python window is clipped to the array bounds while the C++ scan skips
+    out-of-bounds cells; both must therefore price from the same in-bounds
+    cell.  Probed hard against x = 0 where the clip removes leading columns
+    of every row -- the case that would break a naive flat-index mirror.
+    """
+    values = []
+    for gx in (0, 1, 5, 20):
+        origin = (gx, 100)
+        py = _py_router_with_foreign_cells(((0, 20),), origin=origin)
+        cpp = _cpp_pathfinder_with_foreign_cells(((0, 20),), origin=origin)
+        py_cost = py._pairwise_avoidance_cost(gx, 100, 0, HV_NET)
+        cpp_cost = cpp.pairwise_avoidance_cost(gx, 100, 0, HV_NET)
+        assert py_cost == pytest.approx(cpp_cost, abs=1e-6), f"backends disagree at gx={gx}"
+        values.append(py_cost)
+    # The same 20-cell separation is priced identically however much of the
+    # window the board edge clipped away.
+    assert values[0] > 0.0
+    assert all(value == pytest.approx(values[0]) for value in values)
+
+
+@requires_cpp
+def test_avoidance_gradient_parity_wide_class_width() -> None:
+    """The band is measured from the routed net's class width in BOTH engines."""
+    wide = {"/AC_LINE": NetClassRouting(name="HV", trace_width=_WIDE_TRACE_WIDTH, clearance=DRU)}
+    costs = []
+    for dy in range(_GRADIENT_HARD_R, _GRADIENT_HARD_R + _GRADIENT_BAND + 9):
+        py = _py_router_with_foreign_cell(dy, wide)
+        cpp = _cpp_pathfinder_with_foreign_cell(dy, _WIDE_TRACE_WIDTH / 2.0, 0.3)
+        py_cost = py._pairwise_avoidance_cost(100, 100, 0, HV_NET)
+        cpp_cost = cpp.pairwise_avoidance_cost(100, 100, 0, HV_NET)
+        assert py_cost == pytest.approx(cpp_cost, abs=1e-6), f"backends disagree at dy={dy}"
+        costs.append(py_cost)
+    # The wide class moves the hard radius out to 21: cell 18 is now INSIDE
+    # it (free) where the global width priced it.
+    assert costs[1] == 0.0
+    assert any(cost > 0.0 for cost in costs)
+
+
+@requires_cpp
+def test_avoidance_gradient_dormant_parity() -> None:
+    """No matrix installed -> both engines price nothing."""
+    py = _py_router_with_foreign_cell(20, with_table=False)
+    grid = _cpp_grid()  # domains never installed
+    from kicad_tools.router import router_cpp
+
+    cpp = router_cpp.Pathfinder(grid, _cpp_rules(), True)
+    cpp.set_search_pair_widths(TRACE_WIDTH / 2.0, 0.3)
+    grid.mark_blocked(100, 120, 0, LV_NET, False, False)
+    assert py._pairwise_avoidance_cost(100, 100, 0, HV_NET) == 0.0
+    assert cpp.pairwise_avoidance_cost(100, 100, 0, HV_NET) == pytest.approx(0.0)
 
 
 @requires_cpp

--- a/tests/router/test_pairwise_python_search.py
+++ b/tests/router/test_pairwise_python_search.py
@@ -30,6 +30,7 @@ from __future__ import annotations
 import math
 
 import numpy as np
+import pytest
 
 from kicad_tools.router.grid import RoutingGrid
 from kicad_tools.router.layers import Layer, LayerStack
@@ -383,6 +384,228 @@ def test_unmapped_net_id_falls_back_to_global_width() -> None:
     assert router._cross_domain_trace_blocked(gx, gy, 0, HV_TAP_NET, 3) is False
     near = _grid_pos(grid, 15.0, 7.9)  # 15 cells: inside the global 17
     assert router._cross_domain_trace_blocked(*near, 0, HV_TAP_NET, 3) is True
+
+
+# ---------------------------------------------------------------------------
+# Soft cross-domain avoidance gradient (``_pairwise_avoidance_cost``)
+# ---------------------------------------------------------------------------
+#
+# The hard kernels above restore the search<->gate mirror; the soft gradient
+# is what keeps the search from HUGGING that hard limit.  The C++ search has
+# priced the margin since #4511 (``Pathfinder::pairwise_avoidance_cost``);
+# these pin the Python mirror's geometry.  At the 1.6 mm requirement and
+# 0.1 mm resolution: hard radius 17 cells, band ceil(1.6 * 0.5 / 0.1) = 8,
+# so the gradient is priced over cells 18..25 and decays linearly to zero.
+
+_GRADIENT_HARD_R = 17
+_GRADIENT_BAND = 8
+
+
+def _router_with_foreign_cell(
+    dy: int,
+    *,
+    foreign_net: int = LV_NET,
+    with_table: bool = True,
+    net_class_map: dict[str, NetClassRouting] | None = None,
+    layer: int = 0,
+) -> Router:
+    """A 20x20 board carrying ONE foreign cell ``dy`` cells below (100, 100).
+
+    Cell-exact fixture (there is no public single-cell setter on
+    ``RoutingGrid``; the search kernels read these arrays directly) -- the
+    same idiom the C++ parity suite's ``mark_blocked`` fixtures use, so the
+    two can be compared probe-for-probe.
+    """
+    rules = _rules(with_table)
+    grid = RoutingGrid(width=20.0, height=20.0, rules=rules, layer_stack=LayerStack.two_layer())
+    grid._blocked[layer, 100 + dy, 100] = True
+    grid._net[layer, 100 + dy, 100] = foreign_net
+    router = Router(grid, rules, diagonal_routing=True, net_class_map=net_class_map)
+    router.set_net_name_to_id(dict(NET_NAMES))
+    return router
+
+
+def test_gradient_dormant_without_table() -> None:
+    """No voltage map -> no soft cost anywhere (byte-identical g-scores)."""
+    router = _router_with_foreign_cell(20, with_table=False)
+    assert router._pairwise_avoidance_cost(100, 100, 0, HV_NET) == 0.0
+    assert router._pairwise_gradient_band(HV_NET) is None
+
+
+def test_gradient_dormant_for_a_net_in_no_widening_pair() -> None:
+    """A net whose every pair sits at the scalar floor is never priced."""
+    router = _router_with_foreign_cell(20, foreign_net=HV_TAP_NET)
+    assert router._pairwise_avoidance_cost(100, 100, 0, HV_NET) == 0.0
+    assert router._pairwise_gradient_band(HV_NET) is None
+
+
+def test_gradient_decays_linearly_across_the_band() -> None:
+    """Strongest just outside the hard block, zero at the band edge."""
+    costs = {
+        dy: _router_with_foreign_cell(dy)._pairwise_avoidance_cost(100, 100, 0, HV_NET)
+        for dy in range(_GRADIENT_HARD_R, _GRADIENT_HARD_R + _GRADIENT_BAND + 3)
+    }
+    # Inside the hard radius: the BLOCKING kernel's job, not the gradient's.
+    assert costs[_GRADIENT_HARD_R] == 0.0
+    # First band cell carries (band - 1) / band of the full step cost.
+    assert costs[18] == pytest.approx(7.0 / 8.0)
+    # Strictly decreasing across the band, zero at (and beyond) its edge.
+    band = [costs[dy] for dy in range(18, 25)]
+    assert band == sorted(band, reverse=True)
+    assert all(cost > 0.0 for cost in band)
+    assert costs[25] == 0.0
+    assert costs[26] == 0.0
+    assert costs[27] == 0.0
+
+
+def test_gradient_is_bounded_by_one_straight_step() -> None:
+    """The nudge can never dominate the route cost (mirror invariant)."""
+    for dy in range(_GRADIENT_HARD_R, _GRADIENT_HARD_R + _GRADIENT_BAND + 1):
+        cost = _router_with_foreign_cell(dy)._pairwise_avoidance_cost(100, 100, 0, HV_NET)
+        assert 0.0 <= cost <= _rules().cost_straight
+
+
+def test_gradient_ignores_same_domain_and_net0_copper() -> None:
+    """Only copper whose pair actually widens is priced."""
+    same = _router_with_foreign_cell(20, foreign_net=HV_TAP_NET)
+    assert same._pairwise_avoidance_cost(100, 100, 0, HV_NET) == 0.0
+    pour = _router_with_foreign_cell(20, foreign_net=0)
+    assert pour._pairwise_avoidance_cost(100, 100, 0, HV_NET) == 0.0
+
+
+def test_gradient_scans_its_own_layer_only() -> None:
+    """Surface creepage: B.Cu copper never prices an F.Cu candidate."""
+    router = _router_with_foreign_cell(20, layer=1)
+    assert router._pairwise_avoidance_cost(100, 100, 0, HV_NET) == 0.0
+    assert router._pairwise_avoidance_cost(100, 100, 1, HV_NET) > 0.0
+
+
+def test_gradient_uses_net_class_trace_width() -> None:
+    """The band tracks the ROUTED net's class width (#4793 parity).
+
+    Class half-extent 0.5 mm -> hard radius 21, band edge 29.  A cell 26
+    cells out is priced for the wide class and free for the global width;
+    18 cells out is the reverse (inside the wide class's hard radius).
+    """
+    assert _router_with_foreign_cell(26)._pairwise_avoidance_cost(100, 100, 0, HV_NET) == 0.0
+    wide = _router_with_foreign_cell(26, net_class_map=_wide_class())
+    assert wide._pairwise_avoidance_cost(100, 100, 0, HV_NET) == pytest.approx(3.0 / 8.0)
+
+    assert _router_with_foreign_cell(18)._pairwise_avoidance_cost(100, 100, 0, HV_NET) > 0.0
+    wide_near = _router_with_foreign_cell(18, net_class_map=_wide_class())
+    assert wide_near._pairwise_avoidance_cost(100, 100, 0, HV_NET) == 0.0
+
+
+def test_gradient_band_gate_flags_every_priced_cell() -> None:
+    """The hot-loop band bitmap is a strict superset of the priced cells.
+
+    ``_route_impl`` consults the exact kernel only where this bitmap is set,
+    so a cell the bitmap misses would silently lose its gradient.
+    """
+    router = _router_with_foreign_cell(0)  # foreign cell AT (100, 100)
+    band = router._pairwise_gradient_band(HV_NET)
+    assert band is not None
+    for dy in range(-30, 31):
+        cost = router._pairwise_avoidance_cost(100, 100 + dy, 0, HV_NET)
+        if cost > 0.0:
+            assert bool(band[0, 100 + dy, 100]) is True, f"band gate misses dy={dy}"
+
+
+def test_gradient_prices_the_first_cell_in_scan_order() -> None:
+    """Mirror wart, pinned: the C++ kernel BREAKS at its first band cell.
+
+    Row-major scan order runs from the topmost row of the window, so the
+    cell 24 cells ABOVE wins over the (much nearer) cell 18 cells below --
+    "one cross-domain neighbour is enough to establish the gradient".  The
+    Python mirror reproduces the same cell so the two engines cannot price a
+    candidate differently; see ``test_avoidance_gradient_parity_*`` in
+    ``test_pairwise_cpp_parity.py`` for the cross-engine proof.
+    """
+    rules = _rules()
+    grid = RoutingGrid(width=20.0, height=20.0, rules=rules, layer_stack=LayerStack.two_layer())
+    for dy in (-24, 18):
+        grid._blocked[0, 100 + dy, 100] = True
+        grid._net[0, 100 + dy, 100] = LV_NET
+    router = Router(grid, rules, diagonal_routing=True)
+    router.set_net_name_to_id(dict(NET_NAMES))
+    assert router._pairwise_avoidance_cost(100, 100, 0, HV_NET) == pytest.approx(1.0 / 8.0)
+
+
+# ---------------------------------------------------------------------------
+# Headline: the priced margin reaches the routed copper
+# ---------------------------------------------------------------------------
+
+# A horizontal LV bar (x in [5, 25], y in [9.7, 10.3]) with the HV pads placed
+# so that the straight run between them sits EXACTLY at the hard limit: the
+# gradient is the only thing that can buy margin, and the detour it has to pay
+# for is real (up and back over a 24 mm span).
+_BAR_TOP_Y = 9.7
+_BAR_BOTTOM_Y = 10.3
+_HV_PAD_Y = 12.0  # 12.0 - 10.3 - 0.1 = 1.6 mm == the requirement
+
+
+def _route_over_lv_bar(gradient: bool):
+    rules = _rules(with_table=True)
+    grid = RoutingGrid(width=30.0, height=20.0, rules=rules, layer_stack=LayerStack.two_layer())
+    start = Pad(
+        x=3.0, y=_HV_PAD_Y, width=0.6, height=0.6, net=HV_NET, net_name="HV", layer=Layer.F_CU
+    )
+    end = Pad(
+        x=27.0, y=_HV_PAD_Y, width=0.6, height=0.6, net=HV_NET, net_name="HV", layer=Layer.F_CU
+    )
+    grid.add_pad(start)
+    grid.add_pad(end)
+    for layer in (Layer.F_CU, Layer.B_CU):
+        grid.add_pad(
+            Pad(x=15.0, y=10.0, width=20.0, height=0.6, net=LV_NET, net_name="LV", layer=layer)
+        )
+    nc = NetClassRouting(name="HV", trace_width=TRACE_WIDTH, clearance=DRU)
+    router = Router(grid, rules, diagonal_routing=True, net_class_map={"HV": nc})
+    router.set_net_name_to_id({"HV": HV_NET, "LV": LV_NET})
+    if not gradient:
+        # Same board, same hard blocking -- only the soft pricing differs.
+        router._pairwise_avoidance_cost = lambda *args, **kwargs: 0.0  # type: ignore[method-assign]
+    return router, router.route(start, end, net_class=nc)
+
+
+def _mid_span_gap(route) -> float:
+    """Smallest bar-edge gap of the copper crossing the middle of the bar."""
+    best = float("inf")
+    for seg in route.segments:
+        for i in range(201):
+            t = i / 200.0
+            px = seg.x1 + t * (seg.x2 - seg.x1)
+            py = seg.y1 + t * (seg.y2 - seg.y1)
+            if abs(px - 15.0) <= 0.5:
+                best = min(best, py - _BAR_BOTTOM_Y - TRACE_WIDTH / 2.0)
+    return best
+
+
+def test_gradient_buys_margin_over_the_hard_limit() -> None:
+    """The soft cost reaches the routed copper: more margin, still gate-clean.
+
+    Both arms enforce the same 1.6 mm hard block (both are pairwise-armed),
+    so the difference is purely the priced margin -- the search declines to
+    run flush against the limit when a bounded detour buys slack.
+    """
+    blind_router, blind_route = _route_over_lv_bar(gradient=False)
+    armed_router, armed_route = _route_over_lv_bar(gradient=True)
+    assert blind_route is not None and armed_route is not None
+
+    id_to_name = {HV_NET: "HV", LV_NET: "LV"}
+    for router, route in ((blind_router, blind_route), (armed_router, armed_route)):
+        assert (
+            route_pairwise_violation(
+                route,
+                HV_NET,
+                router.grid.routes,
+                router.rules.pairwise_clearance,
+                id_to_name=id_to_name,
+            )
+            is None
+        )
+    assert _mid_span_gap(armed_route) > _mid_span_gap(blind_route)
+    assert _mid_span_gap(blind_route) >= IEC_150V_PD2_IIIA_MM - 1e-3
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Fourth *partial increment* of #4507 (epic #4431 Phase 2b) — the **soft-gradient
mirror** the 2026-08-11 sweep handoff nominated as the next slice.

Phase 2b (#4511) gave the **C++** search two things: hard cross-domain blocking
(`cross_domain_trace_blocked` / `cross_domain_via_blocked`) *and* a bounded soft
avoidance gradient (`Pathfinder::pairwise_avoidance_cost`, "Scope 2") that
prices a thin band just beyond the hard block. PR #4791 mirrored **only the hard
half** into the pure-Python fallback A\* and said so explicitly ("Not in this
slice (deliberate): the C++ `pairwise_avoidance_cost` soft gradient has no
Python mirror"). This PR closes that half.

Why it matters beyond bookkeeping: with hard blocking alone the fallback runs
**flush against the pairwise limit** — copper that merely *meets* a creepage
requirement is one rip-up, one negotiated re-route or one `--lattice-optimize`
nudge away from violating it, which is exactly the thrash this phase exists to
remove. And because only one engine priced the margin, the C++ search and its
own fallback converged on measurably different HV routes for the same board.

## Changes

- **`Router._pairwise_avoidance_cost(gx, gy, layer, net)`** (`pathfinder.py`) —
  cell-for-cell mirror of the C++ kernel: same band geometry
  (`hard_r = ceil((half_mm + max_widen)/res)`, `band = ceil(max_widen*0.5/res)`),
  same linear decay scaled to `cost_straight`, same "only foreign copper whose
  domain pair actually widens" filter, same per-net-class half-extent (#4793),
  and the same **scan-order break** (`np.nonzero` yields C order, so the first
  widening entry is the cell the C++ loop stops on). Deliberately no #4506
  attach-zone waiver — mirroring the reference kernel, which has none, because a
  soft nudge never blocks an attach path.
- **Hot-loop wiring** (`_route_impl`) — `_pairwise_gradient_band()` pre-dilates
  the widening foreign copper by the halo radius into a conservative superset
  bitmap; the loop pays one bool lookup per neighbour and calls the exact kernel
  only inside that band (memoised per A\* call, since copper cannot move during
  one search — the same assumption `expanded_blocked` already makes). The scan
  window's `dist_sq`/band mask is pure geometry and is cached per `(hard_r, band)`.
- **Dormancy** — no `--voltage-map` ⇒ `_pairwise_gradient_band` returns `None`
  and the hot loop adds one `is None` test per neighbour, keeping g-scores
  byte-identical. A net in no widening pair is likewise free.
- **Tests** — 15 new Python-side unit tests (`test_pairwise_python_search.py`)
  and 6 new Python↔C++ parity tests (`test_pairwise_cpp_parity.py`), plus the
  fixture helpers generalised to multi-cell / arbitrary-origin probes.
- One CHANGELOG entry under `[Unreleased]` / `### Added`.

**No C++ edits** — the C++ kernel is the reference and is untouched, so
`ROUTER_CPP_BUILD_VERSION` stays at 19 and no rebuild is required to consume
this PR.

## Acceptance Criteria Verification

| Criterion (from #4507 / its children) | Status | Verification |
|---|---|---|
| Ask item 2 — search-time avoidance around HV copper, both engines | Done | The fallback now prices the margin the C++ search has priced since #4511; `test_gradient_buys_margin_over_the_hard_limit` routes the *same* board twice (both arms hard-blocked identically, only the soft pricing differs) and the armed arm keeps strictly more mid-span margin, gate-clean both ways |
| Python↔C++ parity is the deliverable (values, not signs) | Done | `test_avoidance_gradient_parity_across_the_band` (whole band incl. both edges), `_off_axis` (6 diagonal offsets), `_picks_the_same_cell` (4 multi-cell layouts — the case a "nearest instead of first" mirror would fail while still passing every single-cell probe), `_at_the_board_edge` (clipped scan windows), `_wide_class_width` (per-net-class extents), `_dormant_parity` |
| Backward compat — no `--voltage-map` ⇒ unchanged behaviour | Done | Dormancy unit tests + `test_astar_tiebreak_determinism.py`, `test_board_route_determinism.py`, `test_preserve_existing.py` unchanged and green |
| Attach-zone (#4506) handling stays correct | Done | The gradient carries no waiver **by design** (mirror of the C++ kernel); the blocking kernels' layer-scoped waiver is untouched and its tests still pass |
| Softstart rev-C manual proof (item 2b residual) | Not attempted | Local-only fixture with no CI presence — an epic-owner call, unchanged since PR #4780/#4785/#4791's notes. This is why the reference below is `Part of`, not a close |

## Test Plan

Run in the issue worktree with the C++ backend built (`uv run kct build-native
--check` ⇒ available, build version 19), so the parity suite executes rather
than skips:

- `uv run pytest tests/router/test_pairwise_cpp_parity.py tests/router/test_pairwise_python_search.py` — **97 passed** (63 + 34)
- `uv run pytest tests/router/test_pairwise_clearance.py tests/router/test_astar_tiebreak_determinism.py tests/router/test_board_route_determinism.py tests/router/test_preserve_existing.py tests/router/test_cpp_backend_layer_mapping.py tests/router/test_relief_rescue.py` — **157 passed, 2 skipped**
- `uv run pytest tests/test_route_pairwise_gate_4588.py tests/router/test_post_pass_pairwise_gate_4766.py tests/router/lattice/test_pairwise_avoidance.py tests/router/lattice/test_softstart_routing.py tests/test_placement_hv_domains.py` — **102 passed, 1 skipped**
- `uv run pytest tests/router` (full directory, `-x`, no coverage) — exit 0, green
- `uv run ruff check .` — All checks passed; `uv run ruff format --check .` — 1791 files already formatted
- `uv run python scripts/ci/check_mypy_baseline.py` (cold, `--no-incremental`, `.mypy_cache` removed first) — **OK, 1470 errors within the 1472 baseline, no new type errors**

**Cost disclosure.** The gradient is HV-board-only and fallback-only, but it is
not free there: on the new `test_gradient_buys_margin_over_the_hard_limit`
fixture the pure-Python route goes **0.32 s → 0.54 s** (measured in-worktree,
no coverage) — ~1.7x for that net. Boards without `--voltage-map` are
unaffected. The band-gate bitmap, the per-call memo and the cached scan window
are all there to keep that constant down.

**Known wart, mirrored deliberately and filed separately.** The reference C++
kernel breaks at the *first* qualifying cell in row-major scan order rather
than the *nearest*, so the priced value is scan-order dependent (biased toward
copper "above" the candidate). Mirroring it is the right call for a parity
slice — two engines agreeing on a bounded nudge beats two engines disagreeing
about which candidate is cheap — but it is a real defect in the gradient's
intent; follow-up filed as #4848.

Part of #4507
