### PR TITLE
fix(mcp): wire --transport http host/port through the FastMCP constructor

### DIFF
--- a/src/kicad_tools/mcp/server.py
+++ b/src/kicad_tools/mcp/server.py
@@ -211,11 +211,21 @@ def create_server() -> MCPServer:
     return MCPServer()
 
 
-def create_fastmcp_server(http_mode: bool = False) -> FastMCP:
+def create_fastmcp_server(
+    http_mode: bool = False,
+    host: str | None = None,
+    port: int | None = None,
+) -> FastMCP:
     """Create a FastMCP server with all tools registered from the unified registry.
 
     Args:
         http_mode: If True, creates server in stateless HTTP mode.
+        host: Bind address for HTTP transports. FastMCP's own default
+            (``127.0.0.1``) is used when omitted. ``host``/``port`` are
+            constructor arguments in the MCP SDK -- ``FastMCP.run()`` does not
+            accept them -- so they must be supplied here.
+        port: Bind port for HTTP transports. FastMCP's own default (``8000``)
+            is used when omitted.
 
     Returns:
         Configured FastMCP server instance.
@@ -230,7 +240,13 @@ def create_fastmcp_server(http_mode: bool = False) -> FastMCP:
             "FastMCP is required for HTTP transport. Install with: pip install 'kicad-tools[mcp]'"
         ) from e
 
-    mcp = FastMCP("kicad-tools", stateless_http=http_mode)
+    settings: dict[str, Any] = {}
+    if host is not None:
+        settings["host"] = host
+    if port is not None:
+        settings["port"] = port
+
+    mcp = FastMCP("kicad-tools", stateless_http=http_mode, **settings)
 
     # Register all tools from the unified registry
     for tool_name, tool_spec in TOOL_REGISTRY.items():
@@ -297,10 +313,11 @@ def run_server(
         server = create_server()
         server.run()
     elif transport == "http":
-        # Use FastMCP for HTTP transport
-        mcp = create_fastmcp_server(http_mode=True)
+        # Use FastMCP for HTTP transport. host/port are constructor arguments
+        # in the MCP SDK; FastMCP.run() only accepts transport/mount_path.
+        mcp = create_fastmcp_server(http_mode=True, host=host, port=port)
         logger.info(f"Starting HTTP MCP server on {host}:{port}")
-        mcp.run(transport="streamable-http", host=host, port=port)
+        mcp.run(transport="streamable-http")
     else:
         raise ValueError(f"Unknown transport: {transport}. Use 'stdio' or 'http'.")
 

--- a/tests/test_mcp_http.py
+++ b/tests/test_mcp_http.py
@@ -65,6 +65,44 @@ class TestFastMCPServerCreation:
         for tool_name in expected_tools:
             assert tool_name in tool_names, f"Tool {tool_name} not registered"
 
+    def test_create_fastmcp_server_defaults_host_port(self):
+        """Omitting host/port leaves the FastMCP SDK defaults untouched."""
+        pytest.importorskip("mcp")
+        from kicad_tools.mcp.server import create_fastmcp_server
+
+        mcp = create_fastmcp_server(http_mode=True)
+
+        # SDK defaults: 127.0.0.1:8000 -- we must not silently override them.
+        assert mcp.settings.host == "127.0.0.1"
+        assert mcp.settings.port == 8000
+
+    def test_create_fastmcp_server_custom_host_port(self):
+        """host/port are forwarded to the FastMCP constructor (not run())."""
+        pytest.importorskip("mcp")
+        from kicad_tools.mcp.server import create_fastmcp_server
+
+        mcp = create_fastmcp_server(http_mode=True, host="127.0.0.1", port=8792)
+
+        assert mcp.settings.host == "127.0.0.1"
+        assert mcp.settings.port == 8792
+        assert mcp.settings.stateless_http is True
+
+    def test_fastmcp_run_signature_rejects_host_port(self):
+        """Regression guard: FastMCP.run() takes no host/port kwargs.
+
+        This is the API fact that made ``kct mcp --transport http`` raise
+        TypeError. If a future SDK adds them back, this test fails loudly so
+        the wiring can be revisited deliberately.
+        """
+        pytest.importorskip("mcp")
+        import inspect
+
+        from mcp.server.fastmcp import FastMCP
+
+        params = inspect.signature(FastMCP.run).parameters
+        assert "host" not in params
+        assert "port" not in params
+
     def test_fastmcp_import_error(self, monkeypatch):
         """Test ImportError when fastmcp is not installed."""
         import sys
@@ -91,6 +129,18 @@ class TestFastMCPServerCreation:
         # by checking the function raises ImportError when mcp is unavailable
 
 
+class _FakeFastMCP:
+    """Minimal stand-in for FastMCP that records how run() was called."""
+
+    def __init__(self):
+        self.run_calls = []
+
+    def run(self, transport="stdio", mount_path=None):
+        # Mirrors mcp.server.fastmcp.FastMCP.run's signature exactly: any
+        # host/port kwarg would raise TypeError here, just like the real SDK.
+        self.run_calls.append({"transport": transport, "mount_path": mount_path})
+
+
 class TestRunServerFunction:
     """Tests for run_server function."""
 
@@ -100,6 +150,169 @@ class TestRunServerFunction:
 
         with pytest.raises(ValueError, match="Unknown transport"):
             run_server(transport="invalid")
+
+    def test_run_server_http_passes_host_port_to_constructor(self, monkeypatch):
+        """run_server's HTTP branch wires host/port at construction time."""
+        from kicad_tools.mcp import server as server_module
+
+        fake = _FakeFastMCP()
+        created = {}
+
+        def fake_create(http_mode=False, host=None, port=None):
+            created.update({"http_mode": http_mode, "host": host, "port": port})
+            return fake
+
+        monkeypatch.setattr(server_module, "create_fastmcp_server", fake_create)
+
+        server_module.run_server(transport="http", host="0.0.0.0", port=9123)
+
+        assert created == {"http_mode": True, "host": "0.0.0.0", "port": 9123}
+        # run() must be called with transport only -- no host/port kwargs.
+        assert fake.run_calls == [{"transport": "streamable-http", "mount_path": None}]
+
+    def test_run_server_http_does_not_raise_type_error(self, monkeypatch):
+        """Regression for #4855: the HTTP branch reached mcp.run with bad kwargs.
+
+        Uses a real FastMCP instance (so the real run() signature applies) with
+        run() stubbed out, guaranteeing no socket is bound.
+        """
+        pytest.importorskip("mcp")
+        from kicad_tools.mcp import server as server_module
+
+        calls = []
+
+        mcp_instance = server_module.create_fastmcp_server(
+            http_mode=True, host="127.0.0.1", port=8792
+        )
+
+        def capture_run(*args, **kwargs):
+            calls.append((args, kwargs))
+
+        monkeypatch.setattr(mcp_instance, "run", capture_run)
+        monkeypatch.setattr(
+            server_module,
+            "create_fastmcp_server",
+            lambda http_mode=False, host=None, port=None: mcp_instance,
+        )
+
+        # Would have raised TypeError before the fix.
+        server_module.run_server(transport="http", host="127.0.0.1", port=8792)
+
+        assert calls == [((), {"transport": "streamable-http"})]
+        assert mcp_instance.settings.host == "127.0.0.1"
+        assert mcp_instance.settings.port == 8792
+
+    def test_run_server_stdio_unaffected(self, monkeypatch):
+        """The stdio path still uses MCPServer and never touches FastMCP."""
+        from kicad_tools.mcp import server as server_module
+
+        ran = []
+
+        class FakeStdioServer:
+            def run(self):
+                ran.append("stdio")
+
+        monkeypatch.setattr(server_module, "create_server", lambda: FakeStdioServer())
+
+        def explode(*args, **kwargs):  # pragma: no cover - must never run
+            raise AssertionError("stdio transport must not construct FastMCP")
+
+        monkeypatch.setattr(server_module, "create_fastmcp_server", explode)
+
+        server_module.run_server(transport="stdio")
+
+        assert ran == ["stdio"]
+
+
+@pytest.mark.slow
+class TestHTTPTransportSmoke:
+    """End-to-end smoke test of `run_server(transport='http', ...)`.
+
+    Binds a real loopback socket on an ephemeral port in a subprocess, so it is
+    marked slow and kept out of the fast unit suite.
+    """
+
+    def test_http_server_serves_initialize_and_tools_list(self):
+        pytest.importorskip("mcp")
+        pytest.importorskip("uvicorn")
+        httpx = pytest.importorskip("httpx")
+
+        import json
+        import socket
+        import subprocess
+        import sys
+        import time
+
+        # Reserve an ephemeral port, then release it for the server to claim.
+        with socket.socket() as probe:
+            probe.bind(("127.0.0.1", 0))
+            port = probe.getsockname()[1]
+
+        proc = subprocess.Popen(
+            [
+                sys.executable,
+                "-c",
+                "from kicad_tools.mcp.server import run_server; "
+                f"run_server(transport='http', host='127.0.0.1', port={port})",
+            ],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+        )
+
+        url = f"http://127.0.0.1:{port}/mcp"
+        headers = {
+            "Content-Type": "application/json",
+            "Accept": "application/json, text/event-stream",
+        }
+        initialize = {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "initialize",
+            "params": {
+                "protocolVersion": "2025-06-18",
+                "capabilities": {},
+                "clientInfo": {"name": "kicad-tools-test", "version": "1"},
+            },
+        }
+
+        try:
+            deadline = time.time() + 60
+            response = None
+            while time.time() < deadline:
+                if proc.poll() is not None:
+                    output = proc.stdout.read() if proc.stdout else ""
+                    pytest.fail(f"MCP HTTP server exited early:\n{output}")
+                try:
+                    response = httpx.post(url, json=initialize, headers=headers, timeout=5)
+                    break
+                except httpx.HTTPError:
+                    time.sleep(0.5)
+
+            assert response is not None, "server never accepted a connection"
+            assert response.status_code == 200
+            assert "serverInfo" in response.text
+
+            tools_list = {"jsonrpc": "2.0", "id": 2, "method": "tools/list", "params": {}}
+            tools_response = httpx.post(url, json=tools_list, headers=headers, timeout=30)
+            assert tools_response.status_code == 200
+
+            payloads = [
+                json.loads(line[len("data: ") :])
+                for line in tools_response.text.splitlines()
+                if line.startswith("data: ")
+            ]
+            assert payloads, f"no SSE data frames in response: {tools_response.text[:200]}"
+            tool_names = {tool["name"] for tool in payloads[0]["result"]["tools"]}
+            assert "export_gerbers" in tool_names
+            assert "measure_clearance" in tool_names
+        finally:
+            proc.terminate()
+            try:
+                proc.wait(timeout=10)
+            except subprocess.TimeoutExpired:  # pragma: no cover - defensive
+                proc.kill()
+                proc.wait(timeout=10)
 
 
 class TestMCPCLIParser:


