### PR TITLE
fix(router): price the pairwise soft gradient from the nearest band cell

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,17 +72,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   hot loop consults a pre-dilated band bitmap (one bool lookup per neighbour)
   and calls the exact kernel only for cells near cross-domain copper. Strictly
   dormant without `--voltage-map` (one `is None` test per neighbour,
-  byte-identical g-scores). The mirror reproduces the reference's **two-level**
-  break, including the conditional outer one (`if (cost > 0.0f) break;`): a
-  qualifying cell exactly on the halo circle prices `frac == 0` and lets the
-  scan run on into later rows rather than ending it, which matters because the
-  first cell every scan visits (`dy = -halo_r, dx = 0`) always sits on that
-  circle. New Python↔C++ parity tests pin the *value*, not just the sign: the
-  whole band, off-axis distances, board-edge-clipped scan windows,
-  per-net-class widths, the multi-cell case that proves both engines stop on
-  the same candidate cell, and the zero-`frac` cases (an on-circle cell paired
-  with a later priced one, and a single contiguous foreign bar whose topmost
-  row touches the halo).
+  byte-identical g-scores). **As shipped, #4849 mirrored the C++ reference's
+  then-current row-major scan** — including its **two-level** break with a
+  conditional outer one (`if (cost > 0.0f) break;`), so that a qualifying cell
+  exactly on the halo circle priced `frac == 0` and let the scan run on into
+  later rows rather than ending it. **That scan-order contract is superseded
+  inside this same unreleased cycle by #4848** (see *Fixed* below): both
+  engines now price the **nearest** qualifying cell in the band, neither has a
+  two-level break, and an on-circle cell is the band's *farthest* member by
+  construction rather than a scan-continuation special case. The Python↔C++
+  parity tests still pin the *value*, not just the sign — the whole band,
+  off-axis distances, board-edge-clipped scan windows, per-net-class widths, a
+  multi-cell case proving both engines settle on the same candidate cell, and
+  the zero-`frac` cases — but #4848 renamed several of them (and re-pointed
+  their assertions) where the narrowed semantics made the old names describe
+  behavior that no longer exists.
 
 - **Placement pad-anchoring audit** (`docs/placement-pad-anchoring-audit.md`,
   part of #4831) — a docs-only, symbol-anchored survey of where the placement
@@ -826,6 +830,39 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   intended beyond the runtime bump.
 
 ### Fixed
+
+- **The pairwise HV-avoidance gradient is priced from the *nearest* qualifying
+  band cell, not the first one in scan order** (#4848, epic #4431 Phase 2b) —
+  `Pathfinder::pairwise_avoidance_cost` and its Python mirror
+  `Router._pairwise_avoidance_cost` both documented a linear decay "strongest
+  just outside the hard radius, zero at the band edge", but both broke at the
+  first qualifying cell in **row-major** order, which starts at the *topmost*
+  row of the scan window rather than the closest cell. A candidate with foreign
+  LV copper 18 cells below (the binding side, `frac = 7/8`) and 24 cells above
+  (`frac = 1/8`) priced **0.125 instead of 0.875** — a 7x under-price of the
+  real proximity, making the HV↔LV margin nudge effectively random with respect
+  to *which* cross-domain copper was actually close. The C++ kernel now walks a
+  distance-sorted band-offset table built once per `(hard_r, band)`
+  (`Pathfinder::pairwise_band_offsets`, the ring-ordered analogue of
+  `via_kernel_offsets_`), each entry carrying its pre-computed decay `frac`, so
+  the first qualifying cell *is* the nearest and the load-bearing early exit
+  survives — while visiting only the annulus instead of its bounding square
+  (2.3x cheaper per call: 1.945 → 0.845 µs over 198k probes on the HV fixture).
+  The Python mirror replaces the two-level-break replay with a vectorised `min`
+  over the band's squared distances (flat at ~15 µs/call). An on-circle cell
+  (`frac == 0`) can no longer swallow the price by construction — it is the
+  band's farthest member, so it wins only when nothing nearer qualifies, which
+  is exactly when `0.0` is correct — retiring the conditional outer break
+  #4849 had to mirror (that entry, above, is amended accordingly). **Route
+  output changes**: on the two-domain HV fixture the corrected gradient buys
+  +0.163 mm of edge gap (2.000 → 2.163 mm against a 1.6 mm requirement) for
+  +5.5 mm of length, and a seeded randomized parity sweep pins both engines
+  against an independent nearest-cell oracle. **Consumer-visible:**
+  `ROUTER_CPP_BUILD_VERSION` is bumped **19 → 20** (mirrored in
+  `cpp_backend.py`) because a stale `.so` would price a *different* gradient
+  than the Python fallback. The binding surface is unchanged, but any checkout
+  carrying a version-19 extension silently falls back to the pure-Python router
+  (10-100x slower) until `uv run kct build-native` is re-run.
 
 - **The board-06 strict-gate test fixture no longer shells out through a nested
   `uv run`** (#4853) — `TestBoard06StrictGateGuard`'s class-scoped

--- a/src/kicad_tools/router/cpp/include/pathfinder.hpp
+++ b/src/kicad_tools/router/cpp/include/pathfinder.hpp
@@ -421,8 +421,10 @@ private:
     // Cached against ``(hard_r, band)``, which changes at most once per route
     // (they derive from ``search_trace_half_width_mm_`` and the grid's widest
     // pairwise clearance, both fixed for the duration of a search).  Mutable
-    // because the kernel is ``const``, exactly like the other lazily-built
-    // scan geometry.
+    // because the kernel is ``const`` and the table is built on first use --
+    // the lazily-built sibling of the eagerly-constructed
+    // ``via_kernel_offsets_`` above (which is built in the constructor and is
+    // therefore not ``mutable``).
     struct PairwiseBandOffset {
         int16_t dx;
         int16_t dy;

--- a/src/kicad_tools/router/cpp/include/pathfinder.hpp
+++ b/src/kicad_tools/router/cpp/include/pathfinder.hpp
@@ -267,6 +267,13 @@ public:
     // keeps HV<->LV margin (soft cost before hard block) instead of hugging the
     // hard limit and thrashing the negotiator.  0.0 when dormant / no
     // cross-domain copper in the band.
+    //
+    // Issue #4848: the price is taken from the NEAREST qualifying cross-domain
+    // cell in the band (version 19 and earlier priced the first one in
+    // row-major scan order, which is the topmost cell of the window rather
+    // than the closest -- a 7x under-price whenever foreign copper flanked the
+    // candidate on both sides).  Implemented as a ring-ordered scan over
+    // ``pairwise_band_offsets`` so the early exit survives.
     float pairwise_avoidance_cost(int x, int y, int layer, int net) const;
 
     // Shared helper: the widened cross-domain radius (cells) for a routing net
@@ -399,6 +406,35 @@ private:
     // the bounding square rather than a temporary vector allocation
     // (mirrors PR #3232's canonical pattern for ``is_trace_blocked``).
     std::vector<std::pair<int8_t, int8_t>> via_kernel_offsets_;
+
+    // Issue #4848: distance-sorted offsets for the soft pairwise avoidance
+    // band, the ring-ordered analogue of ``via_kernel_offsets_``.  Every entry
+    // lies in the annulus ``(hard_r, hard_r + band]`` and carries its
+    // PRE-COMPUTED linear-decay ``frac``, so the hot kernel neither recomputes
+    // ``sqrt`` nor re-filters the bounding square: walking the vector in order
+    // visits the band from the inside out, and the FIRST qualifying cell is by
+    // construction the NEAREST one.  That is what makes exact nearest-in-band
+    // pricing affordable -- the pre-#4848 row-major scan needed its early
+    // ``break`` to stay cheap and paid for it with scan-order-dependent
+    // prices.
+    //
+    // Cached against ``(hard_r, band)``, which changes at most once per route
+    // (they derive from ``search_trace_half_width_mm_`` and the grid's widest
+    // pairwise clearance, both fixed for the duration of a search).  Mutable
+    // because the kernel is ``const``, exactly like the other lazily-built
+    // scan geometry.
+    struct PairwiseBandOffset {
+        int16_t dx;
+        int16_t dy;
+        float frac;
+    };
+    mutable int pairwise_band_hard_r_ = -1;
+    mutable int pairwise_band_band_ = -1;
+    mutable std::vector<PairwiseBandOffset> pairwise_band_offsets_;
+
+    // Lazily build (and cache) the distance-sorted band offsets above.
+    const std::vector<PairwiseBandOffset>& pairwise_band_offsets(
+        int hard_radius, int band) const;
 
     // Routable layer indices
     std::vector<int> routable_layers_;

--- a/src/kicad_tools/router/cpp/include/types.hpp
+++ b/src/kicad_tools/router/cpp/include/types.hpp
@@ -199,7 +199,21 @@ namespace router {
 // ``net_layers`` map keeps the layer-agnostic version-18 verdict, so old
 // callers are unaffected -- but the struct field and the defaulted argument
 // are both new binding surface, hence the bump.
-constexpr int ROUTER_CPP_BUILD_VERSION = 19;
+//
+// Version 20 (Issue #4848): the soft pairwise avoidance gradient
+// (``Pathfinder::pairwise_avoidance_cost``) prices the NEAREST qualifying
+// cross-domain cell in the band instead of the first one in row-major scan
+// order.  Version 19's two-level break stopped at the topmost band cell, so a
+// candidate with foreign copper 18 cells below (the binding side) and 24 cells
+// above priced 1/8 instead of 7/8 -- a 7x under-price of the real proximity,
+// contradicting the documented "strongest just outside the hard radius" decay.
+// The kernel now walks a distance-sorted band-offset table (built once per
+// ``(hard_r, band)``), so the early exit survives with exact nearest-in-band
+// semantics.  No binding-surface change, but the ROUTE OUTPUT on HV boards
+// changes and the Python mirror (``Router._pairwise_avoidance_cost``) was
+// updated in lockstep: a stale .so would price a different gradient than the
+// fallback, so the version bump forces a rebuild via ``kct build-native``.
+constexpr int ROUTER_CPP_BUILD_VERSION = 20;
 
 // Issue #4071: fixed-capacity owner-set size for per-cell corridor
 // reservations.  Observed owner sets in practice are tiny: 1 for the

--- a/src/kicad_tools/router/cpp/src/pathfinder.cpp
+++ b/src/kicad_tools/router/cpp/src/pathfinder.cpp
@@ -639,6 +639,61 @@ bool Pathfinder::cross_domain_via_blocked(int x, int y, int net) const {
     return false;
 }
 
+const std::vector<Pathfinder::PairwiseBandOffset>&
+Pathfinder::pairwise_band_offsets(int hard_radius, int band) const {
+    if (pairwise_band_hard_r_ == hard_radius && pairwise_band_band_ == band) {
+        return pairwise_band_offsets_;
+    }
+
+    const int halo_radius = hard_radius + band;
+    const int hard_sq = hard_radius * hard_radius;
+    const int halo_sq = halo_radius * halo_radius;
+
+    pairwise_band_offsets_.clear();
+    // Annulus area is ~pi * (halo^2 - hard^2); reserve the bounding-square
+    // upper bound's fraction so the build never reallocates in a loop.
+    pairwise_band_offsets_.reserve(
+        static_cast<size_t>(3.2f * static_cast<float>(halo_sq - hard_sq)) + 8);
+
+    for (int dy = -halo_radius; dy <= halo_radius; ++dy) {
+        for (int dx = -halo_radius; dx <= halo_radius; ++dx) {
+            const int dist_sq = dx * dx + dy * dy;
+            if (dist_sq <= hard_sq || dist_sq > halo_sq) continue;  // band only
+            // Linear decay: strongest just outside the hard radius, zero at the
+            // band edge.  Scaled by the caller to ``cost_straight`` so a cell
+            // hugging the hard limit costs ~1 extra step of detour -- enough to
+            // steer, not enough to distort the optimum route away from a clean
+            // lane.
+            const float d = std::sqrt(static_cast<float>(dist_sq));
+            float frac = (static_cast<float>(halo_radius) - d) /
+                         static_cast<float>(band);
+            if (frac < 0.0f) frac = 0.0f;
+            if (frac > 1.0f) frac = 1.0f;
+            pairwise_band_offsets_.push_back(
+                PairwiseBandOffset{static_cast<int16_t>(dx),
+                                   static_cast<int16_t>(dy), frac});
+        }
+    }
+
+    // Ring order: nearest cell first.  ``frac`` is a strictly decreasing
+    // function of distance, so sorting by DESCENDING ``frac`` is exactly
+    // sorting by ascending distance -- and it keeps the comparison on the
+    // value the kernel returns, so ties (equal distance) are indistinguishable
+    // by construction and the scan is deterministic regardless of which one it
+    // stops on.  ``stable_sort`` keeps the build reproducible across
+    // toolchains.
+    std::stable_sort(pairwise_band_offsets_.begin(),
+                     pairwise_band_offsets_.end(),
+                     [](const PairwiseBandOffset& a,
+                        const PairwiseBandOffset& b) {
+                         return a.frac > b.frac;
+                     });
+
+    pairwise_band_hard_r_ = hard_radius;
+    pairwise_band_band_ = band;
+    return pairwise_band_offsets_;
+}
+
 float Pathfinder::pairwise_avoidance_cost(int x, int y, int layer,
                                           int net) const {
     if (!grid_.pairwise_active()) return 0.0f;
@@ -655,37 +710,23 @@ float Pathfinder::pairwise_avoidance_cost(int x, int y, int layer,
     // limit.  Bounded and thin -- the extra cells scanned are HV-board only.
     const int band = std::max(
         1, static_cast<int>(std::ceil(grid_.max_pairwise_clearance() * 0.5f / res)));
-    const int halo_radius = hard_radius + band;
-    const int hard_sq = hard_radius * hard_radius;
-    const int halo_sq = halo_radius * halo_radius;
 
-    float cost = 0.0f;
-    for (int dy = -halo_radius; dy <= halo_radius; ++dy) {
-        for (int dx = -halo_radius; dx <= halo_radius; ++dx) {
-            const int dist_sq = dx * dx + dy * dy;
-            if (dist_sq <= hard_sq || dist_sq > halo_sq) continue;  // band only
-            const int cx = x + dx, cy = y + dy;
-            if (!grid_.is_valid(cx, cy, layer)) continue;
-            const auto& cell = grid_.at(cx, cy, layer);
-            if (!cell.blocked || cell.net == net || cell.net == 0) continue;
-            if (grid_.pairwise_required_clearance(net, cell.net) <= 0.0f) continue;
-            // Linear decay: strongest just outside the hard radius, zero at the
-            // band edge.  Scaled to ``cost_straight`` so a cell hugging the
-            // hard limit costs ~1 extra step of detour -- enough to steer,
-            // not enough to distort the optimum route away from a clean lane.
-            const float d = std::sqrt(static_cast<float>(dist_sq));
-            float frac = (static_cast<float>(halo_radius) - d) /
-                         static_cast<float>(band);
-            if (frac < 0.0f) frac = 0.0f;
-            if (frac > 1.0f) frac = 1.0f;
-            cost += rules_.cost_straight * frac;
-            // One cross-domain neighbour is enough to establish the gradient;
-            // avoid over-penalising a cell flanked by a long HV run.
-            break;
-        }
-        if (cost > 0.0f) break;
+    // Issue #4848: NEAREST-in-band pricing.  The offsets are pre-sorted from
+    // the hard radius outward, so the first qualifying cell is the closest
+    // cross-domain copper and the scan can return immediately -- the early
+    // exit the pre-#4848 row-major ``break`` bought, but now with the
+    // semantics the gradient was always documented to have ("strongest just
+    // outside the hard radius").  One cross-domain neighbour still sets the
+    // whole price: a candidate flanked by a long HV run is not over-penalised.
+    for (const auto& off : pairwise_band_offsets(hard_radius, band)) {
+        const int cx = x + off.dx, cy = y + off.dy;
+        if (!grid_.is_valid(cx, cy, layer)) continue;
+        const auto& cell = grid_.at(cx, cy, layer);
+        if (!cell.blocked || cell.net == net || cell.net == 0) continue;
+        if (grid_.pairwise_required_clearance(net, cell.net) <= 0.0f) continue;
+        return rules_.cost_straight * off.frac;
     }
-    return cost;
+    return 0.0f;
 }
 
 bool Pathfinder::is_via_blocked(int x, int y, int net, bool allow_sharing,

--- a/src/kicad_tools/router/cpp_backend.py
+++ b/src/kicad_tools/router/cpp_backend.py
@@ -50,7 +50,7 @@ logger = logging.getLogger(__name__)
 # ``AttributeError`` deep in the routing code (e.g. ``router_cpp.PadBounds``
 # missing).  The guard below catches that at import time and falls back to the
 # pure-Python router with an actionable ``kct build-native`` hint.
-_REQUIRED_CPP_BUILD_VERSION = 19
+_REQUIRED_CPP_BUILD_VERSION = 20
 
 # Try to import C++ module with detailed error tracking
 _CPP_IMPORT_ERROR: str | None = None

--- a/src/kicad_tools/router/pathfinder.py
+++ b/src/kicad_tools/router/pathfinder.py
@@ -2409,32 +2409,28 @@ class Router:
     #   outside the hard radius, zero at the band edge), so a cell hugging
     #   the limit costs about one extra step of detour -- enough to steer,
     #   not enough to distort the optimum away from a clean lane.
-    # * Same "one cross-domain neighbour is enough" rule, and same TWO-LEVEL
-    #   break -- the detail #4849's review caught.  The C++ kernel's inner
-    #   ``break`` fires at the first qualifying cell of a ROW (so a cell
-    #   flanked by a long HV run is not over-penalised), but the outer break
-    #   is CONDITIONAL: ``if (cost > 0.0f) break;``.  A qualifying cell
-    #   sitting exactly on the halo circle (``dist_sq == halo_r^2``) prices
-    #   ``frac == 0``, leaves ``cost`` at zero, and so lets the scan run on
-    #   into later rows and price a different cell.  That is not exotic: the
-    #   very first cell the scan visits (``dy = -halo_r, dx = 0``) is always
-    #   exactly on the circle, so any foreign copper whose topmost band cell
-    #   lands in the candidate's own column trips it.  An unconditional
-    #   return at the first qualifying cell would return 0.0 where C++
-    #   returns a full-magnitude cost, so the mirror below tracks the row it
-    #   priced (skipping that row's remaining cells, the inner break) and
-    #   stops only once the accumulated cost is strictly positive.  Because
-    #   every pre-stop contribution is exactly zero, accumulating and
-    #   returning at the first positive term is identical to the C++ sum.
-    #   ``np.nonzero`` yields C (row-major) order, so the entry it stops on
-    #   is the same cell the C++ scan stops on (clipping the scan window at
-    #   the board edge removes whole leading rows/columns and so preserves
-    #   row-major order among the remaining cells).  Scan-order dependence is
-    #   a wart of the reference implementation, mirrored deliberately: parity
-    #   first -- two engines agreeing on an arbitrary-but-bounded nudge beats
-    #   two engines disagreeing about which candidate is cheap.  Changing the
-    #   semantics is #4848's job (both engines together, with a
-    #   ``ROUTER_CPP_BUILD_VERSION`` bump), never a silent divergence here.
+    # * Same "one cross-domain neighbour is enough" rule -- a candidate flanked
+    #   by a long HV run is priced once, not once per cell -- and the same
+    #   NEAREST-IN-BAND choice of which cell that is (#4848).  The price is
+    #   ``cost_straight * frac(d_min)`` where ``d_min`` is the distance to the
+    #   closest qualifying cross-domain cell in the band, so the gradient is a
+    #   monotone function of real proximity.  Ties need no rule: ``frac``
+    #   depends only on the distance, so every cell at ``d_min`` prices the
+    #   same.  Up to ROUTER_CPP_BUILD_VERSION 19 BOTH engines instead priced
+    #   the first qualifying cell in row-major scan order (a two-level break,
+    #   with the outer one conditional on a strictly positive cost so that a
+    #   cell exactly on the halo circle, ``frac == 0``, did not stop the scan).
+    #   That made the nudge scan-order dependent: foreign copper 18 cells below
+    #   a candidate and 24 cells above priced ``1/8`` off the FAR cell instead
+    #   of ``7/8`` off the near one -- a 7x under-price that contradicted this
+    #   kernel's own documented decay.  #4848 changed both engines together,
+    #   with a ``ROUTER_CPP_BUILD_VERSION`` bump so a stale ``.so`` cannot
+    #   price a different gradient than this fallback; the C++ side keeps its
+    #   early exit by walking a distance-sorted band-offset table
+    #   (``Pathfinder::pairwise_band_offsets``) instead of the bounding square,
+    #   while the mirror below takes a vectorised ``min`` over the band's
+    #   squared distances.  Divergence here is always a bug: the two engines
+    #   must agree cell-for-cell on which candidate is cheap.
     # * ``half_mm`` is the ROUTED net's class trace width (#4793), exactly as
     #   in the hard kernels.
     # * NO #4506 attach-zone waiver, mirroring the C++ kernel: this is a
@@ -2540,33 +2536,28 @@ class Router:
         if not bool(np.any(candidates)):
             return 0.0
 
-        # Mirror the C++ kernel's TWO-LEVEL break (see the block comment
-        # above).  ``np.nonzero`` yields C (row-major) order, so walking it
-        # visits cells in the reference's scan order; ``priced_row`` replays
-        # the inner ``break`` (the rest of a row is skipped once that row has
-        # priced a cell) and the ``cost > 0.0`` test replays the CONDITIONAL
-        # outer break -- a cell exactly on the halo circle prices 0.0 and the
-        # scan continues into later rows, exactly as the C++ scan does.
-        cost = 0.0
-        priced_row = -1  # no row index is negative, so this never matches
-        for row, col in zip(*np.nonzero(candidates), strict=True):
-            if row == priced_row:
-                continue  # the C++ inner break already left this row
-            foreign_net = int(net_region[row, col])
-            if foreign_net <= 0 or foreign_net >= widen_lut.size:
-                continue
-            if not widen_lut[foreign_net]:
-                continue  # same domain / no widening for this pair
-            priced_row = int(row)
-            distance = math.sqrt(float(dist_sq[row, col]))
-            # Linear decay: strongest just outside the hard radius, zero at
-            # the band edge, scaled to ``cost_straight``.
-            frac = (halo_r - distance) / band
-            frac = min(1.0, max(0.0, frac))
-            cost += self.rules.cost_straight * frac
-            if cost > 0.0:
-                break
-        return cost
+        # Issue #4848: price the NEAREST qualifying cell, not the first in
+        # scan order (see the block comment above).  Keep the widening filter
+        # off the full window -- ``candidates`` is already sparse, so the
+        # per-net lookup only ever touches the handful of foreign cells that
+        # made it into the band.
+        candidate_nets = net_region[candidates]
+        in_range = (candidate_nets > 0) & (candidate_nets < widen_lut.size)
+        if not bool(np.any(in_range)):
+            return 0.0
+        qualifies = np.zeros(candidate_nets.shape, dtype=np.bool_)
+        # Same domain / no widening for this pair -> not a gradient source.
+        qualifies[in_range] = widen_lut[candidate_nets[in_range]]
+        if not bool(np.any(qualifies)):
+            return 0.0
+
+        nearest_sq = float(dist_sq[candidates][qualifies].min())
+        distance = math.sqrt(nearest_sq)
+        # Linear decay: strongest just outside the hard radius, zero at the
+        # band edge, scaled to ``cost_straight``.
+        frac = (halo_r - distance) / band
+        frac = min(1.0, max(0.0, frac))
+        return self.rules.cost_straight * frac
 
     def _pairwise_band_kernel(self, hard_r: int, band: int) -> tuple[np.ndarray, np.ndarray]:
         """Cached ``(dist_sq, band_mask)`` window for the gradient scan."""

--- a/tests/router/test_pairwise_cpp_parity.py
+++ b/tests/router/test_pairwise_cpp_parity.py
@@ -19,6 +19,9 @@ This module covers:
 
 from __future__ import annotations
 
+import math
+import random
+
 import pytest
 
 from kicad_tools.router.cpp_backend import CppGrid, CppPathfinder, is_cpp_available
@@ -854,8 +857,6 @@ def test_search_avoidance_cost_gradient_near_hv() -> None:
 
 def _seg_rect_gap(seg, x1, x2, y1, y2) -> float:
     """Min distance (mm) from a segment centreline to an axis-aligned rect."""
-    import math
-
     best = float("inf")
     for i in range(101):
         t = i / 100.0
@@ -1336,37 +1337,39 @@ def _route_through_a_rated_gap(layer_scoped: bool):
 
 
 @requires_cpp
-def test_layer_scoped_zone_converges_where_layer_agnostic_thrashes() -> None:
-    """Headline (#4507): the layer-scoped search converges; the agnostic one does not.
+def test_rated_gap_board_converges_on_the_licensed_layer() -> None:
+    """Headline (#4507): the search crosses on the layer the rated part licences.
 
-    Same board, same geometry, same C++ search -- only the zone's layer scoping
-    differs.  Layer-AGNOSTIC (the pre-#4507 C++ shape) the search keeps
-    proposing the F.Cu gap the layer-scoped Python post-check rejects, exhausts
-    its resume budget, drops into the pure-Python fallback and fails.
-    Layer-SCOPED, the search knows the F.Cu gap is illegal from the first
-    expansion, dives to the rated part's own B.Cu layer, and converges.
+    An LV wall with a single 3 mm gap on F.Cu, and a rated footprint whose
+    attach zone straddles the gap but whose pads are on B.Cu.  The only
+    gate-clean answer is to dive to B.Cu and cross there; necking through the
+    F.Cu gap is a pairwise violation the layer-scoped acceptance check
+    (#4699) rejects.
+
+    Evolution of this fixture, so a future reader can tell an improvement from
+    a regression:
+
+    * pre-#4507, layer-AGNOSTIC: the C++ search kept proposing the F.Cu gap
+      the layer-scoped gate rejected, burned its resume budget and dropped
+      into the pure-Python fallback, which then failed outright.
+    * #4507: the fallback became pairwise-aware and layer-scoped, so the
+      agnostic baseline was *rescued* by it -- slowly, but gate-clean.
+    * #4848: with the soft avoidance gradient priced off the NEAREST band
+      cell instead of the first one in scan order, the nudge away from the
+      under-clearance F.Cu gap is strong enough that even the layer-AGNOSTIC
+      configuration converges inside the C++ search -- no thrash, no fallback.
+      That is the routing-quality payoff #4848 was filed for, so this test now
+      pins the *outcome* (converged, gate-clean, on the licensed layer, in the
+      C++ search) for both configurations rather than the old contrast.
     """
-    route, violation, layers, fallback = _route_through_a_rated_gap(layer_scoped=True)
-    assert route is not None, "layer-scoped search failed to converge"
-    assert violation is None, f"converged route still violates the gate: {violation}"
-    assert fallback is False, "convergence must come from the C++ search, not the fallback"
-    # It found the legal answer: cross on the layer the rated part licences.
-    assert "B_CU" in layers
-
-    blind_route, blind_violation, blind_layers, blind_fallback = _route_through_a_rated_gap(
-        layer_scoped=False
-    )
-    # The pre-#4507 shape cannot get there in the C++ search: it burns the
-    # resume budget on routes the layer-scoped gate rejects and ends up in the
-    # slow Python fallback.
-    assert blind_fallback is True, "the agnostic baseline is expected to thrash into fallback"
-    # Since the pure-Python fallback became pairwise-aware and layer-scoped
-    # itself (#4507, the search-time fallback slice), it now RESCUES the net --
-    # slowly, but gate-clean and on the licensed layer -- where it previously
-    # failed outright (``blind_route is None`` was the pinned pre-slice state).
-    assert blind_route is not None, "the pairwise-aware Python fallback should rescue the net"
-    assert blind_violation is None
-    assert "B_CU" in blind_layers
+    for layer_scoped in (True, False):
+        route, violation, layers, fallback = _route_through_a_rated_gap(layer_scoped=layer_scoped)
+        label = "layer-scoped" if layer_scoped else "layer-agnostic"
+        assert route is not None, f"{label} search failed to converge"
+        assert violation is None, f"{label} route violates the gate: {violation}"
+        assert fallback is False, f"{label} convergence must come from the C++ search"
+        # It found the legal answer: cross on the layer the rated part licences.
+        assert "B_CU" in layers, f"{label} route never reached the licensed layer"
 
 
 # ---------------------------------------------------------------------------
@@ -1395,10 +1398,12 @@ def _py_router_with_foreign_cells(
 ):
     """A Python Router on a 20x20 board with foreign LV cells at ``cells``.
 
-    ``cells`` are ``(dy, dx)`` offsets from ``origin`` (the probe point).
-    Cell-exact mirror of the C++ fixtures' ``Grid3D.mark_blocked`` (there is no
-    public single-cell setter on ``RoutingGrid``; the search kernels read these
-    arrays directly).
+    ``cells`` are ``(dy, dx)`` offsets from ``origin`` (the probe point), or
+    ``(dy, dx, net)`` to place copper of some other net (``HV_TAP_NET`` for
+    same-domain copper, ``0`` for the pour / unconnected convention -- neither
+    is a gradient source).  Cell-exact mirror of the C++ fixtures'
+    ``Grid3D.mark_blocked`` (there is no public single-cell setter on
+    ``RoutingGrid``; the search kernels read these arrays directly).
     """
     from kicad_tools.router.layers import LayerStack
     from kicad_tools.router.pathfinder import Router
@@ -1413,9 +1418,11 @@ def _py_router_with_foreign_cells(
     if with_table:
         rules.pairwise_clearance = _table()
     grid = RoutingGrid(width=20.0, height=20.0, rules=rules, layer_stack=LayerStack.two_layer())
-    for dy, dx in cells:
+    for cell in cells:
+        dy, dx = cell[0], cell[1]
+        cell_net = cell[2] if len(cell) > 2 else LV_NET
         grid._blocked[0, origin[1] + dy, origin[0] + dx] = True
-        grid._net[0, origin[1] + dy, origin[0] + dx] = LV_NET
+        grid._net[0, origin[1] + dy, origin[0] + dx] = cell_net
     router = Router(grid, rules, diagonal_routing=True, net_class_map=net_class_map)
     router.set_net_name_to_id(dict(NET_NAMES))
     return router
@@ -1439,8 +1446,10 @@ def _cpp_pathfinder_with_foreign_cells(
 
     pf = router_cpp.Pathfinder(grid, _cpp_rules(), True)
     pf.set_search_pair_widths(half_trace_mm, half_via_mm)
-    for dy, dx in cells:
-        grid.mark_blocked(origin[0] + dx, origin[1] + dy, 0, LV_NET, False, False)
+    for cell in cells:
+        dy, dx = cell[0], cell[1]
+        cell_net = cell[2] if len(cell) > 2 else LV_NET
+        grid.mark_blocked(origin[0] + dx, origin[1] + dy, 0, cell_net, False, False)
     return pf
 
 
@@ -1525,43 +1534,83 @@ def test_avoidance_gradient_parity_off_axis() -> None:
 
 @requires_cpp
 def test_avoidance_gradient_parity_picks_the_same_cell() -> None:
-    """With several band cells, both engines stop on the SAME one.
+    """With several band cells, both engines price the SAME (nearest) one.
 
-    The C++ kernel breaks at its first row-major hit rather than taking the
-    nearest ("one cross-domain neighbour is enough"), so the priced value is
-    scan-order dependent -- a Python mirror that took the nearest instead
-    would disagree here while agreeing on every single-cell probe.
+    Issue #4848: up to build version 19 both kernels broke at the first
+    qualifying cell in ROW-MAJOR scan order, so the topmost band cell set the
+    price rather than the closest one -- ``((18, 0), (-24, 0))`` priced
+    ``1/8`` off the far cell instead of ``7/8`` off the near one.  The
+    expected magnitudes below are the nearest-cell prices, so this fails
+    loudly (not just on a mutual disagreement) if either engine drifts back
+    to scan order.
     """
-    for cells in (
-        ((18, 0), (-24, 0)),
-        ((-18, 0), (24, 0)),
-        ((-24, -3), (18, 2), (19, -1)),
-        ((-20, -20), (-19, 0), (21, 21)),
+    halo_r = _GRADIENT_HARD_R + _GRADIENT_BAND  # 25
+    for cells, expected in (
+        (((18, 0), (-24, 0)), 7.0 / 8.0),  # near cell below wins
+        (((-18, 0), (24, 0)), 7.0 / 8.0),  # ... and above
+        (((-24, -3), (18, 2), (19, -1)), (halo_r - math.sqrt(328)) / 8.0),
+        # Only (-19, 0) is inside the halo at all: the two diagonals sit at
+        # sqrt(800) and sqrt(882), both beyond the band edge.
+        (((-20, -20), (-19, 0), (21, 21)), 6.0 / 8.0),
     ):
         py = _py_router_with_foreign_cells(cells)
         cpp = _cpp_pathfinder_with_foreign_cells(cells)
-        assert py._pairwise_avoidance_cost(100, 100, 0, HV_NET) == pytest.approx(
-            cpp.pairwise_avoidance_cost(100, 100, 0, HV_NET), abs=1e-6
-        ), f"backends disagree for {cells}"
+        py_cost = py._pairwise_avoidance_cost(100, 100, 0, HV_NET)
+        cpp_cost = cpp.pairwise_avoidance_cost(100, 100, 0, HV_NET)
+        assert py_cost == pytest.approx(cpp_cost, abs=1e-6), f"backends disagree for {cells}"
+        assert py_cost == pytest.approx(expected, abs=1e-6), f"not the nearest cell for {cells}"
 
 
 @requires_cpp
-def test_avoidance_gradient_parity_zero_frac_cell_does_not_stop_the_scan() -> None:
-    """A cell exactly ON the halo circle prices 0 and the scan CONTINUES.
+def test_avoidance_gradient_parity_is_order_free() -> None:
+    """Adding FARTHER band copper never changes either engine's price (#4848).
 
-    Issue #4849 (review of the #4507 mirror): the C++ kernel's break is
-    two-level and the outer one is conditional -- ``if (cost > 0.0f) break;``
-    -- so a qualifying cell at exactly ``halo_r`` (``frac == 0``) leaves the
-    accumulated cost at zero and lets the scan run on into later rows, where
-    it can price a different cell.  A Python mirror that returned
+    The scan-order contract this replaced had no such invariant: which cell
+    won depended on where in the window it sat, so a distant blob could
+    override a near one.  Nearest-in-band pricing makes the gradient a pure
+    function of the binding distance, and the two engines agree on it cell
+    for cell.
+    """
+    nearest = ((19, 0),)
+    decoys = (
+        ((-25, 0),),  # exactly on the halo circle (the old zero-frac trap)
+        ((-24, 0), (-23, 3)),
+        ((0, 22), (22, 0), (-20, -12)),
+        ((-24, -3), (24, 4), (-21, 8), (20, -14)),
+    )
+    baseline_py = _py_router_with_foreign_cells(nearest)._pairwise_avoidance_cost(
+        100, 100, 0, HV_NET
+    )
+    assert baseline_py == pytest.approx(6.0 / 8.0, abs=1e-6)
+    for decoy in decoys:
+        cells = nearest + decoy
+        py = _py_router_with_foreign_cells(cells)
+        cpp = _cpp_pathfinder_with_foreign_cells(cells)
+        py_cost = py._pairwise_avoidance_cost(100, 100, 0, HV_NET)
+        cpp_cost = cpp.pairwise_avoidance_cost(100, 100, 0, HV_NET)
+        assert py_cost == pytest.approx(cpp_cost, abs=1e-6), f"backends disagree for {cells}"
+        assert py_cost == pytest.approx(baseline_py, abs=1e-6), f"decoy changed the price: {decoy}"
+
+
+@requires_cpp
+def test_avoidance_gradient_parity_on_circle_cell_never_swallows_the_price() -> None:
+    """A cell exactly ON the halo circle prices 0 and never hides a nearer one.
+
+    History: version 19's C++ break was two-level with a CONDITIONAL outer
+    ``if (cost > 0.0f) break;``, precisely so a qualifying cell at exactly
+    ``halo_r`` (``frac == 0``) would not swallow the price -- the row-major
+    scan's very first cell (``dy = -halo_r, dx = 0``) sits exactly on the
+    circle, so ANY foreign copper whose topmost band cell lands in the
+    candidate's own column tripped it, and a Python mirror that returned
     unconditionally at the first qualifying cell returned 0.0 where C++
-    returned a full-magnitude cost.
+    returned a full-magnitude cost (#4849).
 
-    This is not an exotic corner: the first cell the scan ever visits
-    (``dy = -halo_r, dx = 0``) sits exactly on the circle, so ANY foreign
-    copper whose topmost band cell lands in the candidate's own column trips
-    it -- and A* evaluates a candidate at every grid position, so an HV blob
-    produces a whole row of cells the two engines would price differently.
+    Nearest-in-band pricing (#4848) makes that corner structural rather than
+    conditional: an on-circle cell is the FARTHEST cell in the band, so it can
+    only ever win when nothing nearer qualifies (and then 0.0 is the right
+    answer).  The magnitudes below are unchanged by #4848 -- they were already
+    the nearest cell's price -- so this stays the direct regression net for
+    both engines.
     """
     halo_r = _GRADIENT_HARD_R + _GRADIENT_BAND  # 25
     for cells, expected in (
@@ -1569,27 +1618,29 @@ def test_avoidance_gradient_parity_zero_frac_cell_does_not_stop_the_scan() -> No
         (((-halo_r, 0), (-18, 0)), 0.875),
         (((-halo_r, 0), (0, 20)), 0.625),
         (((-20, -15), (18, 0)), 0.875),  # the (20, 15, 25) Pythagorean triple
+        (((-halo_r, 0),), 0.0),  # alone on the circle -> genuinely free
     ):
         py = _py_router_with_foreign_cells(cells)
         cpp = _cpp_pathfinder_with_foreign_cells(cells)
         py_cost = py._pairwise_avoidance_cost(100, 100, 0, HV_NET)
         cpp_cost = cpp.pairwise_avoidance_cost(100, 100, 0, HV_NET)
         assert py_cost == pytest.approx(cpp_cost, abs=1e-6), f"backends disagree for {cells}"
-        # Non-vacuous: the zero-frac cell must NOT have swallowed the price
+        # Non-vacuous: the on-circle cell must NOT have swallowed the price
         # (the pre-#4849 Python mirror returned exactly 0.0 for every case
         # here, so an equality-only assertion could pass on a mutual zero).
         assert py_cost == pytest.approx(expected, abs=1e-6), f"wrong magnitude for {cells}"
 
 
 @requires_cpp
-def test_avoidance_gradient_parity_contiguous_bar_touching_the_halo() -> None:
-    """One contiguous foreign bar whose nearest row sits exactly at the halo.
+def test_avoidance_gradient_parity_contiguous_bar_slides_nearer() -> None:
+    """A solid foreign bar prices STRICTLY higher as it slides one row nearer.
 
-    The zero-frac divergence above needs no artificial two-blob fixture: a
-    single solid bar of foreign copper is enough, because its topmost band
-    row contributes only the on-circle cell in the candidate's own column.
-    Sliding the same bar one row nearer must price identically -- the
-    on-circle row was worth nothing in either engine.
+    Issue #4848's routing-quality payoff, in miniature and in both engines.
+    Under the version-19 scan-order contract these two positions priced
+    *identically* (0.0836 -- both were charged off the same topmost band row,
+    ``dy = -24, dx = -4``), so the gradient carried no information about how
+    close the copper actually was.  Nearest-in-band pricing charges the bar's
+    closest row: 21 cells out, then 20.
     """
     halo_r = _GRADIENT_HARD_R + _GRADIENT_BAND  # 25
     costs = []
@@ -1601,10 +1652,11 @@ def test_avoidance_gradient_parity_contiguous_bar_touching_the_halo() -> None:
         cpp_cost = cpp.pairwise_avoidance_cost(100, 100, 0, HV_NET)
         assert py_cost == pytest.approx(cpp_cost, abs=1e-6), f"backends disagree for bar at {top}"
         costs.append(py_cost)
-    # Both bars price the row at dy = -24, dx = -4: sqrt(576 + 16) = 24.331,
-    # frac = (25 - 24.331) / 8.
-    assert costs[0] == pytest.approx(costs[1], abs=1e-6)
-    assert costs[0] == pytest.approx(0.0836189, abs=1e-6)
+    # Bar top -25: nearest row is dy = -21 (dx = 0) -> frac = (25 - 21) / 8.
+    # Bar top -24: nearest row is dy = -20 (dx = 0) -> frac = (25 - 20) / 8.
+    assert costs[0] == pytest.approx(4.0 / 8.0, abs=1e-6)
+    assert costs[1] == pytest.approx(5.0 / 8.0, abs=1e-6)
+    assert costs[1] > costs[0]
 
 
 @requires_cpp
@@ -1647,6 +1699,80 @@ def test_avoidance_gradient_parity_wide_class_width() -> None:
     # it (free) where the global width priced it.
     assert costs[1] == 0.0
     assert any(cost > 0.0 for cost in costs)
+
+
+@requires_cpp
+@pytest.mark.parametrize("seed", [17, 4848, 90210])
+def test_avoidance_gradient_parity_randomized_band_population(seed: int) -> None:
+    """Seeded fuzz: the two engines agree on every randomly populated band.
+
+    Issue #4848's acceptance criterion.  The hand-written fixtures above pin
+    named corners; this sweeps arbitrary copper layouts -- cells inside the
+    hard radius, across the whole band, past the halo, plus same-domain and
+    net-0 copper that must be ignored -- and asserts the Python mirror and the
+    C++ kernel return the SAME value, and that the value is exactly the
+    nearest qualifying cell's linear decay (computed independently here, so
+    the sweep does not merely pin two implementations of the same bug).
+
+    Origins are drawn near the board edge as well as in open field, so the
+    clipped-window path (Python clips the array slice; C++ skips
+    out-of-bounds offsets) is fuzzed too.
+    """
+    rng = random.Random(seed)
+    halo_r = _GRADIENT_HARD_R + _GRADIENT_BAND  # 25
+    nonzero_seen = 0
+    for _ in range(60):
+        # Mix open-field origins with ones hard against the board edges.
+        origin = (
+            rng.choice([rng.randint(0, 3), rng.randint(30, 170), rng.randint(196, 199)]),
+            rng.choice([rng.randint(0, 3), rng.randint(30, 170), rng.randint(196, 199)]),
+        )
+        cells = []
+        for _ in range(rng.randint(1, 14)):
+            dy = rng.randint(-halo_r - 3, halo_r + 3)
+            dx = rng.randint(-halo_r - 3, halo_r + 3)
+            gx, gy = origin[0] + dx, origin[1] + dy
+            if not (0 <= gx < 200 and 0 <= gy < 200):
+                continue  # off-board: neither engine can see it
+            # Weighted towards LV (the only gradient source) but with plenty
+            # of same-domain / pour copper to exercise the widening filter.
+            cell_net = rng.choice([LV_NET, LV_NET, LV_NET, HV_TAP_NET, 0])
+            cells.append((dy, dx, cell_net))
+        if not cells:
+            continue
+        cells = tuple(cells)
+
+        py = _py_router_with_foreign_cells(cells, origin=origin)
+        cpp = _cpp_pathfinder_with_foreign_cells(cells, origin=origin)
+        py_cost = py._pairwise_avoidance_cost(origin[0], origin[1], 0, HV_NET)
+        cpp_cost = cpp.pairwise_avoidance_cost(origin[0], origin[1], 0, HV_NET)
+        assert py_cost == pytest.approx(cpp_cost, abs=1e-6), (
+            f"backends disagree at origin={origin} cells={cells}"
+        )
+
+        # Independent oracle: nearest qualifying cell, linear decay.  A later
+        # write wins when two draws land on the same coordinate, exactly as it
+        # does in both grids.
+        by_coord: dict[tuple[int, int], int] = {}
+        for dy, dx, cell_net in cells:
+            by_coord[(dy, dx)] = cell_net
+        qualifying = [
+            dy * dy + dx * dx
+            for (dy, dx), cell_net in by_coord.items()
+            if cell_net == LV_NET and _GRADIENT_HARD_R**2 < dy * dy + dx * dx <= halo_r**2
+        ]
+        expected = 0.0
+        if qualifying:
+            expected = (
+                py.rules.cost_straight * (halo_r - math.sqrt(min(qualifying))) / _GRADIENT_BAND
+            )
+            if expected > 0.0:
+                nonzero_seen += 1
+        assert py_cost == pytest.approx(expected, abs=1e-6), (
+            f"not the nearest cell at origin={origin} cells={cells}"
+        )
+    # Non-vacuous: the sweep must actually have priced something.
+    assert nonzero_seen >= 5, f"only {nonzero_seen} priced boards -- sweep is near-vacuous"
 
 
 @requires_cpp

--- a/tests/router/test_pairwise_python_search.py
+++ b/tests/router/test_pairwise_python_search.py
@@ -511,24 +511,53 @@ def test_gradient_band_gate_flags_every_priced_cell() -> None:
             assert bool(band[0, 100 + dy, 100]) is True, f"band gate misses dy={dy}"
 
 
-def test_gradient_prices_the_first_cell_in_scan_order() -> None:
-    """Mirror wart, pinned: the C++ kernel BREAKS at its first band cell.
-
-    Row-major scan order runs from the topmost row of the window, so the
-    cell 24 cells ABOVE wins over the (much nearer) cell 18 cells below --
-    "one cross-domain neighbour is enough to establish the gradient".  The
-    Python mirror reproduces the same cell so the two engines cannot price a
-    candidate differently; see ``test_avoidance_gradient_parity_*`` in
-    ``test_pairwise_cpp_parity.py`` for the cross-engine proof.
-    """
+def _cost_with_band_cells(cells) -> float:
+    """Gradient price at (100, 100) for foreign LV copper at ``(dy, dx)`` cells."""
     rules = _rules()
     grid = RoutingGrid(width=20.0, height=20.0, rules=rules, layer_stack=LayerStack.two_layer())
-    for dy in (-24, 18):
-        grid._blocked[0, 100 + dy, 100] = True
-        grid._net[0, 100 + dy, 100] = LV_NET
+    for dy, dx in cells:
+        grid._blocked[0, 100 + dy, 100 + dx] = True
+        grid._net[0, 100 + dy, 100 + dx] = LV_NET
     router = Router(grid, rules, diagonal_routing=True)
     router.set_net_name_to_id(dict(NET_NAMES))
-    assert router._pairwise_avoidance_cost(100, 100, 0, HV_NET) == pytest.approx(1.0 / 8.0)
+    return router._pairwise_avoidance_cost(100, 100, 0, HV_NET)
+
+
+def test_gradient_prices_the_nearest_cell_in_the_band() -> None:
+    """Issue #4848: the price comes from the NEAREST band cell, not the first.
+
+    Both engines used to break at the first qualifying cell in ROW-MAJOR scan
+    order, which starts at the topmost row of the window -- so a candidate
+    with foreign copper 18 cells below (the binding side) and 24 cells above
+    priced ``1/8`` off the far cell instead of ``7/8`` off the near one, a 7x
+    under-price of the real proximity.  Nearest-in-band pricing makes the
+    nudge a monotone function of distance, matching the decay this kernel
+    always documented.  Mirrored cell-for-cell in C++ -- see
+    ``test_avoidance_gradient_parity_*`` in ``test_pairwise_cpp_parity.py``.
+    """
+    # The 24-above / 18-below arrangement, both orientations: the NEAR cell
+    # sets the price whichever side of the candidate it sits on.
+    assert _cost_with_band_cells(((-24, 0), (18, 0))) == pytest.approx(7.0 / 8.0)
+    assert _cost_with_band_cells(((24, 0), (-18, 0))) == pytest.approx(7.0 / 8.0)
+    # Order-free: adding FARTHER band copper never changes the price.
+    assert _cost_with_band_cells(((18, 0),)) == pytest.approx(7.0 / 8.0)
+    assert _cost_with_band_cells(((-24, 0), (18, 0), (0, 22), (-20, 3))) == pytest.approx(7.0 / 8.0)
+
+
+def test_gradient_is_monotone_as_copper_approaches() -> None:
+    """Sliding the same foreign blob nearer can only raise the price (#4848).
+
+    Under the old scan-order pricing this was false: moving a bar one row
+    closer left the price unchanged (both positions happened to be priced off
+    the same topmost row), so the gradient carried no information about the
+    binding distance.
+    """
+    prices = [
+        _cost_with_band_cells(tuple((dy, dx) for dy in range(top, top + 5) for dx in range(-4, 5)))
+        for top in range(-25, -17)
+    ]
+    assert prices == sorted(prices), f"gradient not monotone in proximity: {prices}"
+    assert prices[0] < prices[-1]  # non-vacuous: the sweep actually moves
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

The pairwise (HV-isolation) **soft avoidance gradient** documented a linear decay
"strongest just outside the hard radius, zero at the band edge", but both backends
broke at the first qualifying cell in **row-major scan order** — which starts at the
topmost row of the window, not the closest cell. A candidate with foreign LV copper
18 cells below (the binding side, `frac = 7/8`) and 24 cells above (`frac = 1/8`)
priced **0.125 instead of 0.875** — a 7x under-price of the real proximity, making
the HV↔LV margin nudge effectively random with respect to *which* copper was close.

Both engines now price the **nearest** qualifying cross-domain cell in the band,
changed together in this one PR with a `ROUTER_CPP_BUILD_VERSION` bump so no window
exists where a stale `.so` and the Python fallback disagree.

## Changes

- **`cpp/src/pathfinder.cpp`** — new `Pathfinder::pairwise_band_offsets(hard_r, band)`
  builds a **distance-sorted** band-offset table once per `(hard_r, band)` (the
  ring-ordered analogue of `via_kernel_offsets_`), each entry carrying its
  pre-computed decay `frac`. `pairwise_avoidance_cost` walks it and returns at the
  first qualifying cell — which is by construction the nearest — so the load-bearing
  early exit survives. It also now visits only the annulus instead of its bounding
  square (1056 vs 2601 cells at the 1.6 mm / 0.1 mm geometry).
- **`cpp/include/pathfinder.hpp`** — `PairwiseBandOffset` struct + the mutable
  `(hard_r, band)`-keyed cache and the builder declaration.
- **`cpp/include/types.hpp`** — `ROUTER_CPP_BUILD_VERSION` 19 → **20**, with the
  rationale comment (binding surface unchanged, but the *route output* changes and
  the Python mirror moved in lockstep).
- **`cpp_backend.py`** — `_REQUIRED_CPP_BUILD_VERSION` 19 → **20**.
- **`pathfinder.py`** — the mirror replaces the two-level-break replay with a
  vectorised `min` over the band's squared distances; the mirror-contract block
  comment (which explicitly deferred the semantic fix to this issue) now documents
  nearest-in-band semantics and keeps the version-19 history as the "why".

An on-circle cell (`frac == 0`) can no longer swallow the price *by construction*:
it is the **farthest** cell in the band, so it only ever wins when nothing nearer
qualifies — exactly when `0.0` is the right answer. That retires the conditional
outer break #4849 had to mirror.

## Acceptance Criteria Verification

- [x] **Both backends price the band from the nearest qualifying cell, in a single PR.**
      C++ + Python + both version constants in one commit.
- [x] **The 24-above/18-below arrangement prices `7/8`, not `1/8`; test re-pointed.**
      `test_gradient_prices_the_first_cell_in_scan_order` →
      `test_gradient_prices_the_nearest_cell_in_the_band`
      (`tests/router/test_pairwise_python_search.py`), asserting `7/8` in both
      orientations plus order-freedom. New sibling
      `test_gradient_is_monotone_as_copper_approaches` pins that sliding a blob
      nearer can only raise the price (false under the old contract).
- [x] **`test_avoidance_gradient_parity_*` updated and green, incl. board-edge and
      zero-frac cases.**
      - `_picks_the_same_cell` — now asserts the **nearest-cell magnitudes** as well
        as parity, so a drift back to scan order fails loudly rather than passing on
        mutual agreement.
      - `_zero_frac_cell_does_not_stop_the_scan` → `_on_circle_cell_never_swallows_the_price`;
        the four pinned magnitudes are **unchanged** (they were already the nearest
        cell's price), plus a new alone-on-the-circle case that must price `0.0`.
      - `_contiguous_bar_touching_the_halo` → `_contiguous_bar_slides_nearer`: the two
        bar positions used to price *identically* (0.0836, both charged off the same
        topmost row); they now price `4/8` then `5/8`.
      - New `_is_order_free`: adding farther band copper (including an on-circle
        decoy) never changes either engine's price.
      - `_across_the_band`, `_off_axis`, `_at_the_board_edge`, `_wide_class_width`,
        `_dormant_parity` unchanged and green.
- [x] **Randomized band-population parity sweep (seeded).**
      `test_avoidance_gradient_parity_randomized_band_population[17|4848|90210]` —
      60 random boards per seed: random cell counts/offsets straddling the hard
      radius, the band and the halo, a mix of LV / same-domain / net-0 copper, and
      origins drawn both in open field and hard against all four board edges (so the
      clipped-window path is fuzzed). Asserts `py == cpp` **and** that the shared
      value equals an **independent** nearest-cell oracle computed in the test, so the
      sweep cannot pass on two implementations of the same bug. Non-vacuity gate:
      ≥5 priced boards per seed.
- [x] **`ROUTER_CPP_BUILD_VERSION` bumped at `types.hpp` and matched at `cpp_backend.py`.**
      Cross-checked by the existing `tests/test_router_determinism.py` invariant (green).
- [x] **Hot-loop cost measured before/after on an HV board** — see below (measured,
      not hand-waved; includes a number that got worse).
- [x] **No routing-quality regression on the two-domain HV route tests** — both route
      DRC-clean, and the HV edge gap **improved** 2.000 mm → 2.163 mm against a
      1.6 mm requirement.
- [x] **Python fallback still behaves identically with the C++ backend absent** —
      `tests/router/test_pairwise_python_search.py` (pure-Python, no `requires_cpp`)
      is green, and every parity test asserts cell-for-cell agreement.

## Performance / behaviour evidence

Measured on this worktree by rebuilding the `.so` at both revisions (`kct build-native`),
same machine, same fixtures (`tests/router/test_pairwise_cpp_parity.py`).

| Measurement | before (v19) | after (v20) |
|---|---|---|
| **C++ kernel** `pairwise_avoidance_cost`, 198 400 probes over a populated HV grid | 1.945 µs/call | **0.845 µs/call (2.3x faster)** |
| Python mirror `_pairwise_avoidance_cost`, 20 000 calls | 15.00 µs/call | 15.18 µs/call (flat) |
| `_route_two_domain_board(with_pairwise=True)` wall clock (median of 5) | 0.395 s | 1.375 s |
| … A\* nodes explored | 11 411 | 52 535 |
| … per-node cost | 34.6 µs | **26.2 µs (24% cheaper)** |
| … route length / HV edge gap | 26.05 mm / 2.000 mm | 31.60 mm / **2.163 mm** |
| `_route_through_a_rated_gap(layer_scoped=False)` | 0.436 s, **fell into the Python fallback** | **0.161 s, pure C++ (2.7x faster)** |
| `_route_through_a_rated_gap(layer_scoped=True)` | 0.185 s / 4 035 nodes | 0.158 s / 4 022 nodes |

**The early exit survived**: the kernel itself is 2.3x cheaper per call and the
per-node cost of a route dropped 24%. The two-domain fixture's 3.5x wall-clock rise
is entirely **4.6x more A\* expansions** — i.e. the corrected cost landscape, not the
scan. That is the fix doing its job: the search now actually detours away from the LV
wall (+0.163 mm creepage for +5.5 mm of length on a synthetic 6 mm-wide wall). Calling
this out explicitly rather than burying it — it is the one number that moved the wrong
way, and it is semantic, not kernel cost. On the other HV fixture the same change is a
straight win: it removes a Python-fallback thrash entirely.

### One test's contract changed as a consequence

`test_layer_scoped_zone_converges_where_layer_agnostic_thrashes` (#4507's headline)
asserted the layer-**agnostic** baseline thrashes into the Python fallback. With the
gradient priced correctly, the nudge away from the under-clearance F.Cu gap is strong
enough that the agnostic configuration now converges **inside the C++ search**, so
that assertion is no longer true. Renamed to
`test_rated_gap_board_converges_on_the_licensed_layer` and re-pointed to pin the
*outcome* for both configurations (converged, gate-clean, crossing on B.Cu, no
fallback), with the full pre-#4507 → #4507 → #4848 evolution recorded in the docstring
so a future reader can tell an improvement from a regression.

## Test Plan

```
uv run kct build-native            # rebuilt; --check reports "available", build version 20 (required: 20)
uv run pytest tests/router/test_pairwise_cpp_parity.py tests/router/test_pairwise_python_search.py -q
#   -> 111 passed
uv run pytest tests/router -k "pairwise or hv" -q
#   -> 211 passed, 1081 deselected
uv run pytest tests/test_route_pairwise_gate_4588.py tests/test_router_cache.py \
             tests/test_router_determinism.py tests/test_router_cpp_auto_build.py -q
#   -> 155 passed   (includes the types.hpp <-> cpp_backend.py version-match invariant)
uv run pytest tests/router -q -x
#   -> exit 0, whole router suite green (~35 min locally)
uv run ruff check src tests          # All checks passed!
uv run ruff format --check src tests # 1734 files already formatted
uv run python scripts/ci/check_mypy_baseline.py
#   -> OK: 1466 error(s), all within the baseline (1472 allowed). No new type errors.
#      (baseline NOT updated -- 6 stale baseline lines are reported as a warning only,
#       per CLAUDE.md the nanobind import-not-found line must not be dropped)
```

Closes #4848
