### PR TITLE
feat(router): capture the crossing-tail census as a structured, report-only aggregate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Structured crossing-tail census report** (part of #4799) — the #4580
+  diff-pair crossover legality census now also captures what it prints as
+  data. Each censused crossover produces a `CrossingTailCensusRecord`
+  (`net_name`, `head`, `goal`, `legal`, `total`, `distinct_v1`, `census_s`)
+  on the router (`DiffPairRouter._census_records`) and in a process-wide
+  collector; `KCT_CROSSTAIL_CENSUS_REPORT=<path>` writes a
+  `--format json`-shaped document (`schema_version`, `generated_at`, summary +
+  per-crossover detail) at interpreter exit, and the diff-pair phase closes
+  with a `[crosstail-census-summary]` block whenever `KCT_CROSSTAIL_CENSUS=1`
+  is set. The summary aggregates `saturated_pct` (crossovers with nothing
+  legal), `no_ordering_lever_pct` (legal sets confined to a single `v1` site,
+  taken over the *unsaturated* set) and `inert_pct` (their union — the share
+  where no ordering key could have changed the outcome), plus an advisory
+  `verdict` against a documented 90% threshold. **Report-only**: the capture
+  runs after the #4635 budget credit is stamped, changes no routing decision
+  and no exit code, and costs ~1.1 µs per crossover. A board that never
+  synthesizes a shadow-constructed crossover (boards 05 and 07 today) reports
+  `crossovers_scanned: 0` / `verdict: "not-applicable"` rather than a
+  fabricated 0% saturation. New reference doc:
+  `docs/reference/crosstail-census-report.md`.
+
 - **`--format json` on the 5 board-improvement drivers** (part of #4674,
   sixth batch of the #4543 machine-output sweep) — `optimize-placement`,
   `optimize-traces`, `route-auto`, `reason` and `creepage-export-rules` now

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,8 +27,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   and no exit code, and costs ~1.1 µs per crossover. A board that never
   synthesizes a shadow-constructed crossover (boards 05 and 07 today) reports
   `crossovers_scanned: 0` / `verdict: "not-applicable"` rather than a
-  fabricated 0% saturation. New reference doc:
-  `docs/reference/crosstail-census-report.md`.
+  fabricated 0% saturation — and, since board scripts shell out and children
+  inherit the environment, an empty flush never overwrites a report that has
+  records. New reference doc: `docs/reference/crosstail-census-report.md`.
 
 - **`--format json` on the 5 board-improvement drivers** (part of #4674,
   sixth batch of the #4543 machine-output sweep) — `optimize-placement`,

--- a/boards/06-diffpair-test/README.md
+++ b/boards/06-diffpair-test/README.md
@@ -323,6 +323,16 @@ singleton in `v1` carries the same barrel on every legal route, so no ordering
 key can move the result and the constraint lives upstream in placement / escape
 planning.
 
+Add `KCT_CROSSTAIL_CENSUS_REPORT=<path>`
+([#4799](https://github.com/rjwalters/kicad-tools/issues/4799)) to get the same measurement
+as **data** instead of scraped stdout: a JSON document with one record per
+crossover plus the aggregate the per-crossover headers cannot give you
+(`saturated_pct`, `no_ordering_lever_pct`, `inert_pct`, an advisory `verdict`).
+The diff-pair phase also closes with a `[crosstail-census-summary]` block
+whenever the census is on.  It is report-only and costs ~1 µs per crossover on
+top of the census itself; schema and interpretation live in
+[`docs/reference/crosstail-census-report.md`](../../docs/reference/crosstail-census-report.md).
+
 **State-neutral is not the same as budget-neutral ([#4635]).** PR [#4611]'s
 prose claimed the census "cannot" change the route because it is
 "observation-only by construction".  That is true of router **state** — every

--- a/docs/README.md
+++ b/docs/README.md
@@ -34,6 +34,7 @@ Detailed reference documentation:
 |-----------|-------------|
 | [CLI Commands](reference/cli.md) | Complete command-line reference |
 | [Machine Output](reference/machine-output.md) | The canonical `--format json` idiom: inventory, exemptions, rules |
+| [Crossing-Tail Census Report](reference/crosstail-census-report.md) | Report-only diff-pair crossover legality aggregate (`KCT_CROSSTAIL_CENSUS_REPORT`) |
 | [Python API](reference/api.md) | Module-by-module API documentation |
 | [Manufacturer Rules](reference/manufacturers.md) | JLCPCB, OSHPark, PCBWay design rules |
 | [Circuit Blocks](reference/circuit-blocks.md) | Reusable schematic building blocks |

--- a/docs/reference/crosstail-census-report.md
+++ b/docs/reference/crosstail-census-report.md
@@ -46,17 +46,28 @@ KCT_BOARD06_SHADOW=1 PYTHONHASHSEED=42 \
 * `KCT_CROSSTAIL_CENSUS_REPORT=<path>` — writes the JSON document to `<path>`
   at interpreter exit (parent directories are created). Unset ⇒ no file.
 
+Board scripts shell out (`kicad-cli`, helper `python` runs) and every child
+process inherits the environment, so each child reaches the same exit hook with
+nothing measured. **An empty flush never overwrites a report that has
+records** — the child stands down and says so on stderr, leaving the parent's
+measurement intact. A run that measured something always writes.
+
 The human-readable summary is printed at the end of the diff-pair phase
-whenever the census is on, with or without the report path:
+whenever the census is on, with or without the report path. Verbatim from
+board-06 at seed 42 (2026-08-14, shadow-ON):
 
 ```
 [crosstail-census-summary] 166 crossover(s) scanned, verdict=saturated
 [crosstail-census-summary]   saturated (legal=0): 150/166 (90.4%)
-[crosstail-census-summary]   no ordering lever (legal>0, distinct_v1<=1): 12/16 (75.0%)
-[crosstail-census-summary]   inert (no ordering key could change the outcome): 97.6%
-[crosstail-census-summary]   distinct_v1 max=4 credited census_s total=1.2800
-[crosstail-census-summary]   advisory: inert >= 90.0% -- ordering levers are inert; …
+[crosstail-census-summary]   no ordering lever (legal>0, distinct_v1<=1): 7/16 (43.8% of unsaturated)
+[crosstail-census-summary]   inert (no ordering key could change the outcome): 94.6%
+[crosstail-census-summary]   distinct_v1 max=6 credited census_s total=1.2800
+[crosstail-census-summary]   advisory: inert >= 90.0% -- ordering levers are inert; the constraint is upstream in placement / escape planning (non-blocking)
 ```
+
+Both headline figures match what `boards/06-diffpair-test/README.md` already
+documented from the free-text census (150/166 saturated, 1.28 s credited) —
+reproduced through the report path rather than re-derived by inspection.
 
 ### Why an environment variable, not `kct route --census-report`
 

--- a/docs/reference/crosstail-census-report.md
+++ b/docs/reference/crosstail-census-report.md
@@ -1,0 +1,211 @@
+# Crossing-tail census report (`KCT_CROSSTAIL_CENSUS_REPORT`)
+
+A **report-only**, machine-readable aggregate of the diff-pair crossing-tail
+legality census. It answers one question about a board — *how much of the
+crossover via-site lattice is legal at all?* — as data rather than as scraped
+stdout.
+
+Issue [#4799]. The measurement itself is older ([#4580], budget-corrected in
+[#4635]); this document covers the structured capture layered on top of it.
+
+## What is being measured
+
+`DiffPairRouter._synthesize_crossing_tail` builds each layer-crossing tail of a
+shadow-constructed differential pair by enumerating a **225-entry lattice** of
+`(v1, v2)` via-site candidates and shipping the **first legal one** in sorted
+order. That first-legal loop says nothing about the rest of the lattice, so two
+very different worlds look identical from the outside:
+
+* an **ordering** problem — many sites are legal, and a better sort key could
+  pick a kinder one; versus
+* a **saturation** problem — almost nothing is legal, and no key can help.
+
+With `KCT_CROSSTAIL_CENSUS=1` the loop scans the whole lattice instead of
+stopping at the first legal candidate, and prints one header per crossover:
+
+```
+[crosstail-census] net=MIPI_CLK- head=(…) goal=(…) legal=2/225 distinct_v1=1 census_s=0.0164
+```
+
+The route that ships is unchanged (still the first legal candidate); the census
+credits its own incremental wall clock back to the shadow phase's budget so a
+census-on run and a census-off run get the same effective downstream deadlines
+([#4635]).
+
+## Enabling the report
+
+```bash
+KCT_CROSSTAIL_CENSUS=1 \
+KCT_CROSSTAIL_CENSUS_REPORT=/tmp/census.json \
+KCT_BOARD06_SHADOW=1 PYTHONHASHSEED=42 \
+  uv run python boards/06-diffpair-test/generate_design.py --step route --seed 42
+```
+
+* `KCT_CROSSTAIL_CENSUS=1` — turns the underlying census on. Without it nothing
+  is measured and the report is an honest *not applicable*.
+* `KCT_CROSSTAIL_CENSUS_REPORT=<path>` — writes the JSON document to `<path>`
+  at interpreter exit (parent directories are created). Unset ⇒ no file.
+
+The human-readable summary is printed at the end of the diff-pair phase
+whenever the census is on, with or without the report path:
+
+```
+[crosstail-census-summary] 166 crossover(s) scanned, verdict=saturated
+[crosstail-census-summary]   saturated (legal=0): 150/166 (90.4%)
+[crosstail-census-summary]   no ordering lever (legal>0, distinct_v1<=1): 12/16 (75.0%)
+[crosstail-census-summary]   inert (no ordering key could change the outcome): 97.6%
+[crosstail-census-summary]   distinct_v1 max=4 credited census_s total=1.2800
+[crosstail-census-summary]   advisory: inert >= 90.0% -- ordering levers are inert; …
+```
+
+### Why an environment variable, not `kct route --census-report`
+
+The census only fires under `DiffPairRouter` with shadow construction enabled,
+and the only caller that does that today is `boards/06-diffpair-test`'s
+`generate_design.py --step route` — a board script driving the router API
+directly, not `kct route`. A CLI flag would be unreachable from the one run
+that produces data, while an env var composes with the two flags that already
+gate this measurement. The document itself follows the `--format json`
+conventions in [machine-output.md](machine-output.md) (single document, sorted
+keys, `schema_version` / `generated_at`), so a future CLI surface can emit it
+unchanged.
+
+## Document schema (v1)
+
+```json
+{
+  "schema_version": 1,
+  "generated_at": "2026-08-14T22:37:32.773075+00:00",
+  "report": "crosstail-census",
+  "census_enabled": true,
+  "summary": {
+    "applicable": true,
+    "crossovers_scanned": 166,
+    "saturated": 150,
+    "saturated_pct": 90.4,
+    "unsaturated": 16,
+    "no_ordering_lever": 12,
+    "no_ordering_lever_pct": 75.0,
+    "inert_pct": 97.6,
+    "distinct_v1_max": 4,
+    "census_s_total": 1.28,
+    "verdict": "saturated",
+    "saturated_threshold_pct": 90.0
+  },
+  "crossovers": [
+    {
+      "net_name": "MIPI_CLK-",
+      "head": [12.7, 44.45],
+      "goal": [15.24, 46.99],
+      "legal": 2,
+      "total": 225,
+      "distinct_v1": 1,
+      "census_s": 0.0164,
+      "saturated": false,
+      "no_ordering_lever": true
+    }
+  ]
+}
+```
+
+### Per-crossover record
+
+| Field | Meaning |
+|-------|---------|
+| `net_name` | Net of the crossover's head pad |
+| `head` / `goal` | `[x, y]` mm of the tail's endpoints |
+| `legal` / `total` | Size of the legal set / lattice size (225) |
+| `distinct_v1` | Distinct first-barrel sites among the legal candidates |
+| `census_s` | Incremental seconds this crossover's scan cost — the [#4635] credit |
+| `saturated` | `legal == 0` |
+| `no_ordering_lever` | `legal > 0 and distinct_v1 <= 1` |
+
+`legal`, `total`, `distinct_v1` and `census_s` are the same values the
+`[crosstail-census]` header prints, computed once and rendered twice.
+
+### Summary
+
+| Field | Meaning |
+|-------|---------|
+| `applicable` | `crossovers_scanned > 0` — see "Not applicable" below |
+| `crossovers_scanned` | Records collected in this process |
+| `saturated` / `saturated_pct` | Crossovers with nothing legal, as a share of all scanned |
+| `unsaturated` | `crossovers_scanned - saturated` |
+| `no_ordering_lever` / `_pct` | Legal-but-single-site crossovers; the percentage's **denominator is `unsaturated`** ("of the crossovers that had a choice, how many had no real choice") |
+| `inert_pct` | `(saturated + no_ordering_lever) / crossovers_scanned` — the share where **no ordering key could have changed the outcome** |
+| `distinct_v1_max` | Largest legal-set site count seen (the best ordering lever on the board) |
+| `census_s_total` | Sum of the per-crossover credits |
+| `verdict` | See below |
+| `saturated_threshold_pct` | The threshold the verdict used (default 90.0) |
+
+## Interpreting it (advisory, non-blocking)
+
+| Verdict | Condition | Reading |
+|---------|-----------|---------|
+| `not-applicable` | nothing scanned | This run never synthesized a shadow-constructed crossover. **Not** a 0%-saturation clean bill of health. |
+| `saturated` | `saturated_pct >= saturated_threshold_pct` | The lattice offers almost nothing. Ordering keys are inert; the constraint lives upstream in placement / escape planning. |
+| `no-ordering-lever` | `inert_pct >= saturated_threshold_pct` (but not saturated) | Legal sets exist but each has a single site — same conclusion, different mechanism. |
+| `ordering-levers-available` | otherwise | Enough crossovers have a real choice that a better sort key could plausibly move results. |
+
+The default threshold is **90%** (`SATURATED_PCT_ADVISORY_THRESHOLD`), taken
+from the board-06 precedent: its measured saturation sits in the 90–95% band,
+while an open synthetic lattice measures near 0%.
+
+**This is documentation, not a gate.** No code branches on `verdict`, no exit
+code reflects it, and nothing about routing changes when it flips. Wiring
+saturation into an actual go/no-go or steering decision is deliberate follow-up
+work, as is a genuine *pre*-routing predictor (the census's legality checks
+consult order-dependent state — drills already placed by earlier crossovers,
+the escape-channel registry keyed on which nets are still unrouted, and the
+pair's own guide route — so it cannot simply be hoisted ahead of the first A*
+expansion).
+
+## Not applicable ≠ zero
+
+Only board-06 exercises this path today. Board-05 has no differential pairs;
+board-07 never calls `route_all_with_diffpairs`. Running either with the report
+enabled produces a valid document with `crossovers_scanned: 0`,
+`applicable: false` and `verdict: "not-applicable"` — deliberately distinct
+from a `0.0` saturation figure, which would read as a clean result for a board
+that was never measured. Board-07's own routing failure mode (#3438, pad-array
+bundle congestion) is structurally different and **outside** what this census
+can see.
+
+## Cost
+
+The capture is a dataclass construction and two list appends per crossover,
+performed *after* the census has stamped and credited its incremental cost —
+i.e. in the same uncredited, bounded tail as the census's own `print` calls.
+Measured overhead is a few microseconds per crossover against a per-crossover
+census cost measured in milliseconds, so the report is free relative to the
+census it aggregates, and the census remains the only meaningful cost
+(`census_s_total` in the report; ~1.3 s across a whole board-06 shadow phase).
+The JSON document is written once, at exit.
+
+If the report cannot be written (unwritable path, read-only directory), the
+flush prints a diagnostic line to stderr and returns — it never raises, on the
+`_offboard_preflight` precedent that report-only surfaces must not block a
+route that already succeeded.
+
+## API
+
+```python
+from kicad_tools.router.crosstail_census import (
+    CENSUS_COLLECTOR,  # process-wide collector
+    CrossingTailCensusRecord,  # one crossover
+    CrossingTailCensusSummary,  # the aggregate
+    write_report,  # write the JSON document explicitly
+)
+
+summary = CENSUS_COLLECTOR.summary()
+print(summary.saturated_pct, summary.verdict)
+write_report("census.json")
+```
+
+`DiffPairRouter._census_records` holds the same records for a single router
+instance, reset at the start of every `route_all_with_diffpairs` call.
+
+[#3438]: https://github.com/rjwalters/kicad-tools/issues/3438
+[#4580]: https://github.com/rjwalters/kicad-tools/issues/4580
+[#4635]: https://github.com/rjwalters/kicad-tools/issues/4635
+[#4799]: https://github.com/rjwalters/kicad-tools/issues/4799

--- a/src/kicad_tools/router/crosstail_census.py
+++ b/src/kicad_tools/router/crosstail_census.py
@@ -377,6 +377,20 @@ def write_report(
     return target
 
 
+def _existing_report_has_records(target: Path) -> bool:
+    """Does *target* already hold a report that measured something?
+
+    Used by :func:`flush_report` for the no-clobber rule below.  Any read or
+    parse problem answers ``False`` -- an unreadable or foreign file is not a
+    measurement worth protecting.
+    """
+    try:
+        payload = json.loads(target.read_text())
+        return int(payload["summary"]["crossovers_scanned"]) > 0
+    except Exception:
+        return False
+
+
 def flush_report(
     collector: CrossingTailCensusCollector | None = None,
     *,
@@ -384,6 +398,14 @@ def flush_report(
     stream: Any = None,
 ) -> Path | None:
     """Write the report iff :data:`REPORT_ENV_VAR` names a path.
+
+    **An empty report never clobbers a non-empty one.**  Board scripts shell
+    out (``kicad-cli``, helper ``python`` invocations), and every child
+    inherits the environment -- so each child would otherwise flush its own
+    "0 crossovers scanned" document over the parent's real measurement,
+    silently, since the child's stderr is usually captured.  A flush with no
+    records therefore stands down when the target already holds a report that
+    measured something.  A run that DID measure always writes.
 
     Never raises: a diagnostic that can abort a 25-minute route because its
     output directory is read-only would be worse than no diagnostic (the
@@ -397,6 +419,13 @@ def flush_report(
         return None
     sink = collector or CENSUS_COLLECTOR
     out = stream if stream is not None else sys.stderr
+    if not sink.records and target.exists() and _existing_report_has_records(target):
+        print(
+            f"[crosstail-census] report at {target} kept: this process scanned "
+            f"0 crossover(s) and will not overwrite a report that has records",
+            file=out,
+        )
+        return None
     try:
         written = write_report(target, sink)
     except Exception as exc:  # pragma: no cover - defensive, see docstring

--- a/src/kicad_tools/router/crosstail_census.py
+++ b/src/kicad_tools/router/crosstail_census.py
@@ -1,0 +1,436 @@
+"""Structured capture of the diff-pair crossing-tail legality census (issue #4799).
+
+The census itself is older (#4580, budget-corrected in #4635): with
+``KCT_CROSSTAIL_CENSUS=1``, :meth:`DiffPairRouter._synthesize_crossing_tail`
+scans its *whole* 225-entry via-site lattice instead of stopping at the first
+legal candidate, and prints one ``[crosstail-census]`` header per crossover.
+That output answers the question it was built for -- is a crossover's shipped
+via site an *ordering* problem (many sites legal, a better key could pick a
+kinder one) or a *saturation* one (almost nothing is legal, so no key can
+help) -- but only one crossover at a time, in free text, on stdout.
+
+This module turns that already-computed measurement into a **machine-readable
+aggregate**: a per-crossover record, a summary with the saturation figures, and
+a JSON document written to the path in ``KCT_CROSSTAIL_CENSUS_REPORT``.
+
+**Report-only.**  Nothing here participates in a routing decision.  The
+collector is appended to *after* the census has stamped and credited its own
+incremental cost (:attr:`DiffPairRouter._census_elapsed_s`, the #4635 budget
+credit), so the capture sits in the same uncredited, bounded, per-crossover
+tail as the existing ``print`` calls -- it cannot move a deadline, and it
+cannot change which candidate ships.
+
+Why an environment variable and not ``kct route --census-report``
+----------------------------------------------------------------
+
+The census only fires under ``DiffPairRouter`` with shadow construction on, and
+the only caller that does that today is ``boards/06-diffpair-test``'s
+``generate_design.py --step route`` -- a board script driving the router API
+directly, not ``kct route``.  A CLI flag would therefore be unreachable from
+the one run that produces data, whereas an env var composes with the two flags
+that already gate this measurement (``KCT_CROSSTAIL_CENSUS=1``,
+``KCT_BOARD06_SHADOW=1``).  The written document follows the ``--format json``
+conventions (``schema_version`` / ``generated_at``, sorted keys, one document)
+so a future CLI surface can emit exactly this payload unchanged.
+
+Interpreting the summary (advisory, non-blocking)
+-------------------------------------------------
+
+* ``saturated`` -- crossovers with ``legal == 0``: the lattice offered nothing.
+* ``no_ordering_lever`` -- crossovers that *did* have legal candidates but all
+  share a single ``v1`` site: every legal route carries the same barrel, so no
+  ordering key can move the result either.
+* ``inert_pct`` -- the union of the two: the share of crossovers where **no
+  ordering key could have changed the outcome**.  This is the leading
+  indicator; ``saturated_pct`` alone would call a lattice healthy when its few
+  legal sets each offered a single site.
+* ``verdict`` -- one of ``not-applicable`` (nothing scanned), ``saturated``
+  (``saturated_pct`` at or above :data:`SATURATED_PCT_ADVISORY_THRESHOLD`),
+  ``no-ordering-lever`` (``inert_pct`` at or above it, but with real legal
+  sets), or ``ordering-levers-available``.  Read the first two as "ordering
+  levers are inert here; the constraint lives upstream in placement / escape
+  planning", which is the board-06 precedent.  It is **documentation, not a
+  gate**: no code branches on it, no exit code reflects it.  Wiring saturation
+  into an actual go/no-go or steering decision is deliberate follow-up work.
+"""
+
+from __future__ import annotations
+
+import atexit
+import json
+import os
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Mapping, Sequence
+
+__all__ = [
+    "REPORT_ENV_VAR",
+    "SATURATED_PCT_ADVISORY_THRESHOLD",
+    "SCHEMA_VERSION",
+    "VERDICT_NOT_APPLICABLE",
+    "VERDICT_NO_ORDERING_LEVER",
+    "VERDICT_ORDERING_LEVERS",
+    "VERDICT_SATURATED",
+    "CrossingTailCensusCollector",
+    "CrossingTailCensusRecord",
+    "CrossingTailCensusSummary",
+    "CENSUS_COLLECTOR",
+    "register_atexit_flush",
+    "report_path_from_env",
+    "write_report",
+]
+
+#: Bump only on a breaking change to the document below (additions are free).
+SCHEMA_VERSION = 1
+
+#: Set to a filesystem path to have the report written at interpreter exit.
+REPORT_ENV_VAR = "KCT_CROSSTAIL_CENSUS_REPORT"
+
+#: ``saturated_pct`` at or above which the summary's verdict flips to
+#: :data:`VERDICT_SATURATED`.  Advisory only -- see the module docstring.
+#: Chosen from the board-06 precedent, whose measured saturation sits in the
+#: 90-95% band while a healthy (open) lattice measures near 0%.
+SATURATED_PCT_ADVISORY_THRESHOLD = 90.0
+
+VERDICT_NOT_APPLICABLE = "not-applicable"
+VERDICT_SATURATED = "saturated"
+VERDICT_NO_ORDERING_LEVER = "no-ordering-lever"
+VERDICT_ORDERING_LEVERS = "ordering-levers-available"
+
+
+def _pct(numerator: int, denominator: int) -> float:
+    """Percentage rounded to one decimal; ``0.0`` when the denominator is 0."""
+    if denominator <= 0:
+        return 0.0
+    return round(100.0 * numerator / denominator, 1)
+
+
+@dataclass(frozen=True)
+class CrossingTailCensusRecord:
+    """One crossover's census result -- the structured twin of the header line.
+
+    Field names mirror the ``[crosstail-census]`` header exactly
+    (``legal``/``total``/``distinct_v1``/``census_s``) so a reader of one can
+    read the other.
+    """
+
+    net_name: str
+    head: tuple[float, float]
+    goal: tuple[float, float]
+    legal: int
+    total: int
+    distinct_v1: int
+    census_s: float = 0.0
+
+    @property
+    def saturated(self) -> bool:
+        """No candidate in the whole lattice was legal."""
+        return self.legal == 0
+
+    @property
+    def no_ordering_lever(self) -> bool:
+        """Legal candidates exist, but they all land on ONE ``v1`` site.
+
+        Deliberately excludes saturated crossovers: those have no ordering
+        lever either, but for the stronger reason that they have no candidate
+        at all, and conflating the two hides which one a board is hitting.
+        """
+        return self.legal > 0 and self.distinct_v1 <= 1
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "net_name": self.net_name,
+            "head": [self.head[0], self.head[1]],
+            "goal": [self.goal[0], self.goal[1]],
+            "legal": self.legal,
+            "total": self.total,
+            "distinct_v1": self.distinct_v1,
+            "census_s": round(self.census_s, 6),
+            "saturated": self.saturated,
+            "no_ordering_lever": self.no_ordering_lever,
+        }
+
+
+@dataclass(frozen=True)
+class CrossingTailCensusSummary:
+    """Aggregate of every :class:`CrossingTailCensusRecord` in one process."""
+
+    crossovers_scanned: int
+    saturated: int
+    saturated_pct: float
+    no_ordering_lever: int
+    no_ordering_lever_pct: float
+    inert_pct: float
+    distinct_v1_max: int
+    census_s_total: float
+    verdict: str
+    saturated_threshold_pct: float
+
+    @property
+    def applicable(self) -> bool:
+        """Did anything actually exercise the census in this process?
+
+        ``False`` is the honest answer for a board that never routes a
+        differential pair through the shadow constructor (boards 05 and 07
+        today) -- distinct from "0% saturated", which would be a fabricated
+        clean bill of health.
+        """
+        return self.crossovers_scanned > 0
+
+    @classmethod
+    def from_records(
+        cls,
+        records: Sequence[CrossingTailCensusRecord],
+        *,
+        saturated_threshold_pct: float = SATURATED_PCT_ADVISORY_THRESHOLD,
+    ) -> CrossingTailCensusSummary:
+        scanned = len(records)
+        saturated = sum(1 for r in records if r.saturated)
+        unsaturated = scanned - saturated
+        no_lever = sum(1 for r in records if r.no_ordering_lever)
+        saturated_pct = _pct(saturated, scanned)
+        # "Inert" = no ordering key could have changed the outcome, whether
+        # because nothing was legal or because every legal candidate sat on the
+        # same barrel.  This is the union the verdict is really about; keying
+        # only on ``saturated_pct`` would call a lattice "ordering levers
+        # available" when in fact none of its legal sets offered a choice.
+        inert_pct = _pct(saturated + no_lever, scanned)
+        if scanned == 0:
+            verdict = VERDICT_NOT_APPLICABLE
+        elif saturated_pct >= saturated_threshold_pct:
+            verdict = VERDICT_SATURATED
+        elif inert_pct >= saturated_threshold_pct:
+            verdict = VERDICT_NO_ORDERING_LEVER
+        else:
+            verdict = VERDICT_ORDERING_LEVERS
+        return cls(
+            crossovers_scanned=scanned,
+            saturated=saturated,
+            saturated_pct=saturated_pct,
+            no_ordering_lever=no_lever,
+            # Denominator is the UNSATURATED set: "of the crossovers that had a
+            # choice, how many had no real choice".  Against ``scanned`` the
+            # figure would be diluted by the saturated ones and mean nothing.
+            no_ordering_lever_pct=_pct(no_lever, unsaturated),
+            inert_pct=inert_pct,
+            distinct_v1_max=max((r.distinct_v1 for r in records), default=0),
+            census_s_total=round(float(sum(r.census_s for r in records)), 6),
+            verdict=verdict,
+            saturated_threshold_pct=saturated_threshold_pct,
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "applicable": self.applicable,
+            "crossovers_scanned": self.crossovers_scanned,
+            "saturated": self.saturated,
+            "saturated_pct": self.saturated_pct,
+            "unsaturated": self.crossovers_scanned - self.saturated,
+            "no_ordering_lever": self.no_ordering_lever,
+            "no_ordering_lever_pct": self.no_ordering_lever_pct,
+            "inert_pct": self.inert_pct,
+            "distinct_v1_max": self.distinct_v1_max,
+            "census_s_total": self.census_s_total,
+            "verdict": self.verdict,
+            "saturated_threshold_pct": self.saturated_threshold_pct,
+        }
+
+    def format_human(self) -> str:
+        """Multi-line, greppable text form of this summary.
+
+        Every line is prefixed ``[crosstail-census-summary]`` so it survives
+        interleaving with the router's own chatter.
+        """
+        tag = "[crosstail-census-summary]"
+        if not self.applicable:
+            return (
+                f"{tag} 0 crossovers scanned -- NOT APPLICABLE\n"
+                f"{tag}   nothing in this run exercised the diff-pair "
+                f"crossing-tail census (no shadow-constructed crossover was "
+                f"synthesized); this is not a 0% saturation result"
+            )
+        lines = [
+            f"{tag} {self.crossovers_scanned} crossover(s) scanned, verdict={self.verdict}",
+            f"{tag}   saturated (legal=0): {self.saturated}/"
+            f"{self.crossovers_scanned} ({self.saturated_pct}%)",
+            f"{tag}   no ordering lever (legal>0, distinct_v1<=1): "
+            f"{self.no_ordering_lever}/{self.crossovers_scanned - self.saturated} "
+            f"({self.no_ordering_lever_pct}% of unsaturated)",
+            f"{tag}   inert (no ordering key could change the outcome): {self.inert_pct}%",
+            f"{tag}   distinct_v1 max={self.distinct_v1_max} "
+            f"credited census_s total={self.census_s_total:.4f}",
+        ]
+        if self.verdict in (VERDICT_SATURATED, VERDICT_NO_ORDERING_LEVER):
+            lines.append(
+                f"{tag}   advisory: inert >= {self.saturated_threshold_pct}% "
+                f"-- ordering levers are inert; the constraint is upstream in "
+                f"placement / escape planning (non-blocking)"
+            )
+        return "\n".join(lines)
+
+
+class CrossingTailCensusCollector:
+    """Append-only sink for :class:`CrossingTailCensusRecord`s.
+
+    One instance is shared per process (:data:`CENSUS_COLLECTOR`) so a report
+    can be produced even from entry points that never reach
+    ``route_all_with_diffpairs``; :class:`DiffPairRouter` also keeps its own
+    per-instance list for tests that want one router's records in isolation.
+    """
+
+    def __init__(self) -> None:
+        self._records: list[CrossingTailCensusRecord] = []
+
+    def add(self, record: CrossingTailCensusRecord) -> None:
+        self._records.append(record)
+
+    @property
+    def records(self) -> tuple[CrossingTailCensusRecord, ...]:
+        return tuple(self._records)
+
+    def reset(self) -> None:
+        self._records.clear()
+
+    def summary(
+        self,
+        *,
+        saturated_threshold_pct: float = SATURATED_PCT_ADVISORY_THRESHOLD,
+    ) -> CrossingTailCensusSummary:
+        return CrossingTailCensusSummary.from_records(
+            self._records, saturated_threshold_pct=saturated_threshold_pct
+        )
+
+    def to_report_dict(
+        self,
+        *,
+        census_enabled: bool | None = None,
+        saturated_threshold_pct: float = SATURATED_PCT_ADVISORY_THRESHOLD,
+    ) -> dict[str, Any]:
+        """The JSON document: envelope + summary + per-crossover detail."""
+        if census_enabled is None:
+            census_enabled = census_is_enabled()
+        summary = self.summary(saturated_threshold_pct=saturated_threshold_pct)
+        return {
+            "schema_version": SCHEMA_VERSION,
+            "generated_at": datetime.now(timezone.utc).isoformat(),
+            "report": "crosstail-census",
+            "census_enabled": bool(census_enabled),
+            "summary": summary.to_dict(),
+            "crossovers": [r.to_dict() for r in self._records],
+        }
+
+    def format_human(
+        self,
+        *,
+        saturated_threshold_pct: float = SATURATED_PCT_ADVISORY_THRESHOLD,
+    ) -> str:
+        return self.summary(saturated_threshold_pct=saturated_threshold_pct).format_human()
+
+
+#: Process-wide collector.  Reset it in tests rather than rebinding the name.
+CENSUS_COLLECTOR = CrossingTailCensusCollector()
+
+
+def census_is_enabled() -> bool:
+    """Is the underlying #4580 census switched on for this process?
+
+    Read through the module that owns the flag so a ``monkeypatch`` of
+    ``_CROSSTAIL_CENSUS`` is honoured, and tolerate the import cycle during
+    ``diffpair_routing``'s own import by falling back to the environment.
+    """
+    try:
+        from kicad_tools.router import diffpair_routing as _dpr
+
+        return bool(_dpr._CROSSTAIL_CENSUS)
+    except Exception:  # pragma: no cover - import-time / partial-import safety
+        return os.environ.get("KCT_CROSSTAIL_CENSUS", "0") == "1"
+
+
+def report_path_from_env(env: Mapping[str, str] | None = None) -> Path | None:
+    """Path from ``KCT_CROSSTAIL_CENSUS_REPORT``, or ``None`` when unset/blank."""
+    raw = (env if env is not None else os.environ).get(REPORT_ENV_VAR, "")
+    raw = raw.strip()
+    return Path(raw) if raw else None
+
+
+def write_report(
+    path: Path | str,
+    collector: CrossingTailCensusCollector | None = None,
+    *,
+    census_enabled: bool | None = None,
+    saturated_threshold_pct: float = SATURATED_PCT_ADVISORY_THRESHOLD,
+) -> Path:
+    """Write the JSON report for *collector* to *path* and return the path.
+
+    Keys are sorted and the document is a single JSON object, matching
+    ``kct``'s machine-output contract (``docs/reference/machine-output.md``).
+    """
+    target = Path(path)
+    payload = (collector or CENSUS_COLLECTOR).to_report_dict(
+        census_enabled=census_enabled,
+        saturated_threshold_pct=saturated_threshold_pct,
+    )
+    if target.parent and not target.parent.exists():
+        target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(json.dumps(payload, indent=2, sort_keys=True, default=str) + "\n")
+    return target
+
+
+def flush_report(
+    collector: CrossingTailCensusCollector | None = None,
+    *,
+    env: Mapping[str, str] | None = None,
+    stream: Any = None,
+) -> Path | None:
+    """Write the report iff :data:`REPORT_ENV_VAR` names a path.
+
+    Never raises: a diagnostic that can abort a 25-minute route because its
+    output directory is read-only would be worse than no diagnostic (the
+    ``_offboard_preflight`` precedent -- report-only surfaces do not block).
+    Returns the written path, or ``None`` when nothing was written.
+    """
+    import sys
+
+    target = report_path_from_env(env)
+    if target is None:
+        return None
+    sink = collector or CENSUS_COLLECTOR
+    out = stream if stream is not None else sys.stderr
+    try:
+        written = write_report(target, sink)
+    except Exception as exc:  # pragma: no cover - defensive, see docstring
+        print(f"[crosstail-census] report NOT written to {target}: {exc}", file=out)
+        return None
+    summary = sink.summary()
+    print(
+        f"[crosstail-census] report written to {written} "
+        f"({summary.crossovers_scanned} crossover(s) scanned, "
+        f"verdict={summary.verdict})",
+        file=out,
+    )
+    return written
+
+
+_ATEXIT_REGISTERED = False
+
+
+def register_atexit_flush() -> None:
+    """Arrange for :func:`flush_report` to run at interpreter exit (once).
+
+    Registered at import time so *any* entry point that pulls in the router --
+    ``kct route``, a board's ``generate_design.py``, a bare script -- produces
+    a report when the env var is set, including the honest "0 crossovers
+    scanned / not applicable" one for a board that never routes a coupled
+    differential pair.  The hook re-reads the environment when it fires and is
+    a no-op when :data:`REPORT_ENV_VAR` is unset, so importing this module has
+    no observable effect on a normal run.
+    """
+    global _ATEXIT_REGISTERED
+    if _ATEXIT_REGISTERED:
+        return
+    atexit.register(flush_report)
+    _ATEXIT_REGISTERED = True
+
+
+register_atexit_flush()

--- a/src/kicad_tools/router/diffpair_routing.py
+++ b/src/kicad_tools/router/diffpair_routing.py
@@ -36,6 +36,11 @@ from kicad_tools.core.geometry import (
     segment_to_segment_distance as _segment_to_segment_distance,
 )
 
+from .crosstail_census import (
+    CENSUS_COLLECTOR,
+    CrossingTailCensusRecord,
+    CrossingTailCensusSummary,
+)
 from .diffpair import (
     DifferentialPair,
     DifferentialPairConfig,
@@ -3763,6 +3768,15 @@ class DiffPairRouter:
         # deadline computation.  Exactly ``0.0`` whenever the census is off, so
         # the default path's timing arithmetic is bit-identical.
         self._census_elapsed_s: float = 0.0
+        # Issue #4799: structured capture of the #4580 census.  One
+        # ``CrossingTailCensusRecord`` per crossover the census scanned, in
+        # scan order, for THIS router instance (the process-wide twin lives in
+        # ``crosstail_census.CENSUS_COLLECTOR``, which is what the JSON report
+        # is written from).  Appended to only when the census is on, and only
+        # AFTER the #4635 credit has been stamped -- so, like the census's own
+        # ``print`` calls, it is outside every budgeted window and cannot move
+        # a deadline.  Never read by a routing decision.
+        self._census_records: list[CrossingTailCensusRecord] = []
         # Issue #3089: True iff the most-recent call to
         # ``route_differential_pair_coupled`` returned because the
         # inner ``CoupledPathfinder.route_coupled`` exceeded its
@@ -6190,11 +6204,54 @@ class DiffPairRouter:
             # the ``census_s=`` field it prints self-referential.
             census_extra_s = 0.0 if census_extra_t0 is None else time.monotonic() - census_extra_t0
             self._census_elapsed_s += census_extra_s
+            # Issue #4799: capture the same numbers the header prints into a
+            # structured record, for the aggregate report.  Deliberately AFTER
+            # the credit above -- this append is part of the census's
+            # uncredited, bounded per-crossover tail, exactly like the prints.
+            self._collect_crossing_tail_census(
+                head, goal, census_legal, len(candidate_pairs), census_extra_s
+            )
             self._report_crossing_tail_census(
                 head, goal, census_legal, len(candidate_pairs), census_extra_s
             )
             return census_first  # observation only: the first legal candidate
         return None
+
+    def _collect_crossing_tail_census(
+        self,
+        head: Pad,
+        goal: Pad,
+        legal: list[tuple[int, int, float, _XY, _XY]],
+        total: int,
+        census_s: float = 0.0,
+    ) -> CrossingTailCensusRecord:
+        """Record one crossover's census result for the aggregate report (#4799).
+
+        The free-text header printed by :meth:`_report_crossing_tail_census`
+        answers one crossover at a time; a board's actual question is a
+        distribution ("what fraction of crossovers had nothing legal at all?").
+        Reconstructing that from stdout means scraping, so the same figures are
+        captured here as data, on the router instance *and* in the process-wide
+        :data:`~kicad_tools.router.crosstail_census.CENSUS_COLLECTOR` the JSON
+        report is written from.
+
+        Report-only: the returned record is never consulted by a routing
+        decision, and this method is only reached on the census path, which
+        already returns the first legal candidate regardless.
+        """
+        record = CrossingTailCensusRecord(
+            net_name=head.net_name or "",
+            head=(head.x, head.y),
+            goal=(goal.x, goal.y),
+            legal=len(legal),
+            total=total,
+            # Same expression the header prints, so the two can never disagree.
+            distinct_v1=len({site[3] for site in legal}),
+            census_s=census_s,
+        )
+        self._census_records.append(record)
+        CENSUS_COLLECTOR.add(record)
+        return record
 
     @staticmethod
     def _report_crossing_tail_census(
@@ -11911,6 +11968,11 @@ class DiffPairRouter:
         # Issue #4463: pairs that yielded their corridor to unblock a
         # single-ended net (empty unless the corridor guard fired).
         self._last_corridor_yield_pair_names: list[str] = []
+        # Issue #4799: same "latest invocation only" contract for the
+        # per-instance census capture.  The process-wide collector behind the
+        # JSON report is deliberately NOT reset here -- a run that routes in
+        # several passes should report every crossover it scanned.
+        self._census_records = []
 
         if diffpair_config is None or not diffpair_config.enabled:
             return self.autorouter.route_all(net_order), []
@@ -12310,6 +12372,12 @@ class DiffPairRouter:
                 considered,
                 ", ".join(deduped_names),
             )
+
+        # Issue #4799: with the census on, close the phase with the aggregate
+        # the per-crossover headers cannot give you.  Report-only: printed
+        # after every routing decision in this phase has already been made.
+        if _CROSSTAIL_CENSUS:
+            print(CrossingTailCensusSummary.from_records(self._census_records).format_human())
 
         print("\n=== Differential Pair Routing Complete ===")
         print(f"  Total routes: {len(all_routes)}")

--- a/tests/test_crosstail_census_report_4799.py
+++ b/tests/test_crosstail_census_report_4799.py
@@ -365,6 +365,44 @@ def test_flush_writes_and_announces_the_report(tmp_path, capsys):
     assert "1 crossover(s) scanned" in err
 
 
+def test_empty_flush_does_not_clobber_a_report_with_records(tmp_path, capsys):
+    """Child processes inherit the env var; their empty flush must stand down.
+
+    A board script shells out to ``kicad-cli`` and helper ``python`` runs, each
+    of which would otherwise overwrite the parent's real measurement with its
+    own "0 crossovers scanned" document -- invisibly, because the child's
+    stderr is captured.  Observed while measuring board-06 for #4799.
+    """
+    target = tmp_path / "census.json"
+    measured = CrossingTailCensusCollector()
+    measured.add(_record(legal=0, distinct_v1=0))
+    flush_report(measured, env={REPORT_ENV_VAR: str(target)})
+    capsys.readouterr()
+
+    assert flush_report(CrossingTailCensusCollector(), env={REPORT_ENV_VAR: str(target)}) is None
+    assert json.loads(target.read_text())["summary"]["crossovers_scanned"] == 1
+    assert "kept" in capsys.readouterr().err
+
+
+def test_empty_flush_still_writes_when_the_existing_report_is_empty(tmp_path, capsys):
+    """The no-clobber rule protects measurements, not stale empty files."""
+    target = tmp_path / "census.json"
+    write_report(target, CrossingTailCensusCollector())
+
+    assert flush_report(CrossingTailCensusCollector(), env={REPORT_ENV_VAR: str(target)}) == target
+    assert json.loads(target.read_text())["summary"]["verdict"] == VERDICT_NOT_APPLICABLE
+
+
+def test_a_run_with_records_always_overwrites(tmp_path, capsys):
+    target = tmp_path / "census.json"
+    write_report(target, CrossingTailCensusCollector())
+    measured = CrossingTailCensusCollector()
+    measured.add(_record(legal=4, distinct_v1=3))
+
+    assert flush_report(measured, env={REPORT_ENV_VAR: str(target)}) == target
+    assert json.loads(target.read_text())["summary"]["crossovers_scanned"] == 1
+
+
 def test_flush_never_raises_when_the_path_is_unwritable(tmp_path, capsys):
     """Report-only means non-blocking: a bad path must not abort a 25-min route."""
     unwritable = tmp_path / "census.json" / "nope.json"

--- a/tests/test_crosstail_census_report_4799.py
+++ b/tests/test_crosstail_census_report_4799.py
@@ -1,0 +1,496 @@
+"""Issue #4799: the crossing-tail census as a structured, aggregated report.
+
+The #4580 census already computes, per crossover, everything a capacity
+indicator needs -- how many of the 225 via-site candidates were legal and how
+many distinct ``v1`` barrels those legal candidates used.  It emitted that as
+free text, one crossover at a time, so the only way to get the *distribution*
+(the number a "is this lattice saturated?" question actually asks) was to
+scrape stdout.
+
+This module pins the structured surface that replaces the scrape:
+
+1. The per-crossover record and its derived predicates (``saturated``,
+   ``no_ordering_lever``) -- no board fixture required.
+2. The aggregate summary: counts, percentages, the denominator choice, and the
+   advisory verdict thresholds.
+3. The "not applicable" result a run that never synthesizes a crossover must
+   produce -- explicitly distinct from "0% saturated".
+4. The JSON document and the env-gated flush.
+5. Report-ONLY: capture changes neither the route that ships nor the #4635
+   ``_census_elapsed_s`` budget credit.
+
+Fixtures for (5) are imported from ``tests/test_diffpair_shadow.py``, the
+module that owns the #4580 census block -- the same convention
+``tests/test_diffpair_census_budget.py`` uses.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+
+import pytest
+
+from kicad_tools.router.crosstail_census import (
+    CENSUS_COLLECTOR,
+    REPORT_ENV_VAR,
+    SATURATED_PCT_ADVISORY_THRESHOLD,
+    SCHEMA_VERSION,
+    VERDICT_NO_ORDERING_LEVER,
+    VERDICT_NOT_APPLICABLE,
+    VERDICT_ORDERING_LEVERS,
+    VERDICT_SATURATED,
+    CrossingTailCensusCollector,
+    CrossingTailCensusRecord,
+    CrossingTailCensusSummary,
+    flush_report,
+    report_path_from_env,
+    write_report,
+)
+from tests.test_diffpair_census_budget import _SealedPathfinder
+from tests.test_diffpair_shadow import (
+    _crossing_router,
+    _crossing_tail,
+    _tail_pads,
+)
+
+
+@pytest.fixture(autouse=True)
+def _clean_process_collector():
+    """The collector is process-wide; keep tests from seeing each other's records."""
+    CENSUS_COLLECTOR.reset()
+    yield
+    CENSUS_COLLECTOR.reset()
+
+
+def _census_on(monkeypatch) -> None:
+    import kicad_tools.router.diffpair_routing as dpr_mod
+
+    monkeypatch.setattr(dpr_mod, "_CROSSTAIL_CENSUS", True)
+
+
+def _record(legal: int, distinct_v1: int, *, total: int = 225, census_s: float = 0.0):
+    return CrossingTailCensusRecord(
+        net_name="USB3_TX1-",
+        head=(5.0, 5.0),
+        goal=(8.0, 5.0),
+        legal=legal,
+        total=total,
+        distinct_v1=distinct_v1,
+        census_s=census_s,
+    )
+
+
+# ---------------------------------------------------------------------------
+# The per-crossover record
+# ---------------------------------------------------------------------------
+
+
+def test_record_classifies_a_saturated_crossover():
+    """``legal=0`` is the saturated extreme: the lattice offered nothing."""
+    record = _record(legal=0, distinct_v1=0)
+
+    assert record.saturated is True
+    assert record.no_ordering_lever is False, (
+        "a saturated crossover has no ordering lever either, but folding the "
+        "two together hides which failure a board is actually hitting"
+    )
+
+
+def test_record_classifies_a_single_site_legal_set():
+    """Legal candidates that share one ``v1`` carry the same barrel every time."""
+    record = _record(legal=2, distinct_v1=1)
+
+    assert record.saturated is False
+    assert record.no_ordering_lever is True
+
+
+def test_record_with_real_ordering_choice_is_neither():
+    record = _record(legal=17, distinct_v1=9)
+
+    assert record.saturated is False
+    assert record.no_ordering_lever is False
+
+
+def test_record_dict_carries_the_header_field_names():
+    """The JSON keys mirror the ``[crosstail-census]`` header, so the two agree."""
+    payload = _record(legal=2, distinct_v1=1, census_s=0.0164).to_dict()
+
+    assert payload == {
+        "net_name": "USB3_TX1-",
+        "head": [5.0, 5.0],
+        "goal": [8.0, 5.0],
+        "legal": 2,
+        "total": 225,
+        "distinct_v1": 1,
+        "census_s": 0.0164,
+        "saturated": False,
+        "no_ordering_lever": True,
+    }
+
+
+# ---------------------------------------------------------------------------
+# The aggregate summary
+# ---------------------------------------------------------------------------
+
+
+def test_summary_counts_and_percentages():
+    """The board-06 shape: overwhelmingly saturated, a couple of legal sets."""
+    records = [_record(legal=0, distinct_v1=0) for _ in range(19)]
+    records.append(_record(legal=2, distinct_v1=1))
+
+    summary = CrossingTailCensusSummary.from_records(records)
+
+    assert summary.crossovers_scanned == 20
+    assert summary.saturated == 19
+    assert summary.saturated_pct == 95.0
+    assert summary.applicable is True
+
+
+def test_no_ordering_lever_percentage_is_over_the_unsaturated_set():
+    """Denominator choice is load-bearing.
+
+    "Of the crossovers that had a choice, how many had no real choice" is the
+    actionable figure; against the full scan it would be diluted to near-zero
+    by the saturated majority and mean nothing.
+    """
+    records = [_record(legal=0, distinct_v1=0) for _ in range(90)]
+    records += [_record(legal=3, distinct_v1=1) for _ in range(5)]
+    records += [_record(legal=3, distinct_v1=3) for _ in range(5)]
+
+    summary = CrossingTailCensusSummary.from_records(records)
+
+    assert summary.no_ordering_lever == 5
+    assert summary.no_ordering_lever_pct == 50.0  # 5 of the 10 unsaturated
+    assert summary.saturated_pct == 90.0
+
+
+def test_summary_reports_max_distinct_v1_and_total_census_seconds():
+    records = [
+        _record(legal=1, distinct_v1=1, census_s=0.25),
+        _record(legal=8, distinct_v1=4, census_s=0.75),
+    ]
+
+    summary = CrossingTailCensusSummary.from_records(records)
+
+    assert summary.distinct_v1_max == 4
+    assert summary.census_s_total == pytest.approx(1.0)
+
+
+def test_verdict_flips_at_the_documented_threshold():
+    """The advisory heuristic is a documented constant, not a magic number."""
+    saturated = [_record(legal=0, distinct_v1=0) for _ in range(9)]
+    open_one = [_record(legal=5, distinct_v1=5)]
+
+    at_threshold = CrossingTailCensusSummary.from_records(saturated + open_one)
+    below = CrossingTailCensusSummary.from_records(saturated[:-1] + open_one * 2)
+
+    assert SATURATED_PCT_ADVISORY_THRESHOLD == 90.0
+    assert at_threshold.saturated_pct == 90.0
+    assert at_threshold.verdict == VERDICT_SATURATED
+    assert below.saturated_pct < SATURATED_PCT_ADVISORY_THRESHOLD
+    assert below.verdict == VERDICT_ORDERING_LEVERS
+
+
+def test_inert_verdict_catches_a_lattice_saturation_alone_would_call_healthy():
+    """An all-singleton legal set is as inert as an empty one.
+
+    ``saturated_pct`` is 0% here -- every crossover had a legal candidate --
+    but every legal set sits on ONE ``v1``, so no ordering key can move any of
+    them.  Keying the verdict on saturation alone would report this lattice as
+    having levers it does not have.
+    """
+    records = [_record(legal=3, distinct_v1=1) for _ in range(10)]
+
+    summary = CrossingTailCensusSummary.from_records(records)
+
+    assert summary.saturated_pct == 0.0
+    assert summary.inert_pct == 100.0
+    assert summary.verdict == VERDICT_NO_ORDERING_LEVER
+    assert "advisory" in summary.format_human()
+
+
+def test_inert_pct_unions_saturated_and_lever_less_crossovers():
+    records = [_record(legal=0, distinct_v1=0) for _ in range(6)]
+    records += [_record(legal=2, distinct_v1=1) for _ in range(2)]
+    records += [_record(legal=2, distinct_v1=2) for _ in range(2)]
+
+    summary = CrossingTailCensusSummary.from_records(records)
+
+    assert summary.saturated_pct == 60.0
+    assert summary.no_ordering_lever == 2
+    assert summary.inert_pct == 80.0
+    assert summary.verdict == VERDICT_ORDERING_LEVERS  # 80% < the 90% threshold
+
+
+def test_verdict_threshold_is_overridable_without_changing_the_data():
+    records = [_record(legal=0, distinct_v1=0), _record(legal=4, distinct_v1=2)]
+
+    strict = CrossingTailCensusSummary.from_records(records, saturated_threshold_pct=50.0)
+    lenient = CrossingTailCensusSummary.from_records(records, saturated_threshold_pct=99.0)
+
+    assert strict.saturated_pct == lenient.saturated_pct == 50.0
+    assert strict.verdict == VERDICT_SATURATED
+    assert lenient.verdict == VERDICT_ORDERING_LEVERS
+
+
+def test_empty_scan_is_not_applicable_not_zero_percent_saturated():
+    """Boards 05 / 07 never exercise this path -- say so, don't invent a figure."""
+    summary = CrossingTailCensusSummary.from_records([])
+
+    assert summary.crossovers_scanned == 0
+    assert summary.applicable is False
+    assert summary.verdict == VERDICT_NOT_APPLICABLE
+    assert summary.saturated_pct == 0.0
+    assert summary.no_ordering_lever_pct == 0.0
+
+
+def test_human_summary_spells_out_the_not_applicable_case():
+    text = CrossingTailCensusSummary.from_records([]).format_human()
+
+    assert "0 crossovers scanned" in text
+    assert "NOT APPLICABLE" in text
+    assert "not a 0% saturation result" in text
+    assert all(line.startswith("[crosstail-census-summary]") for line in text.splitlines())
+
+
+def test_human_summary_carries_the_advisory_only_when_saturated():
+    saturated = CrossingTailCensusSummary.from_records(
+        [_record(legal=0, distinct_v1=0) for _ in range(10)]
+    ).format_human()
+    healthy = CrossingTailCensusSummary.from_records(
+        [_record(legal=9, distinct_v1=6) for _ in range(10)]
+    ).format_human()
+
+    assert "advisory" in saturated
+    assert "placement / escape planning" in saturated
+    assert "10/10 (100.0%)" in saturated
+    assert "advisory" not in healthy
+    assert f"verdict={VERDICT_ORDERING_LEVERS}" in healthy
+
+
+# ---------------------------------------------------------------------------
+# The collector and the JSON document
+# ---------------------------------------------------------------------------
+
+
+def test_collector_accumulates_in_scan_order_and_resets():
+    collector = CrossingTailCensusCollector()
+    collector.add(_record(legal=0, distinct_v1=0))
+    collector.add(_record(legal=4, distinct_v1=2))
+
+    assert [r.legal for r in collector.records] == [0, 4]
+    assert collector.summary().crossovers_scanned == 2
+
+    collector.reset()
+    assert collector.records == ()
+    assert collector.summary().verdict == VERDICT_NOT_APPLICABLE
+
+
+def test_report_document_is_envelope_summary_and_detail(tmp_path):
+    collector = CrossingTailCensusCollector()
+    collector.add(_record(legal=0, distinct_v1=0))
+    collector.add(_record(legal=2, distinct_v1=1, census_s=0.5))
+
+    path = write_report(tmp_path / "nested" / "census.json", collector, census_enabled=True)
+    payload = json.loads(path.read_text())
+
+    assert path.exists(), "the report must create its parent directory"
+    assert payload["schema_version"] == SCHEMA_VERSION
+    assert payload["report"] == "crosstail-census"
+    assert payload["census_enabled"] is True
+    assert re.match(r"\d{4}-\d\d-\d\dT", payload["generated_at"])
+    assert payload["summary"]["crossovers_scanned"] == 2
+    assert payload["summary"]["saturated"] == 1
+    assert payload["summary"]["saturated_pct"] == 50.0
+    assert [c["legal"] for c in payload["crossovers"]] == [0, 2]
+
+
+def test_report_document_is_deterministic_sorted_json(tmp_path):
+    """Machine-output contract: one document, sorted keys (see machine-output.md)."""
+    collector = CrossingTailCensusCollector()
+    collector.add(_record(legal=1, distinct_v1=1))
+
+    text = write_report(tmp_path / "census.json", collector, census_enabled=False).read_text()
+    keys = list(json.loads(text).keys())
+
+    assert keys == sorted(keys)
+    assert text.endswith("\n")
+    assert json.loads(text)["summary"]["verdict"] == VERDICT_NO_ORDERING_LEVER
+
+
+def test_report_for_a_run_that_scanned_nothing(tmp_path):
+    """The board-05 / board-07 shape: a clean file that says "not applicable"."""
+    path = write_report(
+        tmp_path / "census.json", CrossingTailCensusCollector(), census_enabled=False
+    )
+    payload = json.loads(path.read_text())
+
+    assert payload["crossovers"] == []
+    assert payload["summary"]["applicable"] is False
+    assert payload["summary"]["crossovers_scanned"] == 0
+    assert payload["summary"]["verdict"] == VERDICT_NOT_APPLICABLE
+
+
+# ---------------------------------------------------------------------------
+# The env-gated flush
+# ---------------------------------------------------------------------------
+
+
+def test_report_path_is_none_when_unset_or_blank():
+    assert report_path_from_env({}) is None
+    assert report_path_from_env({REPORT_ENV_VAR: "   "}) is None
+    assert report_path_from_env({REPORT_ENV_VAR: "/tmp/x.json"}).name == "x.json"
+
+
+def test_flush_is_a_no_op_without_the_env_var(tmp_path, capsys):
+    collector = CrossingTailCensusCollector()
+    collector.add(_record(legal=0, distinct_v1=0))
+
+    assert flush_report(collector, env={}) is None
+    assert capsys.readouterr().err == "", "a disabled diagnostic must stay silent"
+
+
+def test_flush_writes_and_announces_the_report(tmp_path, capsys):
+    target = tmp_path / "census.json"
+    collector = CrossingTailCensusCollector()
+    collector.add(_record(legal=0, distinct_v1=0))
+
+    written = flush_report(collector, env={REPORT_ENV_VAR: str(target)})
+
+    assert written == target
+    assert json.loads(target.read_text())["summary"]["saturated"] == 1
+    err = capsys.readouterr().err
+    assert "report written to" in err
+    assert "1 crossover(s) scanned" in err
+
+
+def test_flush_never_raises_when_the_path_is_unwritable(tmp_path, capsys):
+    """Report-only means non-blocking: a bad path must not abort a 25-min route."""
+    unwritable = tmp_path / "census.json" / "nope.json"
+    (tmp_path / "census.json").write_text("not a directory")
+
+    assert (
+        flush_report(CrossingTailCensusCollector(), env={REPORT_ENV_VAR: str(unwritable)}) is None
+    )
+    assert "NOT written" in capsys.readouterr().err
+
+
+# ---------------------------------------------------------------------------
+# Capture is wired to the real census -- and changes nothing
+# ---------------------------------------------------------------------------
+
+
+def test_capture_is_off_when_the_census_is_off():
+    """A default run pays nothing and records nothing."""
+    dpr = _crossing_router()
+
+    assert _crossing_tail(dpr) is not None
+    assert dpr._census_records == []
+    assert CENSUS_COLLECTOR.records == ()
+
+
+def test_capture_matches_the_printed_header(monkeypatch, capsys):
+    """The record and the header are two views of ONE measurement."""
+    _census_on(monkeypatch)
+    dpr = _crossing_router()
+
+    assert _crossing_tail(dpr) is not None
+
+    header = next(
+        line for line in capsys.readouterr().out.splitlines() if "[crosstail-census] net=" in line
+    )
+    match = re.search(r"legal=(\d+)/(\d+) distinct_v1=(\d+) census_s=([0-9.]+)", header)
+    assert match is not None, header
+    assert len(dpr._census_records) == 1
+    record = dpr._census_records[0]
+    assert record.legal == int(match.group(1))
+    assert record.total == int(match.group(2))
+    assert record.distinct_v1 == int(match.group(3))
+    assert record.census_s == pytest.approx(float(match.group(4)), abs=5e-5)
+    assert record.net_name == "USB3_TX1-"
+    assert record.head == (5.0, 5.0)
+
+
+def test_capture_also_lands_in_the_process_collector(monkeypatch, capsys):
+    """The JSON report is written from the process-wide collector, not a router."""
+    _census_on(monkeypatch)
+    dpr = _crossing_router()
+
+    assert _crossing_tail(dpr) is not None
+    capsys.readouterr()
+
+    assert len(CENSUS_COLLECTOR.records) == 1
+    assert CENSUS_COLLECTOR.records[0] == dpr._census_records[0]
+    assert CENSUS_COLLECTOR.summary().crossovers_scanned == 1
+
+
+def test_saturated_crossover_is_captured_as_saturated(monkeypatch, capsys):
+    """The measurement that matters: a whole-lattice miss, recorded as such."""
+    _census_on(monkeypatch)
+    dpr = _crossing_router()
+    head, goal = _tail_pads((5.0, 5.0), (8.0, 5.0))
+
+    tail = dpr._synthesize_crossing_tail(_SealedPathfinder(), head, goal, 0, [])
+    capsys.readouterr()
+
+    assert tail is None
+    record = dpr._census_records[0]
+    assert record.legal == 0
+    assert record.total == 225
+    assert record.saturated is True
+    assert CENSUS_COLLECTOR.summary().saturated_pct == 100.0
+    assert CENSUS_COLLECTOR.summary().verdict == VERDICT_SATURATED
+
+
+def test_capture_does_not_change_the_route_that_ships(monkeypatch, capsys):
+    """Report-only, at the level the acceptance criterion cares about.
+
+    The censused tail must still be the un-instrumented first-legal one --
+    same vias, same segments -- with the capture path active.
+    """
+    baseline = _crossing_tail(_crossing_router())
+    capsys.readouterr()
+
+    _census_on(monkeypatch)
+    dpr = _crossing_router()
+    censused = _crossing_tail(dpr)
+    capsys.readouterr()
+
+    assert baseline is not None and censused is not None
+    assert dpr._census_records, "non-vacuity: the capture must actually have run"
+    assert [(v.x, v.y, v.layers) for v in censused.vias] == [
+        (v.x, v.y, v.layers) for v in baseline.vias
+    ]
+    assert [(s.x1, s.y1, s.x2, s.y2, s.layer) for s in censused.segments] == [
+        (s.x1, s.y1, s.x2, s.y2, s.layer) for s in baseline.segments
+    ]
+
+
+def test_capture_does_not_disturb_the_4635_budget_credit(monkeypatch, capsys):
+    """The #4635 lesson re-asserted against the new code.
+
+    The credit must still be exactly the value the header reports -- the
+    capture appends AFTER the credit is stamped, so it can neither inflate nor
+    deflate it.
+    """
+    _census_on(monkeypatch)
+    dpr = _crossing_router()
+
+    assert _crossing_tail(dpr) is not None
+    capsys.readouterr()
+
+    assert dpr._census_records[0].census_s == pytest.approx(dpr._census_elapsed_s, abs=5e-5)
+
+
+def test_saturated_crossover_still_credits_zero(monkeypatch, capsys):
+    """Both modes scan the whole lattice, so there is nothing to credit."""
+    _census_on(monkeypatch)
+    dpr = _crossing_router()
+    head, goal = _tail_pads((5.0, 5.0), (8.0, 5.0))
+
+    dpr._synthesize_crossing_tail(_SealedPathfinder(), head, goal, 0, [])
+    capsys.readouterr()
+
+    assert dpr._census_elapsed_s == 0.0
+    assert dpr._census_records[0].census_s == 0.0


### PR DESCRIPTION
## Summary

First slice of #4799: turn the **existing, already-computed** diff-pair
crossing-tail legality census (#4580, budget-corrected in #4635) into a
**structured, aggregated, report-only** surface, instead of free text emitted
one crossover at a time on stdout.

This is deliberately **not** a pre-route predictor. As the curated body sets
out, the census's legality checks consult order-dependent state (drills placed
by earlier crossovers, the escape-channel registry keyed on which nets are
still unrouted) and require the pair's own guide route, so a true pre-route
hoist is an open design question and stays out of scope. What is buildable —
and what this PR does — is capture the measurement that already exists, as data.

Zero behaviour change to routing: the capture appends **after** the #4635
budget credit is stamped, so it sits in the same uncredited, bounded
per-crossover tail as the census's own `print` calls. No deadline moves, no
candidate choice changes, no exit code depends on it.

## Changes

- **`src/kicad_tools/router/crosstail_census.py` (new)** — `CrossingTailCensusRecord`
  (`net_name`, `head`, `goal`, `legal`, `total`, `distinct_v1`, `census_s` plus
  the derived `saturated` / `no_ordering_lever`), `CrossingTailCensusSummary`
  (counts, `saturated_pct`, `no_ordering_lever_pct` **over the unsaturated
  set**, their union as `inert_pct`, `distinct_v1_max`, `census_s_total`, an
  advisory `verdict`), a process-wide `CrossingTailCensusCollector`, and the
  JSON writer + env-gated exit flush.
- **`diffpair_routing.py`** — `DiffPairRouter._collect_crossing_tail_census`
  called from the census path in `_synthesize_crossing_tail`, a per-instance
  `_census_records` list (reset per `route_all_with_diffpairs` call), and a
  `[crosstail-census-summary]` block printed at the end of the diff-pair phase
  when `KCT_CROSSTAIL_CENSUS=1`. The census's own header/print code is
  untouched.
- **`KCT_CROSSTAIL_CENSUS_REPORT=<path>`** — writes the JSON document at
  interpreter exit. Env var rather than `kct route --census-report` because the
  only caller that exercises this path today is `boards/06-diffpair-test`'s
  `generate_design.py --step route`, a board script driving the router API
  directly; a CLI flag would be unreachable from the one run that produces
  data. The document follows the `--format json` conventions (single document,
  sorted keys, `schema_version` / `generated_at`) so a future CLI surface can
  emit it unchanged.
- **No-clobber rule** (found while measuring board-06, second commit) — board
  scripts shell out and children inherit the env var, so every child reached
  the exit hook with nothing measured and overwrote the parent's real report
  with its own "0 crossovers scanned" document, invisibly (child stderr is
  captured). An empty flush now stands down when the target already holds a
  report with records.
- **Docs** — new `docs/reference/crosstail-census-report.md` (schema, verdict
  table, documented threshold, cost, the explicit "not applicable ≠ zero"
  section), linked from `docs/README.md` and pointed to from
  `boards/06-diffpair-test/README.md`. `CHANGELOG.md` under `[Unreleased] ### Added`.

## Acceptance criteria verification

- [x] **Report-only, zero behaviour change** — the capture runs after the
  #4635 credit is stamped; `test_capture_does_not_change_the_route_that_ships`
  asserts the censused tail is via-for-via and segment-for-segment the
  un-instrumented one, and
  `test_capture_does_not_disturb_the_4635_budget_credit` /
  `test_saturated_crossover_still_credits_zero` re-assert the credit invariant
  against the new code. Nothing branches on `verdict`; no exit code changes.
- [x] **Structured JSON + human-readable output** — JSON document (schema in
  the new reference doc) plus the `[crosstail-census-summary]` block.
- [x] **Reproduces the board-06 census figure through the new report path** —
  see the run below: **166 crossovers, 150 saturated (90.4%)**, credited census
  time **1.279972 s**. Both match what `boards/06-diffpair-test/README.md`
  already documents from the free-text census (150/166 = 90.4%, 1.28 s
  credited), reproduced rather than re-derived. **Note for the reviewer:** the
  curated body quotes "117/123 = 95%"; that figure does not appear anywhere in
  the repo and is not reproducible on current `main`. The documented,
  reproducible figure is 150/166 = 90.4% (the README's own 2026-08-04
  measurement), which the report matches exactly on both the count and the
  credited seconds.
- [x] **Unit tests on the report format** — `tests/test_crosstail_census_report_4799.py`
  (32 tests), all fabricated-record based, no board fixture required.
- [x] **Bounded, documented runtime** — see Timing below.
- [x] **Boards 05 / 07 report "not applicable, 0 crossovers scanned"** — see
  Board 05 / 07 below.
- [x] **Generic library capability** — a router module + an env-gated report,
  not a board-specific hack. No board `generate_design.py` was modified.
- [x] **`CHANGELOG.md` entry**.

## Board-06 run (the measurement)

```
KCT_CROSSTAIL_CENSUS=1 KCT_BOARD06_SHADOW=1 PYTHONHASHSEED=42 \
KCT_CROSSTAIL_CENSUS_REPORT=/tmp/board06-census.json \
  uv run python boards/06-diffpair-test/generate_design.py --step route --seed 42
```

Console block (verbatim):

```
[crosstail-census-summary] 166 crossover(s) scanned, verdict=saturated
[crosstail-census-summary]   saturated (legal=0): 150/166 (90.4%)
[crosstail-census-summary]   no ordering lever (legal>0, distinct_v1<=1): 7/16 (43.8% of unsaturated)
[crosstail-census-summary]   inert (no ordering key could change the outcome): 94.6%
[crosstail-census-summary]   distinct_v1 max=6 credited census_s total=1.2800
[crosstail-census-summary]   advisory: inert >= 90.0% -- ordering levers are inert; the constraint is upstream in placement / escape planning (non-blocking)
```

JSON summary block (166 per-crossover records elided):

```json
{
  "applicable": true,
  "census_s_total": 1.279972,
  "crossovers_scanned": 166,
  "distinct_v1_max": 6,
  "inert_pct": 94.6,
  "no_ordering_lever": 7,
  "no_ordering_lever_pct": 43.8,
  "saturated": 150,
  "saturated_pct": 90.4,
  "saturated_threshold_pct": 90.0,
  "unsaturated": 16,
  "verdict": "saturated"
}
```

The routed board artifacts produced by this run were reverted; the PR contains
no board output.

## Timing

| Quantity | Measured |
|---|---|
| New capture path, per crossover | **1.14 µs** (20 000 iterations through `_collect_crossing_tail_census`) |
| New capture path, whole board-06 run (166 crossovers) | **~0.19 ms** |
| Aggregate summary over 166 records | **18 µs**, once |
| The census it wraps (credited incremental cost) | **1.28 s** on board-06 |
| Full board-06 `--step route` (shadow-ON, census-ON) | **1424 s** |

So the report costs ~0.0000133% of the census it aggregates and ~0.00000013%
of the route — the "leading indicator must not cost as much as the thing it
avoids" criterion is satisfied by six orders of magnitude on both comparisons.
The JSON document is written once, at exit.

## Boards 05 and 07: "not applicable", not "0% saturated"

Both were run **for real** (not smoke-imported) with the report enabled, and
both exit 0 with an honest document:

| Board | Command | Wall clock | Report |
|---|---|---|---|
| 05 | `design.py <outdir>` (full pipeline) | 1909.8 s | `crossovers_scanned: 0`, `applicable: false`, `verdict: "not-applicable"` |
| 07 | `generate_design.py --step route --seed 42` | 2027.2 s | `crossovers_scanned: 0`, `applicable: false`, `verdict: "not-applicable"` |

That is the correct answer, not a bug: board-05 has no differential pairs, and
board-07 never calls `route_all_with_diffpairs`, so neither exercises the
shadow-constructed crossover path. The summary deliberately distinguishes this
from `saturated_pct: 0.0` (which would read as a clean bill of health for a
board that was never measured) — `applicable: false` and the
`not-applicable` verdict are asserted by unit tests and documented in the
reference doc's "Not applicable ≠ zero" section.

Board-07's run also surfaced the child-process clobber described above (its
`kct`/helper subprocesses each flush at exit), which the second commit fixes.
The routed artifacts both runs produced were reverted / written to a scratch
directory; the PR contains no board output.


## Test plan

```
uv run pytest tests/test_crosstail_census_report_4799.py -q      # 32 passed
uv run pytest tests/ -k diffpair -q                              # 931 passed, 1 skipped
uv run pytest tests/test_docs_source_citations.py tests/test_machine_output_idiom.py \
             tests/test_format_json_sweep.py -q                  # 122 passed
uv run ruff format --check .                                     # clean (ruff 0.16.2)
uv run ruff check <changed files>                                # clean
rm -rf .mypy_cache && uv run python scripts/ci/check_mypy_baseline.py
#   OK: 1466 error(s), all within the baseline (1472 allowed). No new type errors.
```

## Explicitly out of scope (follow-up, per the curated body)

1. A genuine pre-any-A*-expansion predictor (the order-dependency /
   guide-route-prerequisite question).
2. Generalizing the measurement beyond diff-pair crossing tails — in
   particular, #3438's board-07 pad-array bundle congestion is a structurally
   different failure mode this census cannot see, and this PR does not claim
   otherwise.
3. Wiring `verdict` / `saturated_pct` into an actual routing go/no-go or
   steering decision.
4. Calibrating the threshold against #4830's open-schematics corpus.

Part of #4799