### PR DESCRIPTION
Closes #4855

## Problem

`kct mcp --transport http` raised `TypeError` before serving a single request:

```python
mcp.run(transport="streamable-http", host=host, port=port)  # server.py:303
```

The class imported at `src/kicad_tools/mcp/server.py` is the official MCP SDK's
`mcp.server.fastmcp.FastMCP`, whose `run()` signature is
`(self, transport='stdio', mount_path=None)`. `host`/`port` are
**constructor** arguments (`FastMCP.__init__`, defaults `127.0.0.1` / `8000`)
— verified against the installed `mcp==1.25.0`/`1.28.1`.

## Fix (Option A from the issue — feature retained)

- `create_fastmcp_server(http_mode=False, host=None, port=None)` forwards
  `host`/`port` to the `FastMCP(...)` constructor only when provided, so the
  SDK defaults are untouched for existing callers (kwargs are built into a
  dict rather than passed as `None`).
- `run_server`'s HTTP branch now constructs with `host`/`port` and calls
  `mcp.run(transport="streamable-http")` with no extra kwargs.
- The stdio branch is byte-identical (`create_server()` → `server.run()`).
- No CLI changes: `parser.py` and `cli/commands/mcp.py` already passed
  `host`/`port` into `run_server` correctly.

## Tests

