### PR TITLE
fix(tests): drop the nested `uv run` from the board-06 strict-gate fixture

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -773,6 +773,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **The board-06 strict-gate test fixture no longer shells out through a nested
+  `uv run`** (#4853) — `TestBoard06StrictGateGuard`'s class-scoped
+  `strict_gate_result` fixture ran `uv run kct check …` from inside a test.
+  `uv run` re-syncs the project environment before exec'ing, and CI installs
+  with `uv sync --frozen --extra dev` while the nested call resolves the
+  *default* extras — so the inner invocation churned dev packages out from
+  under the running `pytest -n auto` session, at an unbounded and partly
+  network-dependent cost. That variance pushed the fixture past CI's
+  `--timeout=60` reaper, erroring all three tests (the class scope charges the
+  whole subprocess to the first test's setup) and turning `main` and every open
+  PR red on a signature attributable to no diff. The fixture now invokes
+  `[sys.executable, "-m", "kicad_tools.cli", "check", …]` — the same command in
+  the already-resolved interpreter, with no resolve/sync step. The class also
+  carries `@pytest.mark.timeout(180)` so the timeout the fixture already asked
+  of `subprocess.run` is the one that actually applies (a marker takes
+  precedence over the command-line `--timeout`), instead of being silently
+  capped at a third of it. Test-only change; no library behavior is affected.
+
 - **A lattice escalation attempt no longer gets the whole run's wall-clock
   budget as its cap** (#4798) — every other routing engine receives its
   escalation attempt's fair slice as `timeout=_per_attempt_budgeted_timeout(…)`

--- a/tests/test_board_06_diffpair_test.py
+++ b/tests/test_board_06_diffpair_test.py
@@ -699,6 +699,14 @@ class TestManufacturabilityFloor:
 # =============================================================================
 
 
+# Issue #4853: the ``strict_gate_result`` fixture below budgets 180 s for its
+# ``kct check`` subprocess, but CI runs ``pytest ... --timeout=60``, so
+# pytest-timeout reaped the fixture at 60 s and the stated budget was
+# unreachable.  A ``timeout`` marker takes precedence over the command-line
+# value, so this makes the two numbers agree at the fixture's stated 180 s.
+# The class scope means the whole subprocess cost is charged to the FIRST
+# test's setup; the tests themselves are pure assertions over the parsed JSON.
+@pytest.mark.timeout(180)
 class TestBoard06StrictGateGuard:
     """Issue #3338 -- pin the strict CI gate's blocking-error count on the
     committed routed PCB so a future artifact refresh that drifts on the
@@ -899,10 +907,21 @@ class TestBoard06StrictGateGuard:
                 "PR #3273 trap re-opens."
             )
 
+            # Issue #4853: invoke the CLI in the interpreter that is ALREADY
+            # running this test rather than shelling out to ``uv run kct``.
+            # A nested ``uv run`` re-syncs the project environment before
+            # exec'ing, and CI installs with ``uv sync --extra dev`` while
+            # the nested call resolves the DEFAULT extras -- so it churns
+            # (and can uninstall) dev packages out from under the running
+            # ``pytest -n auto`` session.  That unbounded, partly
+            # network-dependent cost is what pushed this fixture past CI's
+            # ``--timeout=60`` reaper and turned ``main`` red.  ``kct`` is a
+            # console script for ``kicad_tools.cli:main``, so
+            # ``-m kicad_tools.cli`` runs the identical command.
             cmd = [
-                "uv",
-                "run",
-                "kct",
+                sys.executable,
+                "-m",
+                "kicad_tools.cli",
                 "check",
                 str(routed_pcb),
                 "--mfr",


### PR DESCRIPTION
## Summary

Hotfix for a red `main`. The class-scoped `strict_gate_result` fixture in
`tests/test_board_06_diffpair_test.py` shelled out to a **nested `uv run kct check`**
from inside a test. Two lines change what it executes and what timeout applies to it.

```diff
-            cmd = [
-                "uv",
-                "run",
-                "kct",
-                "check",
+            cmd = [
+                sys.executable,
+                "-m",
+                "kicad_tools.cli",
+                "check",
```

plus `@pytest.mark.timeout(180)` on `TestBoard06StrictGateGuard`.

Closes #4853

## Why the nested `uv run` was the fault

`uv run` **re-syncs the project environment before exec'ing**. The CI Test job
installs with `uv sync --frozen --extra dev` (`.github/workflows/ci.yml:131`) and
then runs `uv run pytest -n auto -o addopts= --benchmark-disable --timeout=60 -m "not slow"`
(line 154). The nested call inside the fixture carried **no `--extra dev`**, so it
resolved the *default* extras — churning (and potentially uninstalling) dev
packages, including `pytest-xdist`/`pytest-timeout`, out from under the running
pytest session. That cost is unbounded and partly network-dependent, and has
nothing to do with what `kct check` computes.

`kct` is a console script for `kicad_tools.cli:main`, so
`[sys.executable, "-m", "kicad_tools.cli", "check", …]` runs the identical
command in the interpreter pytest is already running in — same arguments, same
JSON on stdout, same `returncode in (0, 2)` contract, no resolve/sync step.

## The two timeouts now agree

The fixture passes `timeout=180` to `subprocess.run`, but CI's `--timeout=60`
reaped it at 60 s, so its stated budget was unreachable — the mismatch the issue
called out. A `timeout` **marker takes precedence over the command-line value**
in pytest-timeout, verified empirically both on a scratch reproduction and on
this class (see the `--timeout=1` run below). With the marker, the 180 s the
fixture already asks for is the number that actually applies.

The class scope means the entire subprocess cost lands in the *first* test's
setup, which is why one overrun errored all three tests; the tests themselves
are pure assertions over the parsed JSON.

## Timed verification (in-worktree, macOS)

| Run | Command | Result |
|---|---|---|
| **Before** | `pytest tests/test_board_06_diffpair_test.py -k StrictGateGuard --timeout=60 -q` | 3 passed in **20.96 s** |
| **After** | `pytest tests/test_board_06_diffpair_test.py -k StrictGateGuard --timeout=60 -q` | 3 passed in **20.09 s** |
| **After**, CI's exact flags | `pytest tests/test_board_06_diffpair_test.py -n auto -o addopts= --benchmark-disable --timeout=60 -m "not slow" -q` | **48 passed in 23.68 s** |
| **After**, marker-override proof | `pytest … -k StrictGateGuard -o addopts= --timeout=1 -q` | 3 passed in **20.12 s** (would have been reaped at 1 s without the marker) |

The `--timeout=1` run is the load-bearing one: the reaper can no longer fire on
runner slowness, because the applicable cap is now 180 s rather than 60 s. Wall
time is unchanged locally (`uv run` overhead is ~0 when the env is already
resolved and no extras conflict — the pathological case is exactly CI's
dev-extras split, which is what this removes).

Also ran, clean: `ruff check` + `ruff format --check` on the touched file
(ruff 0.16.2), and `scripts/ci/check_mypy_baseline.py` (1466 errors, within the
1472 baseline — **no baseline edits**; the 6 "no longer occur" entries are
pre-existing and untouched).

## Scope

Two files: the test fixture and a CHANGELOG entry under `[Unreleased] ### Fixed`.
No source/library change.

I checked for sibling instances of the same pattern:

- `tests/test_kct_check_parity.py:168` (`_run_kct_check`) has the identical
  nested `uv run`, but both of its consumers (`TestBoard07KctCheckParity`,
  `TestCiGateCountsGatedFamilies`) are `@pytest.mark.slow`, so the Test job's
  `-m "not slow"` excludes them — not part of this outage. Left alone to keep
  the hotfix minimal.
- `scripts/ci/check_routed_drc.py`, `check_matchgroup_coverage.py`,
  `check_diffpair_coverage.py` also use `uv run`, but they are standalone CI
  scripts, not run inside a pytest session under a `--timeout` reaper. Correct
  as-is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
