### PR TITLE
feat(placement): score the optimizer objective on pad-anchored wirelength (#4831 M1)

### DIFF
--- a/docs/placement-pad-anchoring-audit.md
+++ b/docs/placement-pad-anchoring-audit.md
@@ -7,6 +7,16 @@
 migration candidate below is a *stub for a future issue*, listed in this
 document rather than filed (issue creation is serialized in this repo).
 
+> **Status update (2026-08-14, later the same day): M1 has landed.**
+> `compute_wirelength` and `evaluate_placement` now accept an optional
+> `pad_positions` map (built by `build_pad_position_map`,
+> `src/kicad_tools/placement/wirelength.py`), and
+> `kct optimize-placement --pad-anchored-wirelength` supplies it from the
+> pads the CLI already decoded. It is **opt-in**: with no map the score is
+> byte-identical to the centre-anchored objective. The line-number citations
+> below describe the tree *as audited*; `cost.py` line numbers shifted by the
+> M1 patch. M2-M5 are unchanged and still unfiled.
+
 ## Why this audit exists
 
 pcbplace (a generative placement engine described to the owner; see #4831 for
@@ -261,7 +271,21 @@ this audit. Benefit rationale is grounded in (a) pcbplace's reported
 59.5 → 12.7 mm wiring reduction from pad anchors, and (b) the first-party
 divergence measured in §4 — with the honest caveat from §4 attached to both.
 
-### M1 — Wire `compute_hpwl` into `evaluate_placement`
+### M1 — Wire `compute_hpwl` into `evaluate_placement` — **LANDED (opt-in)**
+
+> **Shipped as:** `kct optimize-placement --pad-anchored-wirelength` plus the
+> `pad_positions` argument on `compute_wirelength` / `evaluate_placement`.
+> Implementation note: rather than calling `compute_hpwl` directly (which
+> would have dropped `Net.weight`, and which `cost.py` cannot import without
+> a cycle — `wirelength.py` imports `cost.py`), the pad coordinates are
+> passed *into* `compute_wirelength` as a `(reference, pad_name) -> (x, y)`
+> map. That keeps per-net weighting, keeps one net-iteration code path, and
+> adds per-pin fallback to the component centre. The counter-note below about
+> silently dropping `Net.weight` is therefore **resolved, not carried**.
+> Remaining M1 surface, deliberately deferred: the MCP front-end
+> (`src/kicad_tools/mcp/tools/optimize_placement.py`) still discards its
+> pads, and pad anchoring is opt-in rather than the default — flipping the
+> default needs fleet evidence (see M5).
 
 > **Stub title:** `feat(placement): score the optimizer objective on pad-anchored HPWL`
 > **Scope:** give `evaluate_placement` (`cost.py:715`) access to transformed pads
@@ -405,7 +429,7 @@ to standardise on, kept clearly distinct from the "locked/immovable" sense above
 
 | Stub | Title | Depends on |
 |---|---|---|
-| M1 | `feat(placement): score the optimizer objective on pad-anchored HPWL` | — (carry `Net.weight` through) |
+| M1 | `feat(placement): score the optimizer objective on pad-anchored HPWL` | **LANDED opt-in** (`--pad-anchored-wirelength`); MCP front-end + default-on remain |
 | M2 | `refactor(placement): use pad HPWL at multi-fidelity level 1, where pads are already required` | — (low risk, good pathfinder for M1) |
 | M3 | `feat(optim): allow max_distance constraints to target a pad, not a component centre` | overlaps #4831 item 4 |
 | M4 | `fix(optim): pick the shared-net pad instead of pins[0] for cluster springs` | M1 (only if `optim` stays in use) |

--- a/docs/placement-scoring.md
+++ b/docs/placement-scoring.md
@@ -91,6 +91,35 @@ decoded current vector (verified by
   rather than a random population; otherwise CMA-ES searches a layout space
   disconnected from your placement and can regress wirelength substantially.
 
+## What the wirelength term measures: centres vs pads (issue #4831 M1)
+
+The objective's wirelength term (`compute_wirelength`,
+`src/kicad_tools/placement/cost.py`) historically measured every pin at its
+**component centre**. Two consequences worth knowing before reading a score:
+
+- **Rotation is invisible to it.** Only `p.x`/`p.y` are read, so rotating a
+  footprint changes the centre-anchored wirelength by exactly zero — even
+  though the optimizer is searching that rotation dimension.
+- **A pin is scored where the part is, not where the pad is.** On a large IC
+  the error is bounded below by half the package diagonal: a decap "5 mm from
+  the chip centre" can be ~10 mm of copper from the pad it decouples.
+
+Passing `--pad-anchored-wirelength` (CLI) or the `pad_positions` argument of
+`compute_wirelength` / `evaluate_placement` (library) measures each pin at its
+own transformed pad instead. Pads are already produced by every candidate
+decode and thrown away, so the added cost is one dict build per evaluation.
+Resolution is per pin — a pin absent from the map falls back to its component
+centre, so partial pad data degrades gracefully instead of dropping the net.
+Per-net `Net.weight` (the `--anchor-weight` mechanism) is honoured in both
+modes.
+
+This is **opt-in**: with no `pad_positions` the score is byte-identical to the
+historical objective. It is not a rescaling — the two estimators differ by
+0.2 % to 40 % on the *same* layout across this repo's placement fixtures, so
+they can rank two candidate layouts differently. Background, the full
+term-by-term inventory, and the remaining migration candidates are in
+[`placement-pad-anchoring-audit.md`](placement-pad-anchoring-audit.md).
+
 ## HV-aware placement: the creepage-keepout term (issue #4373)
 
 By default the optimizer objective is **voltage-blind**: the wirelength term

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -949,6 +949,7 @@ kct optimize-placement <pcb_file> [options]
 | `--checkpoint DIR` | Directory for checkpoint save/resume |
 | `--no-slide-off` | Disable slide-off overlap pre-processing on the seed |
 | `--anchor-weight FLOAT` | Per-net HPWL multiplier boost for nets that touch `(locked)` footprints. Scales each qualifying net's HPWL by `1 + anchor_weight * (anchored_pins / total_pins)`. **Default 0.0**. |
+| `--pad-anchored-wirelength` | Measure the wirelength term between transformed **pad** coordinates instead of footprint centres (issue #4831 M1). **Default off** — the objective is unchanged unless you pass it. |
 | `--time-budget SEC` | Wall-clock budget (bounds the feasibility-gated convergence loop) |
 | `--allow-infeasible` | Exit 0 even when overlap/DRC/boundary violations remain |
 | `-v` / `-q` | Verbose / quiet |
@@ -960,6 +961,19 @@ uses `--anchor-weight 1.0` — the help-text range is the conservative knob
 designers would reach for; `1.0` is the value that actually lifted board-05
 BLDC from 40% → 60% routing completion in practice. Treat help text as the
 ceiling and the guide as the proven floor.
+
+**Pad-anchored wirelength (`--pad-anchored-wirelength`, issue #4831 M1).**
+By default every net's HPWL is measured between footprint *centres*, so the
+term is blind to where a pad actually sits — and blind to rotation entirely,
+since rotating a part leaves its centre unchanged. The flag measures each pin
+at its own transformed pad instead (pads are already computed for every
+candidate and thrown away today, so the added cost is one dict build per
+evaluation). Per-pin fallback: a pin with no pad in the map is still measured
+at its component centre, so partial pad data degrades rather than dropping the
+net. On this repo's own placement fixtures the two estimators differ by 0.2 %
+to 40 % on the *same* layout, so expect different — not merely rescaled —
+optimizer trajectories. See
+[`docs/placement-pad-anchoring-audit.md`](../placement-pad-anchoring-audit.md).
 
 **Feasibility gate.** By default the optimizer exits **1** with
 `FATAL: optimizer exited with infeasible placement (...)` on stderr if the

--- a/src/kicad_tools/cli/commands/optimize_placement.py
+++ b/src/kicad_tools/cli/commands/optimize_placement.py
@@ -29,6 +29,7 @@ def run_optimize_placement_command(args) -> int:
         quiet=getattr(args, "quiet", False) or getattr(args, "global_quiet", False),
         no_slide_off=getattr(args, "no_slide_off", False),
         anchor_weight=getattr(args, "anchor_weight", 0.0),
+        pad_anchored_wirelength=getattr(args, "pad_anchored_wirelength", False),
         time_budget=getattr(args, "time_budget", None),
         allow_infeasible=getattr(args, "allow_infeasible", False),
         voltage_map_path=getattr(args, "voltage_map", None),

--- a/src/kicad_tools/cli/optimize_placement_cmd.py
+++ b/src/kicad_tools/cli/optimize_placement_cmd.py
@@ -51,6 +51,7 @@ from kicad_tools.placement.vector import (
     bounds,
     decode,
 )
+from kicad_tools.placement.wirelength import build_pad_position_map
 
 # ---------------------------------------------------------------------------
 # Interrupt handling (SIGINT / SIGTERM)
@@ -180,14 +181,24 @@ def _evaluate(
     ref_domains: dict[str, str] | None = None,
     required_mm_by_domain_pair: dict[tuple[str, str], float] | None = None,
     exempt_pairs: set[frozenset[str]] | None = None,
+    pad_anchored: bool = False,
 ) -> PlacementScore:
     """Evaluate a single placement vector and return its score.
 
     When ``ref_domains`` and ``required_mm_by_domain_pair`` are supplied the
     HV creepage-keepout term (issue #4373) is active; otherwise the objective
     is byte-identical to the historical voltage-blind score.
+
+    When *pad_anchored* is True the wirelength term is measured between the
+    transformed pad coordinates ``decode`` already produces, instead of
+    between footprint centres (issue #4831 M1). ``False`` (the default)
+    discards those pads exactly as before, keeping the score unchanged.
     """
-    placements = _vector_to_placements(vector, components)
+    placed = decode(vector, components)
+    placements = [
+        ComponentPlacement(reference=p.reference, x=p.x, y=p.y, rotation=p.rotation) for p in placed
+    ]
+    pad_positions = build_pad_position_map(placed) if pad_anchored else None
     return evaluate_placement(
         placements,
         nets,
@@ -198,6 +209,7 @@ def _evaluate(
         ref_domains=ref_domains,
         required_mm_by_domain_pair=required_mm_by_domain_pair,
         exempt_pairs=exempt_pairs,
+        pad_positions=pad_positions,
     )
 
 
@@ -714,6 +726,7 @@ def run_optimize_placement(
     quiet: bool = False,
     no_slide_off: bool = False,
     anchor_weight: float = 0.0,
+    pad_anchored_wirelength: bool = False,
     time_budget: float | None = None,
     allow_infeasible: bool = False,
     voltage_map_path: str | None = None,
@@ -743,6 +756,15 @@ def run_optimize_placement(
             receive an inflated wirelength weight of
             ``1 + anchor_weight * anchor_pad_fraction``. Default 0.0
             preserves the historical uniform weighting (regression-safe).
+        pad_anchored_wirelength: When True, the wirelength term of the
+            objective is measured between the transformed **pad**
+            coordinates each candidate decode already produces, instead of
+            between footprint centres (issue #4831 M1;
+            ``docs/placement-pad-anchoring-audit.md``). This makes rotation
+            visible to wirelength -- rotating a part cannot change a
+            centre-anchored HPWL at all -- and stops a decap being scored as
+            "at the chip" when it is a package-diagonal away from the pad it
+            decouples. Default False keeps the objective byte-identical.
         time_budget: Wall-clock budget in seconds. The main optimization
             loop exits as soon as the elapsed time exceeds this value
             (after completing the current generation). ``None`` means no
@@ -889,6 +911,21 @@ def run_optimize_placement(
 
     footprint_sizes = _build_footprint_sizes(components)
 
+    # Pad-anchored wirelength (issue #4831 M1). The pads are transformed on
+    # every decode regardless; this only decides whether the objective reads
+    # them or throws them away. Warn -- rather than silently no-op -- when the
+    # board yielded no pads at all, since the per-pin fallback would then make
+    # the flag a no-op.
+    if pad_anchored_wirelength and not quiet:
+        pad_count = sum(len(c.pads) for c in components)
+        if pad_count == 0:
+            print(
+                "  WARNING: --pad-anchored-wirelength requested but no pads were "
+                "extracted; wirelength falls back to footprint centres."
+            )
+        else:
+            print(f"  Wirelength anchored to {pad_count} pads (not footprint centres)")
+
     # Compute bounds
     placement_bounds = bounds(board_outline, components)
 
@@ -930,6 +967,7 @@ def run_optimize_placement(
             ref_domains=hv_ref_domains,
             required_mm_by_domain_pair=hv_required,
             exempt_pairs=hv_exempt,
+            pad_anchored=pad_anchored_wirelength,
         )
         if not quiet:
             _print_score("Current", score)
@@ -1044,6 +1082,7 @@ def run_optimize_placement(
             ref_domains=hv_ref_domains,
             required_mm_by_domain_pair=hv_required,
             exempt_pairs=hv_exempt,
+            pad_anchored=pad_anchored_wirelength,
         )
         if not quiet:
             _print_score("Seed", seed_score)
@@ -1068,6 +1107,7 @@ def run_optimize_placement(
                 ref_domains=hv_ref_domains,
                 required_mm_by_domain_pair=hv_required,
                 exempt_pairs=hv_exempt,
+                pad_anchored=pad_anchored_wirelength,
             )
             initial_scores.append(score.total)
 
@@ -1087,6 +1127,7 @@ def run_optimize_placement(
             ref_domains=hv_ref_domains,
             required_mm_by_domain_pair=hv_required,
             exempt_pairs=hv_exempt,
+            pad_anchored=pad_anchored_wirelength,
         )
 
     # Keep interrupt state up-to-date with best vector for graceful save
@@ -1140,6 +1181,7 @@ def run_optimize_placement(
                     ref_domains=hv_ref_domains,
                     required_mm_by_domain_pair=hv_required,
                     exempt_pairs=hv_exempt,
+                    pad_anchored=pad_anchored_wirelength,
                 )
                 scores.append(score.total)
 
@@ -1206,6 +1248,7 @@ def run_optimize_placement(
         ref_domains=hv_ref_domains,
         required_mm_by_domain_pair=hv_required,
         exempt_pairs=hv_exempt,
+        pad_anchored=pad_anchored_wirelength,
     )
 
     # Save final checkpoint

--- a/src/kicad_tools/cli/parser.py
+++ b/src/kicad_tools/cli/parser.py
@@ -5982,6 +5982,22 @@ def _add_optimize_placement_parser(subparsers) -> None:
         ),
     )
     op_parser.add_argument(
+        "--pad-anchored-wirelength",
+        action="store_true",
+        default=False,
+        help=(
+            "Measure the wirelength term between transformed pad "
+            "coordinates instead of footprint centres. The pads are "
+            "already computed for every candidate and discarded today, so "
+            "this costs one dict build per evaluation. It makes rotation "
+            "visible to wirelength (a centre-anchored HPWL cannot see it) "
+            "and stops a decap scoring as 'at the chip' while sitting a "
+            "package-diagonal from the pad it decouples. Default off "
+            "keeps the objective unchanged (issue #4831; see "
+            "docs/placement-pad-anchoring-audit.md)."
+        ),
+    )
+    op_parser.add_argument(
         "--time-budget",
         type=float,
         default=None,

--- a/src/kicad_tools/placement/__init__.py
+++ b/src/kicad_tools/placement/__init__.py
@@ -103,6 +103,7 @@ from .visualization import (
 from .wirelength import (
     HPWLResult,
     NetWirelength,
+    build_pad_position_map,
     compute_hpwl,
     compute_hpwl_breakdown,
 )
@@ -154,6 +155,7 @@ __all__ = [
     "bounds",
     "bounds_with_blocks",
     "build_affinity_graph",
+    "build_pad_position_map",
     "compute_block_boundary_violation",
     "compute_hpwl",
     "compute_hpwl_breakdown",

--- a/src/kicad_tools/placement/cost.py
+++ b/src/kicad_tools/placement/cost.py
@@ -18,7 +18,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from enum import Enum
-from typing import Sequence
+from typing import Mapping, Sequence
 
 
 class CostMode(Enum):
@@ -228,21 +228,37 @@ class BoardOutline:
 def compute_wirelength(
     placements: Sequence[ComponentPlacement],
     nets: Sequence[Net],
+    pad_positions: Mapping[tuple[str, str], tuple[float, float]] | None = None,
 ) -> float:
     """Compute total half-perimeter wirelength (HPWL) estimate.
 
     For each net, computes the half-perimeter of the bounding box of all
-    connected component positions. This is the standard HPWL estimator
-    used in placement optimization.
+    connected pins. This is the standard HPWL estimator used in placement
+    optimization.
 
     Each net's HPWL contribution is multiplied by ``net.weight`` (default
     ``1.0``). Setting ``weight > 1.0`` prioritises keeping that net short
     (used by the anchor-aware path in ``optimize-placement``); setting
     ``weight = 0.0`` excludes the net from the wirelength sum entirely.
 
+    **Pad anchoring (issue #4831 M1).** By default each pin is measured at
+    its component's *centre*, which makes the estimate blind to where a pad
+    actually sits on the footprint -- and blind to rotation entirely, since
+    rotating a part leaves ``p.x``/``p.y`` unchanged. Passing *pad_positions*
+    (see :func:`kicad_tools.placement.wirelength.build_pad_position_map`)
+    measures each pin at its own pad instead, which is the anchoring
+    pcbplace reports as its single highest-leverage placement finding
+    (``docs/placement-pad-anchoring-audit.md``). Resolution is per pin: a
+    pin absent from *pad_positions* silently falls back to its component
+    centre, so a partially-populated map degrades gracefully rather than
+    dropping the net.
+
     Args:
         placements: Current component positions.
         nets: Net connectivity information.
+        pad_positions: Optional map from ``(reference, pad_name)`` to the
+            absolute ``(x, y)`` of that pad in mm. ``None`` (the default)
+            preserves the historical centre-anchored behaviour exactly.
 
     Returns:
         Total weighted HPWL across all nets (mm).
@@ -256,11 +272,15 @@ def compute_wirelength(
     for net in nets:
         xs: list[float] = []
         ys: list[float] = []
-        for ref, _ in net.pins:
-            if ref in pos_map:
-                x, y = pos_map[ref]
-                xs.append(x)
-                ys.append(y)
+        for ref, pin_name in net.pins:
+            pos: tuple[float, float] | None = None
+            if pad_positions is not None:
+                pos = pad_positions.get((ref, pin_name))
+            if pos is None:
+                pos = pos_map.get(ref)
+            if pos is not None:
+                xs.append(pos[0])
+                ys.append(pos[1])
         if len(xs) >= 2:
             total += net.weight * ((max(xs) - min(xs)) + (max(ys) - min(ys)))
     return total
@@ -724,6 +744,7 @@ def evaluate_placement(
     ref_domains: dict[str, str] | None = None,
     required_mm_by_domain_pair: dict[tuple[str, str], float] | None = None,
     exempt_pairs: set[frozenset[str]] | None = None,
+    pad_positions: Mapping[tuple[str, str], tuple[float, float]] | None = None,
 ) -> PlacementScore:
     """Evaluate a placement configuration and return a composite score.
 
@@ -761,6 +782,15 @@ def evaluate_placement(
             Required alongside *ref_domains* for the creepage term to fire.
         exempt_pairs: Optional set of ``frozenset({ref_a, ref_b})`` pairs
             exempted from the creepage keepout (guarded sense taps).
+        pad_positions: Optional map from ``(reference, pad_name)`` to that
+            pad's absolute ``(x, y)`` in mm, as built by
+            :func:`kicad_tools.placement.wirelength.build_pad_position_map`.
+            When supplied, the **wirelength term only** is measured
+            pad-to-pad instead of centre-to-centre (issue #4831 M1); every
+            other term is unchanged. ``None`` (the default) keeps the
+            objective byte-identical to the historical centre-anchored
+            score. Pins missing from the map fall back to their component
+            centre.
 
     Returns:
         PlacementScore with total score, per-component breakdown, and
@@ -770,7 +800,7 @@ def evaluate_placement(
         config = PlacementCostConfig()
 
     # Compute individual cost components
-    wirelength = compute_wirelength(placements, nets)
+    wirelength = compute_wirelength(placements, nets, pad_positions)
     overlap = compute_overlap(placements, footprint_sizes)
     boundary = compute_boundary_violation(placements, board, footprint_sizes)
     drc = compute_drc_violations(placements, rules, footprint_sizes)

--- a/src/kicad_tools/placement/wirelength.py
+++ b/src/kicad_tools/placement/wirelength.py
@@ -76,6 +76,32 @@ def _build_pad_lookup(
     return lookup
 
 
+def build_pad_position_map(
+    placements: Sequence[PlacedComponent],
+) -> dict[tuple[str, str], tuple[float, float]]:
+    """Build a ``(reference, pad_name) -> (x, y)`` map of absolute pad positions.
+
+    This is the bridge that lets the optimizer objective in
+    :mod:`kicad_tools.placement.cost` measure wirelength against real pad
+    coordinates without importing this module (``wirelength`` already imports
+    ``cost``, so the dependency may only run one way). Pass the result as the
+    ``pad_positions`` argument of
+    :func:`kicad_tools.placement.cost.compute_wirelength` or
+    :func:`kicad_tools.placement.cost.evaluate_placement` (issue #4831 M1;
+    see ``docs/placement-pad-anchoring-audit.md``).
+
+    Args:
+        placements: Decoded placements with transformed pad coordinates
+            (as returned by :func:`kicad_tools.placement.vector.decode`).
+
+    Returns:
+        Mapping from ``(component_reference, pad_name)`` to the pad's
+        absolute ``(x, y)`` position in mm. Components without pads
+        contribute no entries.
+    """
+    return {(comp.reference, pad.name): (pad.x, pad.y) for comp in placements for pad in comp.pads}
+
+
 def _hpwl_for_net(
     net: Net,
     pad_lookup: dict[tuple[str, str], TransformedPad],

--- a/tests/test_placement_pad_anchored_wirelength.py
+++ b/tests/test_placement_pad_anchored_wirelength.py
@@ -1,0 +1,425 @@
+"""Pad-anchored wirelength for the optimizer objective (issue #4831, M1).
+
+The optimizer objective historically measured every net at component
+*centres* while the pads needed to measure it properly were computed on every
+candidate decode and then discarded (see
+``docs/placement-pad-anchoring-audit.md``). These tests pin down the opt-in
+pad-anchored path:
+
+* default (``pad_positions=None``) stays byte-identical to the centre score;
+* pad anchoring changes the wirelength term, and *only* that term;
+* rotation -- invisible to a centre-anchored HPWL -- becomes visible;
+* ``Net.weight`` (the ``--anchor-weight`` mechanism) survives the migration;
+* pins with no pad fall back to their component centre rather than dropping.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from kicad_tools.cli.optimize_placement_cmd import _evaluate
+from kicad_tools.placement.cost import (
+    BoardOutline,
+    ComponentPlacement,
+    DesignRuleSet,
+    Net,
+    PlacementCostConfig,
+    compute_wirelength,
+    evaluate_placement,
+)
+from kicad_tools.placement.vector import (
+    ComponentDef,
+    PadDef,
+    PlacedComponent,
+    TransformedPad,
+    decode,
+    encode,
+)
+from kicad_tools.placement.wirelength import build_pad_position_map, compute_hpwl
+
+FIXTURES_DIR = Path(__file__).parent / "fixtures" / "placement"
+BENCHMARK_FILE = FIXTURES_DIR / "benchmark_boards.json"
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _placed(
+    reference: str,
+    x: float,
+    y: float,
+    pads: list[tuple[str, float, float]],
+    rotation: float = 0.0,
+) -> PlacedComponent:
+    """A PlacedComponent with pads already in absolute board coordinates."""
+    return PlacedComponent(
+        reference=reference,
+        x=x,
+        y=y,
+        rotation=rotation,
+        side=0,
+        pads=tuple(
+            TransformedPad(name=n, x=px, y=py, size_x=0.5, size_y=0.5) for n, px, py in pads
+        ),
+    )
+
+
+def _centres(placements: list[PlacedComponent]) -> list[ComponentPlacement]:
+    return [
+        ComponentPlacement(reference=p.reference, x=p.x, y=p.y, rotation=p.rotation)
+        for p in placements
+    ]
+
+
+# Two 10x10 parts 20 mm apart on centres, connected pad-to-pad on their
+# *facing* edges: the pads are only 10 mm apart.
+#
+#   U1 centre (0,0), pad "1" at (+5, 0)      U2 centre (20,0), pad "1" at (15, 0)
+FACING_PADS = [
+    _placed("U1", 0.0, 0.0, [("1", 5.0, 0.0), ("2", -5.0, 0.0)]),
+    _placed("U2", 20.0, 0.0, [("1", 15.0, 0.0), ("2", 25.0, 0.0)]),
+]
+FACING_NET = Net(name="SIG", pins=[("U1", "1"), ("U2", "1")])
+
+
+# ---------------------------------------------------------------------------
+# build_pad_position_map
+# ---------------------------------------------------------------------------
+
+
+def test_build_pad_position_map_keys_on_reference_and_pad_name() -> None:
+    pad_map = build_pad_position_map(FACING_PADS)
+
+    assert pad_map[("U1", "1")] == (5.0, 0.0)
+    assert pad_map[("U2", "2")] == (25.0, 0.0)
+    assert len(pad_map) == 4
+
+
+def test_build_pad_position_map_skips_components_without_pads() -> None:
+    padless = PlacedComponent(reference="M1", x=1.0, y=2.0, rotation=0.0, side=0, pads=())
+
+    assert build_pad_position_map([padless]) == {}
+
+
+# ---------------------------------------------------------------------------
+# compute_wirelength: default unchanged, pads opt-in
+# ---------------------------------------------------------------------------
+
+
+def test_default_is_centre_anchored_and_unchanged() -> None:
+    """No pad map -> the historical centre-to-centre HPWL, to the mm."""
+    assert compute_wirelength(_centres(FACING_PADS), [FACING_NET]) == pytest.approx(20.0)
+    assert compute_wirelength(_centres(FACING_PADS), [FACING_NET], None) == pytest.approx(20.0)
+
+
+def test_pad_anchoring_measures_the_pads_not_the_centres() -> None:
+    """The facing pads are 10 mm apart though the centres are 20 mm apart."""
+    pad_map = build_pad_position_map(FACING_PADS)
+
+    assert compute_wirelength(_centres(FACING_PADS), [FACING_NET], pad_map) == pytest.approx(10.0)
+
+
+def test_pad_anchoring_can_increase_wirelength() -> None:
+    """Pad anchoring is not a uniform discount -- pads can sit further apart."""
+    placements = [
+        _placed("U1", 0.0, 0.0, [("1", -5.0, 0.0)]),
+        _placed("U2", 20.0, 0.0, [("1", 25.0, 0.0)]),
+    ]
+    net = Net(name="SIG", pins=[("U1", "1"), ("U2", "1")])
+
+    centre = compute_wirelength(_centres(placements), [net])
+    pad = compute_wirelength(_centres(placements), [net], build_pad_position_map(placements))
+
+    assert centre == pytest.approx(20.0)
+    assert pad == pytest.approx(30.0)
+
+
+def test_intra_component_net_is_zero_on_centres_but_real_on_pads() -> None:
+    """Two pads of one part collapse to a single point in the centre model."""
+    placements = [_placed("U1", 0.0, 0.0, [("1", -5.0, 0.0), ("2", 5.0, 2.0)])]
+    net = Net(name="LOOP", pins=[("U1", "1"), ("U1", "2")])
+
+    assert compute_wirelength(_centres(placements), [net]) == pytest.approx(0.0)
+    assert compute_wirelength(
+        _centres(placements), [net], build_pad_position_map(placements)
+    ) == pytest.approx(12.0)
+
+
+def test_net_weight_is_honoured_in_pad_anchored_mode() -> None:
+    """The --anchor-weight mechanism survives the migration (audit counter-note)."""
+    weighted = Net(name="SIG", pins=[("U1", "1"), ("U2", "1")], weight=3.0)
+    pad_map = build_pad_position_map(FACING_PADS)
+
+    assert compute_wirelength(_centres(FACING_PADS), [weighted], pad_map) == pytest.approx(30.0)
+
+
+def test_zero_weight_net_still_excluded_in_pad_anchored_mode() -> None:
+    muted = Net(name="SIG", pins=[("U1", "1"), ("U2", "1")], weight=0.0)
+    pad_map = build_pad_position_map(FACING_PADS)
+
+    assert compute_wirelength(_centres(FACING_PADS), [muted], pad_map) == pytest.approx(0.0)
+
+
+def test_pin_without_a_pad_falls_back_to_its_component_centre() -> None:
+    """Partial pad data degrades per pin instead of dropping the net."""
+    pad_map = build_pad_position_map(FACING_PADS)
+    del pad_map[("U2", "1")]  # U2 loses its pad -> measured at its centre (20, 0)
+
+    assert compute_wirelength(_centres(FACING_PADS), [FACING_NET], pad_map) == pytest.approx(15.0)
+
+
+def test_pad_map_for_an_unplaced_component_is_ignored_like_before() -> None:
+    """A net pin with neither a pad nor a placement contributes nothing."""
+    net = Net(name="SIG", pins=[("U1", "1"), ("GHOST", "1")])
+
+    assert compute_wirelength(
+        _centres(FACING_PADS), [net], build_pad_position_map(FACING_PADS)
+    ) == pytest.approx(0.0)
+
+
+def test_empty_net_list_is_zero_with_pads() -> None:
+    assert compute_wirelength(
+        _centres(FACING_PADS), [], build_pad_position_map(FACING_PADS)
+    ) == pytest.approx(0.0)
+
+
+# ---------------------------------------------------------------------------
+# Rotation: invisible to centres, visible to pads
+# ---------------------------------------------------------------------------
+
+
+def test_rotation_is_invisible_to_centres_but_visible_to_pads() -> None:
+    """The audit's core argument: the optimizer searches a dimension the
+    centre-anchored wirelength term cannot see at all."""
+    parts = [
+        ComponentDef(
+            reference="U1",
+            pads=(PadDef(name="1", local_x=5.0, local_y=0.0, size_x=0.5, size_y=0.5),),
+            width=10.0,
+            height=10.0,
+        ),
+        ComponentDef(
+            reference="U2",
+            pads=(PadDef(name="1", local_x=0.0, local_y=0.0, size_x=0.5, size_y=0.5),),
+            width=2.0,
+            height=2.0,
+        ),
+    ]
+    net = Net(name="SIG", pins=[("U1", "1"), ("U2", "1")])
+
+    def wirelengths(rotation: float) -> tuple[float, float]:
+        vector = encode(
+            [
+                PlacedComponent("U1", 0.0, 0.0, rotation, 0, ()),
+                PlacedComponent("U2", 20.0, 0.0, 0.0, 0, ()),
+            ]
+        )
+        placed = decode(vector, parts)
+        centres = _centres(placed)
+        return (
+            compute_wirelength(centres, [net]),
+            compute_wirelength(centres, [net], build_pad_position_map(placed)),
+        )
+
+    centre_0, pad_0 = wirelengths(0.0)
+    centre_180, pad_180 = wirelengths(180.0)
+
+    # Centres: rotating U1 changes nothing.
+    assert centre_0 == pytest.approx(centre_180) == pytest.approx(20.0)
+    # Pads: U1's pad swings from the near edge to the far edge.
+    assert pad_0 == pytest.approx(15.0)
+    assert pad_180 == pytest.approx(25.0)
+
+
+# ---------------------------------------------------------------------------
+# evaluate_placement plumbing
+# ---------------------------------------------------------------------------
+
+
+def _score(pad_positions):
+    return evaluate_placement(
+        _centres(FACING_PADS),
+        [FACING_NET],
+        DesignRuleSet(),
+        BoardOutline(min_x=-20.0, min_y=-20.0, max_x=60.0, max_y=40.0),
+        PlacementCostConfig(),
+        {"U1": (10.0, 10.0), "U2": (10.0, 10.0)},
+        pad_positions=pad_positions,
+    )
+
+
+def test_evaluate_placement_default_is_unchanged() -> None:
+    assert _score(None).breakdown.wirelength == pytest.approx(20.0)
+
+
+def test_evaluate_placement_pad_positions_changes_only_the_wirelength_term() -> None:
+    centre = _score(None)
+    pad = _score(build_pad_position_map(FACING_PADS))
+
+    assert pad.breakdown.wirelength == pytest.approx(10.0)
+    assert pad.total < centre.total
+    for field in ("overlap", "boundary", "drc", "area", "block_boundary", "inter_block"):
+        assert getattr(pad.breakdown, field) == pytest.approx(getattr(centre.breakdown, field))
+    assert pad.is_feasible == centre.is_feasible
+
+
+# ---------------------------------------------------------------------------
+# CLI evaluation path (kct optimize-placement --pad-anchored-wirelength)
+# ---------------------------------------------------------------------------
+
+
+def _cli_parts() -> list[ComponentDef]:
+    return [
+        ComponentDef(
+            reference="U1",
+            pads=(PadDef(name="1", local_x=5.0, local_y=0.0, size_x=0.5, size_y=0.5),),
+            width=10.0,
+            height=10.0,
+        ),
+        ComponentDef(
+            reference="C1",
+            pads=(PadDef(name="1", local_x=0.5, local_y=0.0, size_x=0.5, size_y=0.5),),
+            width=2.0,
+            height=1.0,
+        ),
+    ]
+
+
+def test_cli_evaluate_pad_anchored_flag_switches_the_objective() -> None:
+    parts = _cli_parts()
+    vector = encode(
+        [
+            PlacedComponent("U1", 0.0, 0.0, 0.0, 0, ()),
+            PlacedComponent("C1", 20.0, 0.0, 0.0, 0, ()),
+        ]
+    )
+    nets = [Net(name="VCC", pins=[("U1", "1"), ("C1", "1")])]
+    args = (
+        vector,
+        parts,
+        nets,
+        DesignRuleSet(),
+        BoardOutline(min_x=-20.0, min_y=-20.0, max_x=60.0, max_y=40.0),
+        PlacementCostConfig(),
+        {"U1": (10.0, 10.0), "C1": (2.0, 1.0)},
+    )
+
+    centre = _evaluate(*args)
+    pad = _evaluate(*args, pad_anchored=True)
+
+    assert centre.breakdown.wirelength == pytest.approx(20.0)
+    assert pad.breakdown.wirelength == pytest.approx(15.5)
+
+
+def test_cli_evaluate_defaults_to_centre_anchored() -> None:
+    """The flag is opt-in: omitting it must not perturb any existing run."""
+    parts = _cli_parts()
+    vector = encode(
+        [
+            PlacedComponent("U1", 0.0, 0.0, 0.0, 0, ()),
+            PlacedComponent("C1", 20.0, 0.0, 0.0, 0, ()),
+        ]
+    )
+    nets = [Net(name="VCC", pins=[("U1", "1"), ("C1", "1")])]
+    args = (
+        vector,
+        parts,
+        nets,
+        DesignRuleSet(),
+        BoardOutline(min_x=-20.0, min_y=-20.0, max_x=60.0, max_y=40.0),
+        PlacementCostConfig(),
+        {"U1": (10.0, 10.0), "C1": (2.0, 1.0)},
+    )
+
+    assert _evaluate(*args).total == pytest.approx(_evaluate(*args, pad_anchored=False).total)
+
+
+def test_cli_flag_exists_and_defaults_off() -> None:
+    from kicad_tools.cli.parser import create_parser
+
+    args = create_parser().parse_args(["optimize-placement", "board.kicad_pcb"])
+    assert args.pad_anchored_wirelength is False
+
+    args = create_parser().parse_args(
+        ["optimize-placement", "board.kicad_pcb", "--pad-anchored-wirelength"]
+    )
+    assert args.pad_anchored_wirelength is True
+
+
+# ---------------------------------------------------------------------------
+# Fixture-board regression: the audit's measured divergence, via the new path
+# ---------------------------------------------------------------------------
+
+
+def _load_fixture_board(name: str) -> tuple[list[PlacedComponent], list[Net]]:
+    boards: dict[str, Any] = json.loads(BENCHMARK_FILE.read_text())["boards"]
+    board = boards[name]
+
+    defs = {
+        c["reference"]: ComponentDef(
+            reference=c["reference"],
+            pads=tuple(
+                PadDef(
+                    name=p["name"],
+                    local_x=p["local_x"],
+                    local_y=p["local_y"],
+                    size_x=p.get("size_x", 0.5),
+                    size_y=p.get("size_y", 0.5),
+                )
+                for p in c.get("pads", [])
+            ),
+            width=c.get("width", 1.0),
+            height=c.get("height", 1.0),
+        )
+        for c in board["components"]
+    }
+    raw = board.get("known_optimal_placement") or board["reference_placement"]
+    order = [defs[r["reference"]] for r in raw]
+    vector = encode(
+        [
+            PlacedComponent(
+                reference=r["reference"],
+                x=r["x"],
+                y=r["y"],
+                rotation=r.get("rotation", 0.0),
+                side=r.get("side", 0),
+                pads=(),
+            )
+            for r in raw
+        ]
+    )
+    nets = [Net(name=n["name"], pins=[(p[0], p[1]) for p in n["pins"]]) for n in board["nets"]]
+    return decode(vector, order), nets
+
+
+@pytest.mark.parametrize(
+    "board_name,centre_mm,pad_mm",
+    [
+        ("trivial_3_resistors", 12.0, 7.2),
+        ("simple_rc_filter", 127.0, 126.69),
+        ("medium_mcu_board", 382.0, 339.23),
+    ],
+)
+def test_committed_fixtures_reproduce_the_audit_divergence(
+    board_name: str, centre_mm: float, pad_mm: float
+) -> None:
+    """§4 of docs/placement-pad-anchoring-audit.md, now guarded by a test.
+
+    The two estimators disagree by 0.2%-40% on the *same* committed layout,
+    which is the mechanism by which a pad-anchored objective can rank two
+    candidates differently. Also asserts the new ``pad_positions`` path agrees
+    with the pre-existing ``compute_hpwl`` estimator on unweighted nets.
+    """
+    placed, nets = _load_fixture_board(board_name)
+    centres = _centres(placed)
+    pad_map = build_pad_position_map(placed)
+
+    assert compute_wirelength(centres, nets) == pytest.approx(centre_mm, abs=0.01)
+    assert compute_wirelength(centres, nets, pad_map) == pytest.approx(pad_mm, abs=0.01)
+    assert compute_wirelength(centres, nets, pad_map) == pytest.approx(compute_hpwl(placed, nets))


### PR DESCRIPTION
Part of #4831 — implements **M1** of `docs/placement-pad-anchoring-audit.md` (the audit landed in #4842). M2–M5 remain unfiled/unimplemented.

## What and why

The audit's load-bearing finding: the optimizer objective measures wirelength between **footprint centres**, while both front-ends decode every candidate into `PlacedComponent` objects *with* absolute pad coordinates and immediately throw them away (`_vector_to_placements`). Two consequences:

- **Rotation is invisible to the objective.** `compute_wirelength` reads only `p.x`/`p.y`, so rotating a part changes it by exactly zero — the optimizer searches a rotation dimension its wirelength term cannot see.
- **A pin is scored where the part is, not where the pad is.** On a 10 mm QFP a decap "within 5 mm of centre" can be ~10 mm of copper from the pad it decouples. This is pcbplace's reported 59.5 → 12.7 mm mechanism.

## Shape (opt-in, generic library capability)

- `compute_wirelength(placements, nets, pad_positions=None)` and `evaluate_placement(..., pad_positions=None)` accept a `(reference, pad_name) -> (x, y)` map. Resolution is **per pin**: a pin absent from the map falls back to its component centre, so partial pad data degrades rather than dropping the net.
- `build_pad_position_map()` in `placement/wirelength.py` builds that map from decoded placements (exported from `kicad_tools.placement`).
- `kct optimize-placement --pad-anchored-wirelength` opts in; the CLI `_evaluate()` now decodes once and reuses the pads it already had (one dict build per evaluation, no new transform pass).

**Why a map instead of calling `compute_hpwl` directly** (the audit's M1 counter-note): `compute_hpwl` ignores `Net.weight`, which `--anchor-weight` depends on, and `cost.py` cannot import `wirelength.py` without a cycle (`wirelength` imports `cost`). Passing coordinates in keeps per-net weighting and one net-iteration code path. The counter-note is resolved, not carried.

**Default off.** With no map the score is byte-identical to the historical objective — no existing run, snapshot or board pipeline moves. It is *not* a rescaling: the two estimators differ by 0.2 %–40 % on the *same* committed fixture layouts, so they can rank candidates differently. Flipping the default needs fleet evidence (audit M5). The MCP front-end still discards its pads — deliberately deferred and recorded in the audit doc.

## Test evidence

New: `tests/test_placement_pad_anchored_wirelength.py` — 20 cases.

```
uv run pytest tests/test_placement_pad_anchored_wirelength.py -q   ->  20 passed
uv run pytest tests -k "placement or optim" -q                     ->  2109 passed, 38 skipped
uv run pytest tests/test_format_json_sweep_drivers.py tests/test_cli_parser_drift.py \
             tests/test_build_parser_parity.py tests/test_docs_source_citations.py -q
                                                                   ->  109 passed
uv run ruff check src tests && uv run ruff format --check src tests -> clean
uv run python scripts/ci/check_mypy_baseline.py                    -> OK (1466 errors, 1472 allowed; no new)
```

Coverage of the behaviour, not just the plumbing:
- rotation case: centre HPWL identical at 0° and 180° (20.0 mm both), pad HPWL swings 15.0 → 25.0 mm;
- pad anchoring can *increase* wirelength (not a uniform discount);
- `Net.weight` honoured and `weight=0.0` still excludes a net in pad mode;
- per-pin fallback when a pad is missing (20 → 15 mm, net not dropped);
- `evaluate_placement`: only `breakdown.wirelength` moves, every other term and `is_feasible` unchanged;
- CLI `_evaluate` default equals `pad_anchored=False`; parser flag exists and defaults `False`;
- **fixture regression** reproducing the audit's §4 measurement through the new path and pinning it to the pre-existing `compute_hpwl`: `trivial_3_resistors` 12.0 → 7.2 mm, `simple_rc_filter` 127.0 → 126.69 mm, `medium_mcu_board` 382.0 → 339.23 mm.

## Docs

- `docs/placement-pad-anchoring-audit.md` — status banner + M1 marked LANDED (opt-in), with the deferred surface named; line-number citations flagged as describing the tree as audited.
- `docs/placement-scoring.md` — new section on what the wirelength term measures (centres vs pads).
- `docs/reference/cli.md` — flag row + explanation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)