`tests/test_mcp_http.py` previously only exercised `create_fastmcp_server`
construction — the `run_server` HTTP branch was never executed, which is why
the bug shipped. Added:

- `test_create_fastmcp_server_defaults_host_port` — omitting host/port leaves
  the SDK defaults (`127.0.0.1:8000`) untouched.
- `test_create_fastmcp_server_custom_host_port` — constructor-level assertion
  on `mcp.settings.host` / `.port` / `.stateless_http` (no sockets bound).
- `test_run_server_http_passes_host_port_to_constructor` — fake FastMCP whose
  `run()` mirrors the real signature exactly, so a stray host/port kwarg would
  raise `TypeError`.
- `test_run_server_http_does_not_raise_type_error` — direct regression: real
  FastMCP instance with `run` stubbed; asserts `run` is called with
  `transport="streamable-http"` only.
- `test_run_server_stdio_unaffected` — stdio must never construct FastMCP.
- `test_fastmcp_run_signature_rejects_host_port` — guard that fails loudly if a
  future SDK re-adds host/port to `run()`.
- `TestHTTPTransportSmoke` (`@pytest.mark.slow`) — end-to-end: starts
  `run_server(transport='http', host='127.0.0.1', port=<ephemeral>)` in a
  subprocess, POSTs an MCP `initialize` (expects HTTP 200 + `serverInfo`) and
  `tools/list` (expects the registry tool set), then terminates the process.
  Slow-marked because it binds a real socket; the fast unit suite binds none.

## Evidence

```
$ uv run pytest tests/test_mcp_http.py -q -o addopts= --no-cov -m ""
21 passed

$ uv run pytest tests -k mcp -q -o addopts= --no-cov
561 passed, 1 skipped, 25940 deselected in 32.20s

$ uv run ruff check src tests           # All checks passed!
$ uv run ruff format --check src tests  # 1734 files already formatted
$ uv run python scripts/ci/check_mypy_baseline.py
OK: mypy reports 1464 error(s), all within the baseline (1472 allowed).
```

Manual acceptance-criteria check against a live server on the fixed code:
`initialize` → HTTP 200, `serverInfo.name = kicad-tools`; `tools/list` → HTTP
200 with 38 tools.

Note: `tests/test_mcp_routing.py::TestRouteNetAuto::test_route_net_auto_routes_multi_pad_net`
failed on the first run in the fresh worktree *before* the C++ router
extension was built (Python-fallback routing succeeded where the test expects
a partial). It passes after `uv run kct build-native`, and passes on `main` at
the same commit — unrelated to this diff.