### PR TITLE
docs(router): record the measured shadow-constructor flip verdict (stays OFF)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -589,6 +589,37 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **The diff-pair shadow constructor stays default-OFF — measured, not
+  assumed** (#4800, part of #4409) — all five correctness gates the
+  `DifferentialPairConfig.enable_shadow_construction` flip was waiting on
+  closed on 2026-08-04 (#4579/#4581/#4582/#4604 merged, #4580 a documented
+  negative result), so the flip evaluation was finally run. **Verdict:
+  the default stays `False`**, and the code comments that carried the stale
+  2026-08-02 numbers now carry the fresh ones. Method: two repeats per arm
+  on board 06 (`PYTHONHASHSEED=42 … --seed 42`, C++ backend built, main @
+  `fa18a25b` — i.e. *after* #4791 and #4840), board quality read with the CI
+  gate itself (`scripts/ci/check_diffpair_coverage.py --skip-route`) and
+  cross-checked with `kicad-cli pcb drc --refill-zones`; both arms were
+  byte-identical across their repeats modulo `(uuid …)`, so these are
+  single-mode figures rather than a Mode-A-vs-Mode-B accident (#4536).
+  Shadow-ON buys `coupled-ok` 0/9 → 5/9 (stable **by name**: MIPI_CLK,
+  PCIE_RX, USB2_D, USB3_TX1, USB3_TX2) and pays for it with signal reach
+  21/21 → **18/21**, DRC 18 → **35**, diff-pair violations 18 → 31, a
+  **copper-union pour-connectivity failure** (+3V3 in 3 disjoint groups,
+  GND in 5 — a blocker not on the previous list), `kicad-cli` clearance
+  errors 11 → 169–176 with 0 → **9 unconnected items**, and **2.16x**
+  wall-clock. The `diffpair-routing-regression` gate exits 0 shadow-OFF and
+  **2 shadow-ON, on four separate assertions**. Both previously-named
+  blockers are re-verified rather than refuted: the corridor-yield planner
+  still reports `USB_CC1 stays unroutable with every coupled corridor
+  lifted`, and its MIPI_D0 recovery now *reverts* (`reach 18 -> 18 of 21`),
+  so shadow-ON has **regressed** from the 19/21 recorded under #4463; on
+  wall-clock the CI margin has shrunk, with ten consecutive green `main`
+  runs putting the job at 17.9–25.2 min (median 24.5, re-route step 23m30s)
+  against its 30-minute ceiling. The decline-count baseline is re-confirmed
+  at **46** (the board-06 README's `47` was pre-#4604). Comments/docs only —
+  no behaviour, defaults or artifacts change.
+
 - **The pure-Python router's pairwise (HV-isolation) widening bitmap is now
   cached across `route()` calls** (#4794) —
   `Router._pairwise_expanded_blocked` (the search-time bitmap the pure-Python

--- a/boards/06-diffpair-test/README.md
+++ b/boards/06-diffpair-test/README.md
@@ -226,6 +226,11 @@ across the 9 pairs). The #4582 Judge independently reproduced the same
 323 figure across four separate runs spanning both downstream modes
 below. The nondeterminism is entirely downstream of this phase.
 
+The **decline count is now 46**, not 47 --- [#4604] retired one decline.
+Re-confirmed 2026-08-14 under [#4800] at 46 declines / 33 `[coupled-tail]`
+lines on two independent runs, so use 46 as the baseline any new
+measurement is compared against.
+
 Reproduce the shadow phase and its debug trace:
 
 ```bash
@@ -250,6 +255,13 @@ continuum:
 |---|---|---|---|
 | Mode A | 32 | 7 | 19 of 21 |
 | Mode B | 35 | 19 | 18 of 21 |
+
+Both [#4800] repeats (2026-08-14, main @ `fa18a25b`) landed in **Mode B**
+and were byte-identical to each other modulo `(uuid …)` --- 424 uuid lines
+changed, zero geometry lines --- so on the current tree a shadow-ON pair of
+runs is not guaranteed to sample both modes.  Sample enough repeats to
+*identify* your mode before comparing; do not assume a single run of each
+side straddles them.
 
 `coupled-ok` is 5/9 in both modes --- the shadow-ON convergence figure
 recorded in the recipe comments ("Convergence is 5/9 (post-#4576)").  A
@@ -302,6 +314,38 @@ change that knocks a pair from coupled to declined removes it from
 skew-checking entirely --- the error count can drop while the change is
 a regression, not a win.  Always read `coupled-ok` and reach alongside
 the raw error count, never the error count alone.
+
+### Why the default is shadow-OFF (measured, [#4800], 2026-08-14)
+
+The obvious question --- "5/9 coupled beats 0/9, why is this off?" --- has
+a measured answer.  Two repeats per arm on main @ `fa18a25b`
+(`PYTHONHASHSEED=42 … --seed 42`, C++ backend built), board quality read
+with the CI gate itself (`scripts/ci/check_diffpair_coverage.py
+--skip-route`) and cross-checked with `kicad-cli pcb drc --refill-zones`:
+
+| | shadow OFF (default) | shadow ON |
+|---|---|---|
+| `coupled-ok` | 0/9 | 5/9 |
+| `[coupled-follow] declined` | n/a | 46 |
+| signal reach | **21/21** | **18/21** |
+| `kct check` DRC errors | **18** (allowlist 18) | **35** |
+| diff-pair violations | 18 (baseline 18) | 31 |
+| pour connectivity | PASS | **FAIL** (+3V3 3 groups, GND 5 groups) |
+| `kicad-cli` errors | 444 (11 clearance) | 639–646 (169–176 clearance) |
+| `kicad-cli` unconnected | 0 | **9** |
+| `--step route` wall-clock | 745.2 s / 739.9 s | 1649.8 s / 1570.6 s |
+| CI gate exit code | **0** | **2** (4 assertions) |
+
+The 5 pairs that couple are stable by name --- MIPI_CLK, PCIE_RX, USB2_D,
+USB3_TX1, USB3_TX2.  The three stranded nets are MIPI_D0+, MIPI_D0- and
+USB_CC1; the [#4463] corridor-yield recovery yields MIPI_CLK, re-runs,
+measures `reach 18 -> 18 of 21` and **reverts**, so shadow-ON no longer
+reaches the 19/21 recorded on 2026-08-02.  USB_CC1 is still not a
+corridor-competition failure --- the planner says so itself:
+`[corridor-yield] USB_CC1 stays unroutable with every coupled corridor
+lifted`.  Wall-clock is 2.16x, against a CI job already running a median
+24.5 min of its 30-minute ceiling (ten consecutive green main runs,
+2026-08-14; the re-route step alone is 23m30s).
 
 ### The crossover legality census (`KCT_CROSSTAIL_CENSUS=1`)
 
@@ -363,6 +407,7 @@ lattice the picture reverses — a synthetic fixture whose first legal candidate
 is at rank 0 pays ~3.9 ms of a ~4.0 ms census, ~39x the un-instrumented
 0.10 ms.)
 
+[#4463]: https://github.com/rjwalters/kicad-tools/issues/4463
 [#4536]: https://github.com/rjwalters/kicad-tools/issues/4536
 [#4570]: https://github.com/rjwalters/kicad-tools/issues/4570
 [#4574]: https://github.com/rjwalters/kicad-tools/issues/4574
@@ -372,8 +417,10 @@ is at rank 0 pays ~3.9 ms of a ~4.0 ms census, ~39x the un-instrumented
 [#4580]: https://github.com/rjwalters/kicad-tools/issues/4580
 [#4581]: https://github.com/rjwalters/kicad-tools/issues/4581
 [#4582]: https://github.com/rjwalters/kicad-tools/issues/4582
+[#4604]: https://github.com/rjwalters/kicad-tools/issues/4604
 [#4611]: https://github.com/rjwalters/kicad-tools/pull/4611
 [#4635]: https://github.com/rjwalters/kicad-tools/issues/4635
+[#4800]: https://github.com/rjwalters/kicad-tools/issues/4800
 
 ## CI Gate (Phase 4N, #2660)
 

--- a/boards/06-diffpair-test/generate_design.py
+++ b/boards/06-diffpair-test/generate_design.py
@@ -2656,19 +2656,57 @@ def route_pcb(input_path: Path, output_path: Path) -> bool:
     # (shadow-OFF measures 361.5 s / 21/21 / 587.9 s total on the same
     # machine; shadow-ON totals 1351.2 s post-fix, so the total job -- not
     # the negotiated phase -- is now the wall-clock problem).
+    #
+    # Issue #4800 (2026-08-14 FLIP EVALUATION, main @ fa18a25b, i.e. after
+    # #4791 + #4840): all five correctness gates the flip was waiting on are
+    # closed, so this was the decision run.  DECISION: the env default STAYS
+    # "0".  Two repeats per arm, seed 42 / PYTHONHASHSEED=42, C++ backend
+    # built; both arms byte-identical across their repeats modulo ``(uuid …)``
+    # (so these are single-mode figures).  Board quality read with the CI gate
+    # itself, ``scripts/ci/check_diffpair_coverage.py --skip-route``:
+    #
+    #                            shadow OFF (this default)  shadow ON
+    #     coupled-ok              0/9                        5/9
+    #     [coupled-follow] decl.  n/a                        46
+    #     signal reach            21/21                      18/21
+    #     kct check DRC errors    18 (allowlist 18)          35
+    #     diff-pair violations    18 (baseline 18)           31
+    #     pour connectivity       PASS                       FAIL
+    #     kicad-cli errors        444 (11 clearance)         639-646 (169-176)
+    #     kicad-cli unconnected   0                          9
+    #     wall-clock (--step route) 745.2 / 739.9 s          1649.8 / 1570.6 s
+    #     CI gate exit code       0                          2
+    #
     # Shadow-ON is still not shippable here:
-    #   * Convergence is 5/9 (post-#4576).  The 0.225-0.275 mm coupled widths
-    #     make the geometric parallel offset infeasible for the rest
-    #     (self-check overlap; mid-route blockage; #4574 guide-missing).
-    #   * USB_CC1 still strands -- its corridor is contested even with the
-    #     coupled bodies gone.
-    #   * The surviving shadow segments are off-angle (#3975
-    #     OffAngleSegmentWarning; the post-route quantization pass repairs
-    #     them, #3907 is the by-construction fix) and skew/continuity
-    #     residuals (#4570/#4575/#4577) are still open.
-    # Enabling by default needs those to close.  When they do, flip the env
-    # default and the optimizer/nudge diff-pair protections below together.
-    # See #4409 (epic) and #4463 for the current data.
+    #   * Convergence is 5/9 -- unchanged since 2026-08-02, and stable BY
+    #     NAME across repeats: MIPI_CLK, PCIE_RX, USB2_D, USB3_TX1, USB3_TX2
+    #     couple; MIPI_D0 is guide-missing and PCIE_TX / USB3_RX1 / USB3_RX2
+    #     are shadow-declined-blockage.  The 0.225-0.275 mm coupled widths
+    #     make the geometric parallel offset infeasible for the rest.
+    #   * USB_CC1 still strands -- and the #4463 corridor-yield recovery no
+    #     longer buys back MIPI_D0: it yields MIPI_CLK, re-runs, measures
+    #     ``reach 18 -> 18 of 21`` and REVERTS.  Shadow-ON therefore lands at
+    #     18/21 (MIPI_D0+, MIPI_D0-, USB_CC1), a regression against the 19/21
+    #     recorded under #4463 and 3 short of ``REQUIRED_SIGNAL_REACH``.  The
+    #     planner's own verdict, on both repeats: "[corridor-yield] USB_CC1
+    #     stays unroutable with every coupled corridor lifted -- not a
+    #     corridor-competition failure".
+    #   * NEW blocker: the stranded nets break the copper-union pour audit
+    #     (``REQUIRE_POUR_CONNECTIVITY``, #3509) -- +3V3 splits into 3 disjoint
+    #     pad groups (largest 9/11), GND into 5 (largest 118/122).
+    #   * Wall-clock: 2.16x shadow-OFF locally.  Ten consecutive green main
+    #     runs (2026-08-14) put the ``diffpair-routing-regression`` job at
+    #     17.9-25.2 min (median 24.5) against its 30-min ``timeout-minutes``,
+    #     with the re-route step alone at 23m30s -- ~5.5 min of margin.  2.16x
+    #     on that step is ~51 min, ~21 min past the ceiling.
+    #   * The skew/continuity residuals (#4570/#4575/#4577) and the
+    #     by-construction dogleg (#3907/#3975/#3988) that this list used to
+    #     carry ARE closed; they are no longer what blocks the flip.
+    # Enabling by default needs USB_CC1 routable with the coupled corridors in
+    # place (not merely yielded) and the total job back inside the CI ceiling.
+    # When they do, flip the env default and the optimizer/nudge diff-pair
+    # protections below together, and re-run the A/B above first.
+    # See #4409 (epic), #4463 and #4800 for the current data.
     import os as _os
 
     ENABLE_COUPLED_SHADOW = _os.environ.get("KCT_BOARD06_SHADOW", "0") == "1"

--- a/src/kicad_tools/router/diffpair.py
+++ b/src/kicad_tools/router/diffpair.py
@@ -686,43 +686,88 @@ class DifferentialPairConfig:
     #      board 06: zero ``OffAngleSegmentWarning`` across all 9 pairs
     #      (#4461, closed already-satisfied).
     #
-    # WALL-CLOCK (re-measured 2026-08-02 under #4463; the old "~150 s
-    # shadow-OFF vs >1200 s shadow-ON" figures in this comment were stale
-    # and framed against the wrong budget).  The real envelope is the
-    # ``diffpair-routing-regression`` CI job's 30-minute ``timeout-minutes``
-    # ceiling, against which a GREEN shadow-OFF run historically lands at
-    # 14m22s-20m42s TOTAL job wall-clock -- roughly half of that budget is
-    # the post-route pipeline (pour fill/stitch/repair/re-fill, copper-union
-    # audit, DRC, mfg export), not diff-pair routing.  On this machine,
-    # ``generate_design.py --step route --seed 42`` measures (one machine,
-    # one build; ``KCT_CORRIDOR_YIELD=0`` reproduces the "before" row):
+    # FLIP EVALUATION (#4800, re-measured 2026-08-14 on main @ fa18a25b --
+    # i.e. AFTER the #4791 pairwise-HV fallback and its #4840 per-net-class
+    # width fix).  All five correctness gates the flip was waiting on are
+    # closed (#4579/#4581/#4582/#4604 merged; #4580 a documented negative
+    # result), so this run is the decision measurement, not another gate.
+    # VERDICT: the default STAYS FALSE.  Shadow-ON buys +5 coupled pairs and
+    # loses the board.
     #
-    #     shadow OFF          : 587.9 s total, negotiated 361.5 s, 21/21
-    #     shadow ON, pre-#4463: 770.4 s total, negotiated 362.3 s, 18/21
-    #     shadow ON, post     : 1351.2 s total, negotiated 148.1 s +
-    #                           50.6 s planning + 300.5 s capped re-run,
-    #                           19/21
+    # Method: two repeats per arm, ``PYTHONHASHSEED=42 ... --seed 42``,
+    # C++ backend built; board quality read with the CI gate itself
+    # (``scripts/ci/check_diffpair_coverage.py --skip-route``) and
+    # cross-checked with ``kicad-cli pcb drc --refill-zones``.  Both arms
+    # were byte-identical across their two repeats modulo ``(uuid ...)``
+    # (424 uuid lines, zero geometry lines), so these are single-mode
+    # figures, not a mode-A-vs-mode-B accident.
     #
-    # So the negotiated phase itself is now WELL inside the 2x-of-shadow-OFF
-    # target (148.1 s vs 361.5 s; 448.6 s counting the recovery re-run), but
-    # the TOTAL shadow-ON job grew: the two pairs that yield stop being
-    # diff-pair nets, so they re-enter the optimizer / nudge / repair passes
-    # the shadow path excludes them from.  22.5 min of local wall-clock has
-    # no headroom against the job's 30-minute ceiling on a slower CI runner
-    # -- which is itself a reason the default stays OFF.  CI never runs this
-    # path today (the board-06 recipe gates it behind ``KCT_BOARD06_SHADOW``
-    # and CI does not set it).
+    #                            shadow OFF (default)   shadow ON
+    #     coupled-ok              0/9                    5/9
+    #     [coupled-follow] decl.  n/a                    46
+    #     signal reach            21/21                  18/21
+    #     kct check DRC errors    18 (allowlist 18)      35
+    #     diff-pair violations    18 (baseline 18)       31
+    #     pour-connectivity       PASS                   FAIL (+3V3 3 groups,
+    #                                                    GND 5 groups)
+    #     kicad-cli errors        444 (11 clearance)     639-646 (169-176)
+    #     kicad-cli unconnected   0                      9
+    #     total wall-clock        745.2 s / 739.9 s      1649.8 s / 1570.6 s
+    #     negotiated phase        491.6 s / 485.3 s      789.6 s + 59.2 s
+    #                                                    planning + 187.4 s
+    #                                                    re-run
     #
-    # Enabling this by default is therefore still blocked on: the
-    # remaining corridor contention (USB_CC1 is not recoverable by
-    # yielding, measured 2026-08-02 under #4463) and the total shadow-ON
-    # wall-clock above.  The other blockers this list once carried are
-    # resolved: the skew/continuity residuals #4570/#4574/#4575/#4577 all
-    # CLOSED by 2026-08-04, and the shadow-aware by-construction dogleg
-    # exists since #3988 (item B above; #3907/#3975 likewise closed).
+    # The 5 pairs that DO couple are stable by name across repeats --
+    # MIPI_CLK, PCIE_RX, USB2_D, USB3_TX1, USB3_TX2 -- and the four that
+    # do not are MIPI_D0 (guide-missing) plus PCIE_TX / USB3_RX1 /
+    # USB3_RX2 (shadow-declined-blockage).  Count the pairs BY NAME: the
+    # 5/9 headline has not moved since 2026-08-02, so the two blockers
+    # below are not a stale reading of an improved constructor.
+    #
+    # Blocker 1 -- USB_CC1 corridor contention (RE-VERIFIED, unchanged).
+    # The corridor-yield planner says so in its own words on both repeats:
+    # ``[corridor-yield] USB_CC1 stays unroutable with every coupled
+    # corridor lifted -- not a corridor-competition failure``.  Worse, the
+    # recovery that used to buy back MIPI_D0 no longer does: it yields
+    # MIPI_CLK, re-runs, measures ``reach 18 -> 18 of 21`` and reverts, so
+    # shadow-ON now lands at 18/21 (MIPI_D0+, MIPI_D0-, USB_CC1 stranded)
+    # rather than the 19/21 recorded under #4463 -- a REGRESSION against
+    # the 2026-08-02 figure, and 3 nets short of the board's
+    # ``REQUIRED_SIGNAL_REACH``.
+    #
+    # Blocker 2 -- wall-clock (RE-VERIFIED, and the CI margin has SHRUNK).
+    # Shadow-ON costs 2.16x shadow-OFF locally (1610 s vs 743 s, mean of
+    # two repeats).  The envelope is still the ``diffpair-routing-regression``
+    # CI job's 30-minute ``timeout-minutes`` ceiling (``.github/workflows/
+    # ci.yml``), but the "14m22s-20m42s" figure this comment used to quote
+    # is stale: ten consecutive GREEN runs on main (2026-08-14) measure the
+    # job at 17.9-25.2 min, median 24.5 min, of which the single
+    # ``Re-route board + check diff-pair coverage`` step is 23m30s.  That is
+    # ~5.5 min of margin at shadow-OFF.  Scaling the measured 2.16x onto
+    # that step puts shadow-ON near 51 min -- roughly 21 min PAST the
+    # ceiling.  Raising ``timeout-minutes`` is not the fix; the job would
+    # still be shipping a board that fails its own gate.
+    #
+    # Blocker 3 -- pour connectivity (NEW; not on the 2026-08-02 list).
+    # The stranded nets break the copper-union audit
+    # (``REQUIRE_POUR_CONNECTIVITY``, #3509): +3V3 splits into 3 disjoint
+    # pad groups (largest 9/11) and GND into 5 (largest 118/122).  The CI
+    # gate fails on this independently of DRC count and reach.
+    #
+    # Net effect on the CI gate: shadow-OFF exits 0; shadow-ON exits 2 on
+    # FOUR separate assertions (reach, pour connectivity, diff-pair
+    # violation baseline, total DRC allowlist).  The trade is not close,
+    # and it is not a tuning question -- +5 coupled pairs cost 3 signal
+    # nets, 17 extra DRC errors, 158+ extra kicad-cli clearance errors,
+    # 9 unconnected items and 2.16x the wall-clock.
+    #
     # Set ``KCT_BOARD06_SHADOW=1`` on the board-06 recipe to reproduce the
     # shadow-ON run.  Default False keeps recipes on their pre-#3508
     # budget-exit behaviour (0/9 coupled, 21/21 single-ended reach).
+    # A future flip needs USB_CC1 routable with the coupled corridors in
+    # place (not merely yielded) AND the total job back inside the CI
+    # ceiling -- re-run the A/B above before proposing one.  See #4409
+    # (epic) and #4800 for the full tables.
     enable_shadow_construction: bool = False
 
     def get_rules(self, pair_type: DifferentialPairType) -> DifferentialPairRules:

--- a/src/kicad_tools/router/diffpair_routing.py
+++ b/src/kicad_tools/router/diffpair_routing.py
@@ -3815,6 +3815,14 @@ class DiffPairRouter:
         # measurements that keep this defaulted OFF).  Set from the
         # config by ``route_all_with_diffpairs``; tests may set it
         # directly.
+        #
+        # Issue #4800 (2026-08-14) re-ran the flip evaluation now that all
+        # five correctness gates are closed and kept the default OFF: on
+        # board 06 shadow-ON trades 0/9 -> 5/9 coupled pairs for 21/21 ->
+        # 18/21 signal reach, 18 -> 35 DRC errors, a copper-union
+        # pour-connectivity failure and 2.16x wall-clock (the CI gate exits
+        # 0 shadow-OFF and 2 shadow-ON).  The dated A/B table lives with the
+        # config field; do not flip this without re-running it.
         self.enable_shadow_construction: bool = False
 
     def _collect_existing_drills(self) -> list[tuple[float, float, float]]:

--- a/tests/test_diffpair_shadow.py
+++ b/tests/test_diffpair_shadow.py
@@ -796,12 +796,16 @@ def test_shadow_construction_flag_defaults_off():
     and parallel-offset feasibility -> #4460 (closed 2026-07-31 via
     #4512/#4526), lifting board-06 construction to 6/9.
 
-    The flag still stays OFF for the two reasons measured 2026-08-02
-    under #4463: corridor competition strands single-ended nets (3 nets
-    strand, 18/21 reach on seed 42; USB_CC1 is not recoverable even by
-    corridor yielding), and total shadow-ON wall-clock (~22.5 min local)
-    has no headroom against the diff-pair regression CI job's 30-minute
-    ceiling.  The comment block above
+    The flag nonetheless stays OFF.  #4800 re-ran the full A/B on
+    2026-08-14 (main @ fa18a25b, two repeats per arm, seed 42) now that
+    all five correctness gates are closed, and the trade got *worse*, not
+    better: shadow-ON buys 5/9 coupled pairs but drops signal reach to
+    18/21 (MIPI_D0+, MIPI_D0-, USB_CC1 -- the #4463 corridor-yield
+    recovery now reverts instead of recovering MIPI_D0), raises DRC from
+    18 to 35, fails the copper-union pour audit, and costs 2.16x the
+    wall-clock against a CI job that already runs 24.5 min of a 30-min
+    ceiling.  The ``diffpair-routing-regression`` gate exits 0 shadow-OFF
+    and 2 shadow-ON on four separate assertions.  The comment block above
     ``DifferentialPairConfig.enable_shadow_construction`` in
     ``kicad_tools/router/diffpair.py`` is the canonical, dated history.
     """


### PR DESCRIPTION
## Summary

The shadow-constructor flip evaluation, finally run. All five correctness gates
it was waiting on closed on 2026-08-04 (#4579/#4581/#4582/#4604 merged, #4580 a
documented negative result), so this PR is the decision measurement.

**Verdict: `enable_shadow_construction` stays `False`, and `KCT_BOARD06_SHADOW`
stays `"0"`.** Shadow-ON buys +5 coupled pairs and loses the board — it fails
its own CI gate on four separate assertions and costs 2.16x the wall-clock
against a job already running a median 24.5 min of a 30-minute ceiling.

This is outcome (b) from the issue's acceptance criteria: a documented negative
result (the #4580 pattern). Comments, docs and one test docstring only — **no
behaviour, defaults or artifacts change.**

## Method

Two repeats per arm on `main @ fa18a25b` (i.e. **after** #4791 and its #4840
per-net-class width fix), in a fresh worktree with `uv run kct build-native`
run first (`C++ backend: available (version 1.0.0)`, build version 19):

```bash
# arm A (default)
PYTHONHASHSEED=42 KCT_SHADOW_DEBUG=1 uv run python \
  boards/06-diffpair-test/generate_design.py --step route --seed 42
# arm B
KCT_BOARD06_SHADOW=1 PYTHONHASHSEED=42 KCT_SHADOW_DEBUG=1 uv run python \
  boards/06-diffpair-test/generate_design.py --step route --seed 42
# board quality, both arms, via the CI gate itself:
uv run python scripts/ci/check_diffpair_coverage.py boards/06-diffpair-test \
  --skip-route --seed 42
# independent cross-check (project convention):
kicad-cli pcb drc --refill-zones --format json -o <out>.json <artifact>.kicad_pcb
```

Runs were **serial** (never concurrent) so the wall-clock column is comparable.

## Determinism / provenance of each number

Per the issue's determinism AC, here is which surface each figure came from:

| Figure | Source | Determinism |
|---|---|---|
| `coupled-ok` by name, per-pair class | `[coupled-pair-report]` lines, shadow phase | deterministic; identical across repeats |
| decline count (46), `[coupled-tail]` (33), `[coupled-channel]` (10) | `KCT_SHADOW_DEBUG=1` counters | deterministic; identical across repeats |
| DRC error count, per-rule split, reach, pour connectivity | full-regen artifact via `check_diffpair_coverage.py --skip-route` | **paired mode-for-mode** — see below |
| `kicad-cli` errors / clearance / unconnected | full-regen artifact via `kicad-cli pcb drc --refill-zones` | same artifacts as the row above |
| wall-clock | `/usr/bin/time -p` on `--step route` | timing, 2 samples per arm |
| CI job wall-clock | 10 consecutive **green** `main` runs, GitHub API | observational |

**Mode pairing.** Both shadow-ON repeats landed in the documented **Mode B**
(35 DRC / 19 `diffpair_clearance_intra` / 18-of-21 reach) — all three mode
signals mutually consistent, so this is not a Mode-A-vs-Mode-B mix-up. Stronger
than that: within each arm the two artifacts are **byte-identical modulo
`(uuid …)`** — 424 uuid lines differ, **zero** geometry lines
(`diff | grep -c uuid` = 424 of 424 changed pairs, both arms). So the compared
rows are single-mode, not a lucky draw. Shadow-OFF landed on the documented
committed/CI floor (18 DRC = 9 skew + 9 continuity, 21/21) both times.

## Results

| | shadow OFF (default) | shadow ON (`KCT_BOARD06_SHADOW=1`) |
|---|---|---|
| `coupled-ok` | **0/9** | **5/9** |
| `[coupled-follow] declined` | n/a (no shadow phase) | **46** |
| `[coupled-tail]` lines | n/a | 33 |
| signal reach | **21/21** | **18/21** (MIPI_D0+, MIPI_D0-, USB_CC1) |
| `kct check` DRC errors | **18** (allowlist 18) | **35** (allowlist 18) |
| diff-pair violations | 18 (baseline 18) | **31** (baseline 18) |
| — `diffpair_clearance_intra` | 0 | 19 |
| — `diffpair_length_skew` | 9 | 6 |
| — `diffpair_routing_continuity` | 9 | 6 |
| pour connectivity (copper-union) | **PASS** | **FAIL** — +3V3 in 3 disjoint groups (largest 9/11), GND in 5 (largest 118/122) |
| `kicad-cli` errors | 444 / 444 | 639 / 646 |
| — of which `clearance` | 11 / 11 | 169 / 176 |
| `kicad-cli` unconnected items | **0 / 0** | **9 / 9** |
| `--step route` wall-clock | 745.2 s / 739.9 s | 1649.8 s / 1570.6 s |
| negotiated phase | 491.6 s / 485.3 s | 789.6 s + 59.2 s planning + 187.4 s re-run |
| **CI gate exit code** | **0** | **2** |

**Coupled-ok by name** (identical on both ON repeats — the AC's "by name, not
count" requirement; a count match can hide one pair gained and another lost):

| pair | shadow OFF | shadow ON |
|---|---|---|
| MIPI_CLK | joint-A\*-plateau | **coupled-ok** |
| MIPI_D0 | joint-A\*-plateau | guide-missing |
| PCIE_RX | joint-A\*-plateau | **coupled-ok** |
| PCIE_TX | joint-A\*-plateau | shadow-declined-blockage |
| USB2_D | joint-A\*-plateau | **coupled-ok** |
| USB3_RX1 | joint-A\*-plateau | shadow-declined-blockage |
| USB3_RX2 | joint-A\*-plateau | shadow-declined-blockage |
| USB3_TX1 | joint-A\*-plateau | **coupled-ok** |
| USB3_TX2 | joint-A\*-plateau | **coupled-ok** |

**The vacuity trap is live in this data and does not rescue shadow-ON.**
`diffpair_length_skew` *drops* 9 → 6 and `diffpair_routing_continuity` 9 → 6
under shadow-ON, which reads as an improvement until you notice
`diffpair_clearance_intra` goes 0 → 19 and reach drops. Read `coupled-ok` and
reach alongside the counts, as the board README instructs.

## Re-verifying the two named blockers

**Blocker 1 — USB_CC1 corridor contention: RE-VERIFIED, and worse.** The
corridor-yield planner states it itself, on both repeats:

```
[corridor-yield] 3 net(s) left unconnected by the main strategy: USB_CC1, MIPI_D0+, MIPI_D0-
  [corridor-yield] USB_CC1 stays unroutable with every coupled corridor lifted -- not a corridor-competition failure
  [corridor-yield] MIPI_D0+ is sealed in by MIPI_CLK
[corridor-yield] planning took 59.2s; 1 pair(s) to yield
[corridor-yield] 1 pair(s) yielded their corridor: MIPI_CLK; re-running the main strategy for the freed nets
[corridor-yield] reach 18 -> 18 of 21 net(s); yield reverted
```

Note the last line: the #4463 recovery that used to buy back MIPI_D0 **now
reverts**. Shadow-ON lands at **18/21**, not the 19/21 recorded on 2026-08-02 —
a regression against the previous measurement, and 3 nets short of the board's
`REQUIRED_SIGNAL_REACH`. It still pays 59 s of planning and a 187 s re-run for
that null result.

**Blocker 2 — wall-clock: RE-VERIFIED, and the CI margin has SHRUNK.**
Shadow-ON costs **2.16x** shadow-OFF locally (1610.2 s vs 742.6 s, means of two
repeats). The comment's quoted "14m22s–20m42s" green-run band is now stale —
ten consecutive green `ci.yml` runs on `main` (2026-08-14) measure the
`diffpair-routing-regression` job at:

```
24.65, 24.82, 17.92, 24.70, 24.38, 25.20, 24.40, 24.05, 24.60, 22.20  (min)
min 17.9 | median 24.5 | max 25.2   vs   timeout-minutes: 30
```

Step-level, the single `Re-route board + check diff-pair coverage` step is
**23m30s** of that (setup is only ~65 s). That is **~5.5 min of margin at
shadow-OFF**. Applying the measured 2.16x to that step puts shadow-ON near
**51 min — roughly 21 min past the ceiling.** Raising `timeout-minutes` is
explicitly *not* the fix the issue asks for, and would in any case only buy time
to ship a board that fails the gate; `ci.yml` is untouched by this PR.

**Blocker 3 — pour connectivity (NEW, not on the 2026-08-02 list).** The
stranded nets break the copper-union audit (`REQUIRE_POUR_CONNECTIVITY`,
#3509): +3V3 splits into 3 disjoint pad groups, GND into 5. This fails the CI
gate independently of DRC count and reach, and matches the `kicad-cli`
cross-check finding 9 unconnected items where shadow-OFF has 0.

**Net effect on the gate:** shadow-OFF exits **0**; shadow-ON exits **2** on
four separate assertions (reach, pour connectivity, diff-pair violation
baseline, total DRC allowlist). The trade is not close and it is not a tuning
question.

## Changes

- `src/kicad_tools/router/diffpair.py` — replaced the stale 2026-08-02
  WALL-CLOCK/blocker block above `enable_shadow_construction` with the dated
  #4800 A/B table, the by-name coupled set, all three blockers (including the
  new pour-connectivity one), the corrected CI-margin figures, and an explicit
  statement of what a future flip must clear first. Default unchanged (`False`).
- `boards/06-diffpair-test/generate_design.py` — same treatment for the
  `KCT_BOARD06_SHADOW` comment block; corrects its "takes the shadow-ON run to
  19/21" claim, which no longer holds. Env default unchanged (`"0"`).
- `src/kicad_tools/router/diffpair_routing.py` — comment-only pointer at the
  runtime `self.enable_shadow_construction` mirror so a reader there sees the
  verdict without chasing the config field.
- `boards/06-diffpair-test/README.md` — re-baselines the decline count from a
  stale **47** to the measured **46** (retired by #4604, re-confirmed here);
  notes that on the current tree both ON repeats land in Mode B and are
  uuid-identical, so a two-run sample does not necessarily straddle the modes;
  adds a "Why the default is shadow-OFF (measured)" section carrying the table.
- `tests/test_diffpair_shadow.py` — `test_shadow_construction_flag_defaults_off`
  docstring refreshed to the current rationale (it cited the superseded
  2026-08-02 reasons). Assertions unchanged.
- `CHANGELOG.md` — `[Unreleased] / ### Changed` entry.

## Acceptance Criteria Verification

- [x] **A/B run using the deterministic shadow-phase surface, not a single
      full-regen diff** — shadow-phase counters (`[coupled-pair-report]`,
      `[coupled-follow] declined`, `[coupled-tail]`) compared directly and
      identical across repeats; full-regen results compared mode-for-mode.
- [x] **Coupled-pair count verified by name, per pair** — table above; the
      5-pair set is byte-stable across both ON repeats.
- [x] **DRC error count and category breakdown** — both `kct check` (the CI
      gate's own surface, with the per-rule split) and
      `kicad-cli pcb drc --refill-zones` (project convention), for all four
      artifacts.
- [x] **Decline count from the shadow-phase counters** — **46**, matching the
      post-#4604 baseline exactly; the README's stale 47 is re-baselined here.
- [x] **Total job wall-clock + negotiated sub-total, against the 30-minute
      ceiling** — measured both arms, and the ceiling re-derived from ten real
      green CI runs rather than the stale in-comment band.
- [x] **Explicitly re-verify or refute the two 2026-08-02 blockers** — both
      re-verified with fresh evidence (USB_CC1 quoted verbatim from the
      planner; wall-clock margin re-derived and found *smaller*), plus a third
      blocker discovered.
- [x] **Produce the measurement and its written conclusion** — outcome (b), the
      documented negative result; the in-code measurement logs in both files
      now carry the current numbers.
- [x] **Determinism handling stated explicitly** — provenance table above; mode
      identified on both ON runs before any comparison; uuid-normalized
      artifact equality reported.
- [x] **Decline-count metric re-baselined in the docs that cite it** — README
      47 → 46.

## Test Plan

- `uv run kct build-native --check` → `C++ backend: available (version 1.0.0)`
  (measurements are meaningless on the Python fallback).
- `uv run pytest tests/test_diffpair_shadow.py tests/test_board_06_diffpair_test.py`
  → **228 passed**.
- `uv run pytest tests/test_diffpair*.py tests/test_validate_diffpair*.py
  tests/test_cli_check_diffpair*.py tests/test_check_diffpair_coverage.py
  tests/test_escape_diffpair.py` → **809 passed**.
- `uv run pytest tests/router/test_escape_diffpair_composition.py
  tests/test_diffpair_corridor.py tests/test_diffpair_census_budget.py
  tests/test_diffpair_corridor_guard.py` → **48 passed**.
- `uv run pytest tests/test_changelog_gap_report.py
  tests/test_docs_source_citations.py` → **17 passed**.
- `ruff check` / `ruff format --check` clean on all changed Python files.
- `rm -rf .mypy_cache && uv run python scripts/ci/check_mypy_baseline.py` →
  `1470 error(s), all within the baseline (1472 allowed)`. No baseline edits;
  the "2 no longer occur" warning is the known env-dependent nanobind pair.
- Regenerated board artifacts from the measurement runs were reverted
  (`git checkout -- boards/06-diffpair-test/output/`); the diff is comments,
  docs, one test docstring and the changelog only.

Closes #4800
Part of #4409

🤖 Generated with [Claude Code](https://claude.com/claude-code)
