### PR TITLE
feat(router): name the cross-domain blocker on a pairwise-blocked search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Cross-domain (HV) failures now name a rip-up target** (part of #4507, epic
+  #4431 Phase 2) — the search-time pairwise kernels
+  (`Pathfinder::cross_domain_trace_blocked` / `cross_domain_via_blocked`,
+  #4511) refused HV-through-LV candidates *silently*: unlike the #2476
+  stored-via check they named no blocker, so a net that failed only because a
+  low-voltage neighbour crowded its widened HV keepout came back as a bare
+  `FAILURE_NO_PATH` — a reason code the negotiated strategy has no targeted
+  response for, so it blanket-retried. That is exactly the negotiator thrash
+  Phase 2 exists to end. Both kernels now record the foreign net and the
+  refused candidate's world position, and a search that drains the open set
+  with such an observation reports the new
+  `FAILURE_PAIRWISE_BLOCKED` (7) with the blocker in
+  `RouteResult.blocking_via_net` — the same field
+  `NegotiatedRouter.via_blocked_ripup` already drains, so the HV net's
+  crowding neighbour gets ripped up and the HV net is routed first.
+  Precedence is deliberately conservative: `FAILURE_VIA_VIA_BLOCKED` still
+  wins when both were seen, and TIMEOUT / ITERATION_LIMIT are never
+  overridden (they are budget artifacts per #2610, not geometry). An
+  attach-zone-waived (#4506) pair records nothing — ripping it up would not
+  help. Router log label: `pairwise_blocked`. Strictly dormant without
+  `--voltage-map` (single `pairwise_active()` boolean, unchanged route
+  output); `ROUTER_CPP_BUILD_VERSION` 20 → 21 for the new binding surface.
+
 - **Structured crossing-tail census report** (part of #4799) — the #4580
   diff-pair crossover legality census now also captures what it prints as
   data. Each censused crossover produces a `CrossingTailCensusRecord`

--- a/src/kicad_tools/router/algorithms/negotiated.py
+++ b/src/kicad_tools/router/algorithms/negotiated.py
@@ -1312,6 +1312,12 @@ class NegotiatedRouter:
     # Issue #2610: per-net wall-clock deadline (--per-net-timeout) was hit.
     _FAILURE_TIMEOUT = 3
     _FAILURE_VIA_VIA_BLOCKED = 5
+    # Issue #4507 (epic #4431 Phase 2): the A* open set drained while
+    # search-time pairwise (HV-isolation) widening refused expansions.  Carries
+    # the offending foreign-domain net in ``blocking_via_net``, exactly like
+    # the via-vs-via case, so the same targeted rip-up applies.  (6 is reserved
+    # by the mirrored ``violation_type`` vocabulary for drill spacing.)
+    _FAILURE_PAIRWISE_BLOCKED = 7
 
     # Issue #2610: Human-readable labels for log differentiation.  Used by
     # describe_failure_reason() to emit "DAC_CLK aborted at iteration cap
@@ -1324,6 +1330,7 @@ class NegotiatedRouter:
         _FAILURE_ITERATION_LIMIT: "iteration_cap",
         _FAILURE_TIMEOUT: "wall_clock_timeout",
         _FAILURE_VIA_VIA_BLOCKED: "via_via_blocked",
+        _FAILURE_PAIRWISE_BLOCKED: "pairwise_blocked",
     }
 
     @classmethod
@@ -1341,15 +1348,20 @@ class NegotiatedRouter:
 
         Returns:
             One of: ``"none"``, ``"blocked_path"``, ``"iteration_cap"``,
-            ``"wall_clock_timeout"``, ``"via_via_blocked"``, ``"unknown"``.
+            ``"wall_clock_timeout"``, ``"via_via_blocked"``,
+            ``"pairwise_blocked"``, ``"unknown"``.
         """
         if not info:
             return "none"
         reason = int(info.get("failure_reason") or 0)
         return cls._FAILURE_REASON_LABELS.get(reason, "unknown")
 
+    # Failure reasons that name an actionable blocking net in
+    # ``blocking_via_net`` and therefore feed :meth:`via_blocked_ripup`.
+    _BLOCKER_FAILURE_REASONS = frozenset({_FAILURE_VIA_VIA_BLOCKED, _FAILURE_PAIRWISE_BLOCKED})
+
     def _record_via_blocked_failure(self, failed_net: int) -> None:
-        """Capture a via-vs-via failure from the most recent route() call.
+        """Capture a blocker-naming failure from the most recent route() call.
 
         Issue #2476: When a sub-route fails, ask the underlying router for
         structured failure diagnostics.  If the C++ pathfinder reports
@@ -1358,11 +1370,20 @@ class NegotiatedRouter:
         the negotiated outer loop can rip up the specific blocker rather
         than blanket retry.
 
+        Issue #4507 (epic #4431 Phase 2): ``FAILURE_PAIRWISE_BLOCKED`` is
+        accepted on the same footing.  There the blocker is the foreign-domain
+        (HV<->LV) net whose copper made the widened pairwise clearance
+        unsatisfiable -- the search-time refusal that previously produced a
+        bare ``NO_PATH``, so an HV net that was merely *crowded* by a
+        low-voltage neighbour fell through to blanket retry and thrashed the
+        negotiator.  Ripping up the named neighbour and routing the HV net
+        first is exactly the move that resolves it.
+
         This is a no-op when:
         - The router is the Python pathfinder (returns ``None``).
         - The failure was an unrelated grid-cell rejection (no actionable
           diagnostic).
-        - The blocking net id is 0 (not a stored-via geometric reject).
+        - The blocking net id is 0 (no geometric/pairwise blocker named).
 
         Args:
             failed_net: Net id of the net whose route failed.
@@ -1373,7 +1394,7 @@ class NegotiatedRouter:
         info = get_info()
         if not info:
             return
-        if info.get("failure_reason") != self._FAILURE_VIA_VIA_BLOCKED:
+        if info.get("failure_reason") not in self._BLOCKER_FAILURE_REASONS:
             return
         blocking_net = int(info.get("blocking_via_net") or 0)
         if blocking_net == 0 or blocking_net == failed_net:
@@ -2346,6 +2367,9 @@ class NegotiatedRouter:
         Issue #2476: When the C++ A* search refuses every via candidate
         because of a stored-via clearance violation, it surfaces the
         offending stored-via net via ``RouteResult.blocking_via_net``.
+        Issue #4507 feeds the same channel from ``FAILURE_PAIRWISE_BLOCKED``
+        (the cross-domain HV blocker), so this method now also resolves
+        "HV net crowded by a low-voltage neighbour" failures.
         This method drains those (failed_net, blocking_net) pairs from
         :meth:`get_and_clear_via_blocking_nets`, rips up each blocking
         net, and routes the failed net first.  Displaced blockers are

--- a/src/kicad_tools/router/cpp/include/pathfinder.hpp
+++ b/src/kicad_tools/router/cpp/include/pathfinder.hpp
@@ -281,6 +281,31 @@ public:
     // pair.  Used to size the annulus scans above.  Returns 0 when dormant.
     int pairwise_wide_radius_cells(float half_mm) const;
 
+    // Issue #4507: cross-domain rip-up diagnostics.  Both kernels above record
+    // the foreign net whose copper refused the candidate (plus the candidate's
+    // world coordinates) so a drained search can name a blocker instead of
+    // returning a bare NO_PATH.  This is the pairwise sibling of the #2476
+    // stored-via diagnostic and feeds the same
+    // ``NegotiatedRouter.via_blocked_ripup`` path.
+    //
+    // The counters are pure diagnostics -- they never change which candidates
+    // are accepted -- and are only written on a rejection that already
+    // short-circuited on ``pairwise_active()``, so the no-voltage-map hot path
+    // is untouched.
+    int pairwise_block_count() const { return pairwise_block_count_; }
+    int last_pairwise_block_net() const { return last_pairwise_block_net_; }
+    float last_pairwise_block_x() const { return last_pairwise_block_x_; }
+    float last_pairwise_block_y() const { return last_pairwise_block_y_; }
+
+    // Reset the diagnostics above.  Called at the start of every search so a
+    // stale blocker from the previous net cannot leak into the next one.
+    void clear_pairwise_block_diagnostics() {
+        pairwise_block_count_ = 0;
+        last_pairwise_block_net_ = 0;
+        last_pairwise_block_x_ = 0.0f;
+        last_pairwise_block_y_ = 0.0f;
+    }
+
     // Check if diagonal move cuts through obstacles.
     //
     // Public for binding + unit-test access (Issue #3456): the
@@ -437,6 +462,35 @@ private:
     // Lazily build (and cache) the distance-sorted band offsets above.
     const std::vector<PairwiseBandOffset>& pairwise_band_offsets(
         int hard_radius, int band) const;
+
+    // Issue #4507: cross-domain rip-up diagnostics (see the public accessors).
+    // Mutable because the recording kernels are ``const`` -- same rationale as
+    // the band-offset cache above; nothing here feeds a routing decision.
+    mutable int pairwise_block_count_ = 0;
+    mutable int last_pairwise_block_net_ = 0;
+    mutable float last_pairwise_block_x_ = 0.0f;
+    mutable float last_pairwise_block_y_ = 0.0f;
+
+    // Record one cross-domain refusal.  ``foreign_net`` is the net whose
+    // copper triggered the widened requirement; ``(wx, wy)`` is the world
+    // location of the REFUSED CANDIDATE (matching the #2476 via-vs-via
+    // convention, which reports the candidate rather than the blocker).
+    void note_pairwise_block(int foreign_net, float wx, float wy) const {
+        ++pairwise_block_count_;
+        last_pairwise_block_net_ = foreign_net;
+        last_pairwise_block_x_ = wx;
+        last_pairwise_block_y_ = wy;
+    }
+
+    // Stamp the recorded cross-domain blocker onto a failed RouteResult.
+    // Shared by the one-shot ``route()`` epilogue and the resumable
+    // ``run_astar_loop()`` epilogue so the two cannot drift.
+    void set_pairwise_failure(RouteResult& result) const {
+        result.failure_reason = FAILURE_PAIRWISE_BLOCKED;
+        result.blocking_via_net = last_pairwise_block_net_;
+        result.failure_x = last_pairwise_block_x_;
+        result.failure_y = last_pairwise_block_y_;
+    }
 
     // Routable layer indices
     std::vector<int> routable_layers_;

--- a/src/kicad_tools/router/cpp/include/types.hpp
+++ b/src/kicad_tools/router/cpp/include/types.hpp
@@ -213,7 +213,18 @@ namespace router {
 // changes and the Python mirror (``Router._pairwise_avoidance_cost``) was
 // updated in lockstep: a stale .so would price a different gradient than the
 // fallback, so the version bump forces a rebuild via ``kct build-native``.
-constexpr int ROUTER_CPP_BUILD_VERSION = 20;
+//
+// Version 21 (Issue #4507): cross-domain (HV) rip-up diagnostics.  The
+// search-time pairwise kernels (``cross_domain_trace_blocked`` /
+// ``cross_domain_via_blocked``) now record the foreign net whose copper
+// refused the candidate, and a drained-open-set failure with such an
+// observation is reported as the new ``FAILURE_PAIRWISE_BLOCKED`` with the
+// blocker in ``RouteResult::blocking_via_net``.  Before this the HV widening
+// was the one refusal path that produced NO diagnostic at all, so the
+// negotiated strategy fell through to blanket retry (the thrash Phase 2
+// exists to end).  New module constant + four ``Pathfinder`` accessors =
+// binding-surface change; route output is unchanged (diagnostics only).
+constexpr int ROUTER_CPP_BUILD_VERSION = 21;
 
 // Issue #4071: fixed-capacity owner-set size for per-cell corridor
 // reservations.  Observed owner sets in practice are tiny: 1 for the
@@ -354,12 +365,27 @@ struct Via {
 // location of the candidate via that was rejected.  The negotiated strategy
 // uses these fields to target rip-up at the specific net whose stored via
 // blocked progress, rather than blanket retry.
+//
+// FAILURE_PAIRWISE_BLOCKED (Issue #4507, epic #4431 Phase 2) is the
+// cross-domain sibling: the A* open set drained while at least one expansion
+// was refused by the search-time pairwise (HV-isolation) widening
+// (``Pathfinder::cross_domain_trace_blocked`` / ``cross_domain_via_blocked``).
+// ``RouteResult::blocking_via_net`` then carries the net id of the most
+// recently observed foreign-domain copper and ``failure_x``/``failure_y`` the
+// world location of the refused candidate, so the negotiated strategy can rip
+// up THAT net rather than blanket retry.  It is strictly weaker than
+// FAILURE_VIA_VIA_BLOCKED (which wins when both were observed) and, unlike it,
+// never overrides TIMEOUT / ITERATION_LIMIT: those are budget artifacts, and a
+// widened HV keepout is only the actionable explanation when the search truly
+// ran out of candidates.  Value 7 skips 6, which the mirrored
+// ``violation_type`` vocabulary uses for drill spacing.
 enum FailureReason : int {
     FAILURE_NONE = 0,
     FAILURE_NO_PATH = 1,            // Open set exhausted, no candidates remained.
     FAILURE_ITERATION_LIMIT = 2,    // Reached max_iterations cap (memory backstop).
     FAILURE_TIMEOUT = 3,            // Per-net wall-clock deadline exceeded (Issue #2610).
     FAILURE_VIA_VIA_BLOCKED = 5,    // All via candidates refused by stored-via geometry.
+    FAILURE_PAIRWISE_BLOCKED = 7,   // Expansions refused by cross-domain (HV) widening.
 };
 
 // Complete route result

--- a/src/kicad_tools/router/cpp/src/bindings.cpp
+++ b/src/kicad_tools/router/cpp/src/bindings.cpp
@@ -176,6 +176,10 @@ NB_MODULE(router_cpp, m) {
     // Issue #2610: wall-clock deadline (--per-net-timeout) was hit.
     m.attr("FAILURE_TIMEOUT") = static_cast<int>(FAILURE_TIMEOUT);
     m.attr("FAILURE_VIA_VIA_BLOCKED") = static_cast<int>(FAILURE_VIA_VIA_BLOCKED);
+    // Issue #4507: the open set drained while cross-domain (HV) pairwise
+    // widening refused expansions; ``blocking_via_net`` names the foreign net.
+    m.attr("FAILURE_PAIRWISE_BLOCKED") =
+        static_cast<int>(FAILURE_PAIRWISE_BLOCKED);
 
     // Grid3D class
     nb::class_<Grid3D>(m, "Grid3D")
@@ -537,6 +541,27 @@ NB_MODULE(router_cpp, m) {
              "x"_a, "y"_a, "layer"_a, "net"_a,
              "Issue #4511 Scope 2: the soft cross-domain avoidance cost (0.0 "
              "when dormant or no HV copper in the gradient band).")
+        .def("clear_pairwise_block_diagnostics",
+             &Pathfinder::clear_pairwise_block_diagnostics,
+             "Issue #4507: reset the cross-domain (HV) rip-up diagnostics.  "
+             "Called automatically at the start of every search; exposed so "
+             "tests can drive the kernels in isolation.")
+        .def_prop_ro("pairwise_block_count",
+                     &Pathfinder::pairwise_block_count,
+                     "Issue #4507: how many expansions the search-time "
+                     "pairwise (HV) widening refused since the last reset.")
+        .def_prop_ro("last_pairwise_block_net",
+                     &Pathfinder::last_pairwise_block_net,
+                     "Issue #4507: net id of the most recently observed "
+                     "cross-domain blocker (0 when none).  Surfaced on a "
+                     "drained search as ``RouteResult.blocking_via_net`` with "
+                     "``failure_reason == FAILURE_PAIRWISE_BLOCKED``.")
+        .def_prop_ro("last_pairwise_block_x",
+                     &Pathfinder::last_pairwise_block_x,
+                     "Issue #4507: world X of the refused candidate.")
+        .def_prop_ro("last_pairwise_block_y",
+                     &Pathfinder::last_pairwise_block_y,
+                     "Issue #4507: world Y of the refused candidate.")
         .def_prop_ro("iterations", &Pathfinder::get_iterations)
         .def_prop_ro("nodes_explored", &Pathfinder::get_nodes_explored);
 

--- a/src/kicad_tools/router/cpp/src/pathfinder.cpp
+++ b/src/kicad_tools/router/cpp/src/pathfinder.cpp
@@ -589,6 +589,10 @@ bool Pathfinder::cross_domain_trace_blocked(int x, int y, int layer, int net,
             const float mx = (cw.first + fw.first) * 0.5f;
             const float my = (cw.second + fw.second) * 0.5f;
             if (grid_.attach_zone_exempts(mx, my, net, cell.net, layer)) continue;
+            // Issue #4507: name the blocker so a drained search can report
+            // FAILURE_PAIRWISE_BLOCKED instead of a bare NO_PATH.  Diagnostic
+            // only -- the verdict below is unchanged.
+            note_pairwise_block(cell.net, cw.first, cw.second);
             return true;
         }
     }
@@ -632,6 +636,8 @@ bool Pathfinder::cross_domain_via_blocked(int x, int y, int net) const {
                 // ``layer``, so the waiver is scoped to it (a via passing a
                 // rated SMD part's pad field on an inner layer is not exempt).
                 if (grid_.attach_zone_exempts(mx, my, net, cell.net, layer)) continue;
+                // Issue #4507: record the blocker (diagnostic only).
+                note_pairwise_block(cell.net, cw.first, cw.second);
                 return true;
             }
         }
@@ -1184,6 +1190,13 @@ RouteResult Pathfinder::route(
     float last_block_world_x = 0.0f;
     float last_block_world_y = 0.0f;
 
+    // Issue #4507: same idea for cross-domain (HV) refusals, which until now
+    // were the one rejection path that produced no diagnostic at all.  The
+    // counters live on the pathfinder (the recording kernels are ``const``
+    // and are reached from four different blocking call sites), so reset them
+    // here for a fresh one-shot search.
+    clear_pairwise_block_diagnostics();
+
     // Issue #3143: Populate the per-cell pad-channel cost lookup so the
     // one-shot route() path honours the budget identically to
     // route_resumable().  Empty budget list (default) leaves the map
@@ -1570,6 +1583,15 @@ RouteResult Pathfinder::route(
         result.blocking_via_net = last_blocking_net;
         result.failure_x = last_block_world_x;
         result.failure_y = last_block_world_y;
+    } else if (result.failure_reason == FAILURE_NO_PATH &&
+               pairwise_block_count_ > 0 && last_pairwise_block_net_ != 0) {
+        // Issue #4507: no stored-via blocker, but the open set drained while
+        // cross-domain (HV) widening refused expansions -- name that net so
+        // the negotiated strategy rips IT up instead of blanket-retrying.
+        // Deliberately narrower than the VIA_VIA branch above: only a genuine
+        // drain qualifies, never TIMEOUT / ITERATION_LIMIT (budget artifacts,
+        // per Issue #2610's distinction).
+        set_pairwise_failure(result);
     }
     return result;
 }
@@ -1695,6 +1717,12 @@ RouteResult Pathfinder::route_resumable(
     search_last_blocking_net_ = 0;
     search_last_block_world_x_ = 0.0f;
     search_last_block_world_y_ = 0.0f;
+
+    // Issue #4507: cross-domain (HV) refusal diagnostics follow the SAME
+    // reset discipline -- cleared for a fresh resumable search, deliberately
+    // preserved across resume() so a blocker observed by the initial search
+    // still names the culprit when a later resume drains the open set.
+    clear_pairwise_block_diagnostics();
 
     // Issue #3143: Build the per-cell pad-channel cost lookup ONCE per
     // resumable search.  Held across resume() calls so the soft-budget
@@ -2152,6 +2180,11 @@ RouteResult Pathfinder::run_astar_loop() {
         result.blocking_via_net = search_last_blocking_net_;
         result.failure_x = search_last_block_world_x_;
         result.failure_y = search_last_block_world_y_;
+    } else if (result.failure_reason == FAILURE_NO_PATH &&
+               pairwise_block_count_ > 0 && last_pairwise_block_net_ != 0) {
+        // Issue #4507: cross-domain (HV) blocker on a genuine drain -- see the
+        // twin branch in route() for the precedence rationale.
+        set_pairwise_failure(result);
     }
     return result;
 }
@@ -2174,6 +2207,8 @@ void Pathfinder::clear_search_state() {
     search_last_blocking_net_ = 0;
     search_last_block_world_x_ = 0.0f;
     search_last_block_world_y_ = 0.0f;
+    // Issue #4507: ditto for the cross-domain (HV) blocker diagnostics.
+    clear_pairwise_block_diagnostics();
     // Issue #2559 / Phase 1C: reset partner-net state so a stale partner
     // from a previous net does not leak into the next route().
     search_partner_net_ = -1;

--- a/src/kicad_tools/router/cpp_backend.py
+++ b/src/kicad_tools/router/cpp_backend.py
@@ -50,7 +50,7 @@ logger = logging.getLogger(__name__)
 # ``AttributeError`` deep in the routing code (e.g. ``router_cpp.PadBounds``
 # missing).  The guard below catches that at import time and falls back to the
 # pure-Python router with an actionable ``kct build-native`` hint.
-_REQUIRED_CPP_BUILD_VERSION = 20
+_REQUIRED_CPP_BUILD_VERSION = 21
 
 # Try to import C++ module with detailed error tracking
 _CPP_IMPORT_ERROR: str | None = None
@@ -2294,6 +2294,13 @@ class CppPathfinder:
         unreachable goal).  We also record the C++ pathfinder's iteration
         counter so callers can log "aborted at N iterations" cleanly.
 
+        Issue #4507: ``failure_reason`` may also be
+        ``FAILURE_PAIRWISE_BLOCKED`` -- the open set drained while
+        cross-domain (HV-isolation) widening refused expansions.  It uses the
+        same ``blocking_via_net`` field (the foreign-domain net whose copper
+        refused the candidate), so the negotiated strategy's targeted rip-up
+        works on it unchanged.
+
         Note: We capture even when we are about to fall back to the Python
         router.  If the Python fallback also fails, the cpp-side
         diagnostic is still actionable (the via blocker has not moved).
@@ -2346,12 +2353,23 @@ class CppPathfinder:
             int(router_cpp.FAILURE_VIA_VIA_BLOCKED): (
                 "all via candidates blocked by stored-via geometry"
             ),
+            # Issue #4507: the cross-domain (HV-isolation) sibling.
+            int(router_cpp.FAILURE_PAIRWISE_BLOCKED): (
+                "open set drained with expansions refused by pairwise (HV-isolation) clearance"
+            ),
         }
         desc = descriptions.get(reason)
         if desc is None:
             return f"C++ search failed (failure_reason={reason})"
         blocking_net = int(getattr(result, "blocking_via_net", 0))
-        if reason == int(router_cpp.FAILURE_VIA_VIA_BLOCKED) and blocking_net:
+        if (
+            reason
+            in (
+                int(router_cpp.FAILURE_VIA_VIA_BLOCKED),
+                int(router_cpp.FAILURE_PAIRWISE_BLOCKED),
+            )
+            and blocking_net
+        ):
             desc += f" (blocking net id {blocking_net})"
         return desc
 

--- a/tests/router/test_pairwise_ripup_diagnostics_4507.py
+++ b/tests/router/test_pairwise_ripup_diagnostics_4507.py
@@ -1,0 +1,395 @@
+"""Cross-domain (HV) rip-up diagnostics for the search-time pairwise kernels.
+
+Issue #4507 (epic #4431 Phase 2).  Phase 2b (#4511) gave the C++ A* search hard
+cross-domain blocking, but the refusal was *silent*: unlike the #2476
+stored-via check, ``cross_domain_trace_blocked`` / ``cross_domain_via_blocked``
+named no blocker, so a net that failed because a low-voltage neighbour crowded
+its widened HV keepout came back as a bare ``FAILURE_NO_PATH``.  The negotiated
+strategy has no rip-up target for that reason code, so it blanket-retried --
+precisely the thrash Phase 2 exists to end.
+
+This module pins the new diagnostic end to end:
+
+* the kernels record ``(foreign net, refused candidate)`` -- and record
+  *nothing* when the refusal never happens (dormant / same-domain / net 0) or
+  when a rated footprint's attach zone (#4506) waives the widening;
+* a drained search reports ``FAILURE_PAIRWISE_BLOCKED`` with the blocker in
+  ``RouteResult.blocking_via_net``, while TIMEOUT / ITERATION_LIMIT (budget
+  artifacts, per #2610) and the stored-via diagnostic keep precedence;
+* ``NegotiatedRouter`` feeds the new reason into the existing targeted rip-up
+  queue; and
+* without a voltage map nothing above can fire (byte-identical dormancy).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from kicad_tools.router.cpp_backend import CppGrid, CppPathfinder, is_cpp_available
+from kicad_tools.router.grid import RoutingGrid
+from kicad_tools.router.layers import Layer, LayerStack
+from kicad_tools.router.pairwise_clearance import (
+    build_cpp_domain_matrix,
+    build_pairwise_clearance_table,
+)
+from kicad_tools.router.primitives import Pad
+from kicad_tools.router.rules import DesignRules, NetClassRouting
+
+requires_cpp = pytest.mark.skipif(
+    not is_cpp_available(),
+    reason="C++ router backend not available",
+)
+
+DRU = 0.2
+TRACE_WIDTH = 0.2
+RESOLUTION = 0.1
+
+HV_NET = 1  # /AC_LINE  @ 150 V
+LV_NET = 2  # /GND      @ 0 V
+HV_TAP_NET = 3  # /AC_LINE_TAP -- same domain as HV_NET
+NET_NAMES = {"/AC_LINE": HV_NET, "/GND": LV_NET, "/AC_LINE_TAP": HV_TAP_NET}
+VOLTAGES = {"/AC_LINE": 150.0, "/GND": 0.0, "/AC_LINE_TAP": 150.0}
+
+# IEC 60664-1, PD2, material group IIIa @ 150 V -> 1.6 mm.  At 0.1 mm
+# resolution the scalar trace radius is 3 cells and the widened HV<->LV radius
+# is ceil((0.1 + 1.6) / 0.1) = 17 cells, so a foreign cell 8 cells away sits in
+# the annulus: inside the widening, outside the scalar disc.
+SCALAR_RADIUS = 3
+ANNULUS_DY = 8
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _cpp_grid(cols: int = 200, rows: int = 200):
+    from kicad_tools.router import router_cpp
+
+    return router_cpp.Grid3D(cols, rows, 2, RESOLUTION, 0.0, 0.0)
+
+
+def _cpp_rules():
+    from kicad_tools.router import router_cpp
+
+    rules = router_cpp.DesignRules()
+    rules.trace_width = TRACE_WIDTH
+    rules.trace_clearance = DRU
+    rules.via_diameter = 0.6
+    rules.via_clearance = DRU
+    rules.grid_resolution = RESOLUTION
+    rules.cost_straight = 1.0
+    return rules
+
+
+def _pathfinder(grid):
+    from kicad_tools.router import router_cpp
+
+    pf = router_cpp.Pathfinder(grid, _cpp_rules(), True)
+    pf.set_search_pair_widths(TRACE_WIDTH / 2.0, 0.3)
+    return pf
+
+
+def _install_domains(grid) -> None:
+    domains = build_cpp_domain_matrix(build_pairwise_clearance_table(VOLTAGES, dru=DRU), NET_NAMES)
+    assert domains is not None
+    grid.set_pairwise_domains(domains.net_to_domain, domains.matrix)
+
+
+def _cpp_zone(min_x, min_y, max_x, max_y, net_ids):
+    from kicad_tools.router import router_cpp
+
+    zone = router_cpp.AttachZone()
+    zone.min_x, zone.min_y, zone.max_x, zone.max_y = min_x, min_y, max_x, max_y
+    zone.net_ids = list(net_ids)
+    return zone
+
+
+# ---------------------------------------------------------------------------
+# Kernel-level recording
+# ---------------------------------------------------------------------------
+
+
+@requires_cpp
+def test_trace_kernel_records_the_foreign_blocker() -> None:
+    """A cross-domain refusal names the LV net and the refused candidate."""
+    grid = _cpp_grid()
+    _install_domains(grid)
+    pf = _pathfinder(grid)
+    grid.mark_blocked(100, 100 + ANNULUS_DY, 0, LV_NET, False, False)
+
+    assert pf.pairwise_block_count == 0
+    assert pf.cross_domain_trace_blocked(100, 100, 0, HV_NET, SCALAR_RADIUS) is True
+
+    assert pf.pairwise_block_count == 1
+    assert pf.last_pairwise_block_net == LV_NET
+    # The #2476 convention reports the REFUSED CANDIDATE, not the blocker.
+    assert pf.last_pairwise_block_x == pytest.approx(10.0)
+    assert pf.last_pairwise_block_y == pytest.approx(10.0)
+
+
+@requires_cpp
+def test_via_kernel_records_the_foreign_blocker() -> None:
+    """The via sibling records through the same channel."""
+    grid = _cpp_grid()
+    _install_domains(grid)
+    pf = _pathfinder(grid)
+    # 12 cells away: outside the scalar via disc, inside the widened radius
+    # ceil((0.3 + 1.6) / 0.1) = 19 cells.
+    grid.mark_blocked(100, 112, 1, LV_NET, False, False)
+
+    assert pf.cross_domain_via_blocked(100, 100, HV_NET) is True
+    assert pf.pairwise_block_count == 1
+    assert pf.last_pairwise_block_net == LV_NET
+
+
+@requires_cpp
+@pytest.mark.parametrize("foreign_net", [HV_TAP_NET, 0])
+def test_no_widening_records_nothing(foreign_net: int) -> None:
+    """Same-domain copper and net 0 never widen, so they never record."""
+    grid = _cpp_grid()
+    _install_domains(grid)
+    pf = _pathfinder(grid)
+    grid.mark_blocked(100, 100 + ANNULUS_DY, 0, foreign_net, False, False)
+
+    assert pf.cross_domain_trace_blocked(100, 100, 0, HV_NET, SCALAR_RADIUS) is False
+    assert pf.pairwise_block_count == 0
+    assert pf.last_pairwise_block_net == 0
+
+
+@requires_cpp
+def test_dormant_kernel_records_nothing() -> None:
+    """No installed matrix -> the kernel short-circuits before any recording."""
+    grid = _cpp_grid()
+    pf = _pathfinder(grid)
+    grid.mark_blocked(100, 100 + ANNULUS_DY, 0, LV_NET, False, False)
+
+    assert pf.cross_domain_trace_blocked(100, 100, 0, HV_NET, SCALAR_RADIUS) is False
+    assert pf.cross_domain_via_blocked(100, 100, HV_NET) is False
+    assert pf.pairwise_block_count == 0
+
+
+@requires_cpp
+def test_attach_zone_waiver_records_nothing() -> None:
+    """A waived (#4506) pair is not a blocker -- ripping it up would not help."""
+    grid = _cpp_grid()
+    _install_domains(grid)
+    grid.set_attach_zones([_cpp_zone(0.0, 0.0, 20.0, 20.0, [HV_NET, LV_NET])])
+    pf = _pathfinder(grid)
+    grid.mark_blocked(100, 100 + ANNULUS_DY, 0, LV_NET, False, False)
+
+    assert pf.cross_domain_trace_blocked(100, 100, 0, HV_NET, SCALAR_RADIUS) is False
+    assert pf.pairwise_block_count == 0
+
+
+@requires_cpp
+def test_clear_resets_the_diagnostics() -> None:
+    grid = _cpp_grid()
+    _install_domains(grid)
+    pf = _pathfinder(grid)
+    grid.mark_blocked(100, 100 + ANNULUS_DY, 0, LV_NET, False, False)
+    assert pf.cross_domain_trace_blocked(100, 100, 0, HV_NET, SCALAR_RADIUS) is True
+
+    pf.clear_pairwise_block_diagnostics()
+    assert pf.pairwise_block_count == 0
+    assert pf.last_pairwise_block_net == 0
+    assert pf.last_pairwise_block_x == pytest.approx(0.0)
+    assert pf.last_pairwise_block_y == pytest.approx(0.0)
+
+
+# ---------------------------------------------------------------------------
+# Search-level failure reason
+# ---------------------------------------------------------------------------
+
+
+def _curtain_grid(with_pairwise: bool):
+    """An LV curtain across the board with a 1.0 mm slot at mid-height.
+
+    The slot is wide enough for the HV trace at the DRU floor (0.3 mm each
+    side) and far too narrow for the 1.6 mm creepage requirement, so the SAME
+    geometry routes when the matrix is dormant and drains when it is not.
+    """
+    grid = _cpp_grid(cols=120, rows=120)
+    if with_pairwise:
+        _install_domains(grid)
+    for layer in (0, 1):
+        for y in range(120):
+            if 55 <= y <= 65:  # 1.0 mm slot centred on y = 6.0 mm
+                continue
+            grid.mark_blocked(60, y, layer, LV_NET, False, False)
+    return grid
+
+
+def _route_across_curtain(grid, **kwargs):
+    pf = _pathfinder(grid)
+    return pf.route(
+        start_x=2.0,
+        start_y=6.0,
+        start_layer=0,
+        end_x=10.0,
+        end_y=6.0,
+        end_layer=0,
+        net=HV_NET,
+        trace_radius_cells=SCALAR_RADIUS,
+        via_radius_cells=SCALAR_RADIUS,
+        **kwargs,
+    )
+
+
+@requires_cpp
+def test_drained_search_names_the_cross_domain_blocker() -> None:
+    """The headline: a pairwise-blocked drain is actionable, not a bare NO_PATH."""
+    from kicad_tools.router import router_cpp
+
+    # Baseline: the same slot is routable while the matrix is dormant, so the
+    # failure below is caused by the pairwise widening and nothing else.
+    open_result = _route_across_curtain(_curtain_grid(with_pairwise=False))
+    assert open_result.success is True
+    assert open_result.failure_reason == router_cpp.FAILURE_NONE
+
+    blocked = _route_across_curtain(_curtain_grid(with_pairwise=True))
+    assert blocked.success is False
+    assert blocked.failure_reason == router_cpp.FAILURE_PAIRWISE_BLOCKED
+    assert blocked.blocking_via_net == LV_NET
+    # The reported location is a refused candidate on the board, not (0, 0).
+    assert 0.0 < blocked.failure_x < 12.0
+
+
+@requires_cpp
+def test_no_matrix_drain_stays_no_path() -> None:
+    """Backward compat: dormant pairwise -> the pre-#4507 reason code."""
+    from kicad_tools.router import router_cpp
+
+    grid = _cpp_grid(cols=120, rows=120)
+    for layer in (0, 1):
+        for y in range(120):
+            grid.mark_blocked(60, y, layer, LV_NET, False, False)  # solid curtain
+
+    result = _route_across_curtain(grid)
+    assert result.success is False
+    assert result.failure_reason == router_cpp.FAILURE_NO_PATH
+    assert result.blocking_via_net == 0
+
+
+@requires_cpp
+def test_iteration_limit_keeps_precedence_over_the_pairwise_blocker() -> None:
+    """A budget artifact is never relabelled as a geometric HV blocker.
+
+    ``--max-search-iterations`` exhaustion means "we ran out of budget", which
+    calls for a bigger cap (#2610), not for ripping up a neighbouring net.
+    """
+    from kicad_tools.router import router_cpp
+
+    result = _route_across_curtain(_curtain_grid(with_pairwise=True), max_search_iterations=5)
+    assert result.success is False
+    assert result.failure_reason == router_cpp.FAILURE_ITERATION_LIMIT
+
+
+# ---------------------------------------------------------------------------
+# cpp_backend / negotiated plumbing
+# ---------------------------------------------------------------------------
+
+
+@requires_cpp
+def test_failure_reason_constant_is_exposed_and_mirrored() -> None:
+    from kicad_tools.router import router_cpp
+    from kicad_tools.router.algorithms.negotiated import NegotiatedRouter
+
+    assert int(router_cpp.FAILURE_PAIRWISE_BLOCKED) == 7
+    assert int(router_cpp.FAILURE_PAIRWISE_BLOCKED) == NegotiatedRouter._FAILURE_PAIRWISE_BLOCKED
+    # 6 belongs to the mirrored ``violation_type`` vocabulary (drill spacing).
+    assert int(router_cpp.FAILURE_PAIRWISE_BLOCKED) != int(router_cpp.FAILURE_VIA_VIA_BLOCKED)
+
+
+@requires_cpp
+def test_backend_surfaces_the_diagnostic_to_the_negotiated_strategy() -> None:
+    """``get_last_failure_info`` carries the blocker through ``CppPathfinder``."""
+    from kicad_tools.router import router_cpp
+
+    rules = DesignRules(
+        trace_width=TRACE_WIDTH,
+        trace_clearance=DRU,
+        via_diameter=0.6,
+        via_clearance=DRU,
+        grid_resolution=RESOLUTION,
+    )
+    rules.pairwise_clearance = build_pairwise_clearance_table({"HV": 150.0, "LV": 0.0}, dru=DRU)
+    grid = RoutingGrid(width=12.0, height=12.0, rules=rules, layer_stack=LayerStack.two_layer())
+    start = Pad(x=2.0, y=6.0, width=0.6, height=0.6, net=1, net_name="HV", layer=Layer.F_CU)
+    end = Pad(x=10.0, y=6.0, width=0.6, height=0.6, net=1, net_name="HV", layer=Layer.F_CU)
+    grid.add_pad(start)
+    grid.add_pad(end)
+    # LV curtain with a 1.0 mm slot at y = 6.0, on both layers.
+    for layer in (Layer.F_CU, Layer.B_CU):
+        grid.add_pad(Pad(x=6.0, y=3.0, width=0.6, height=5.0, net=2, net_name="LV", layer=layer))
+        grid.add_pad(Pad(x=6.0, y=9.0, width=0.6, height=5.0, net=2, net_name="LV", layer=layer))
+    nc = NetClassRouting(name="HV", trace_width=TRACE_WIDTH, clearance=DRU)
+    cpp_grid = CppGrid.from_routing_grid(grid)
+    pf = CppPathfinder(cpp_grid, rules, diagonal_routing=True, net_class_map={"HV": nc})
+    pf.set_net_name_to_id({"HV": 1, "LV": 2})
+    # The 10-100x-slower pure-Python fallback is HV-aware too (#4791) and would
+    # only re-derive the same verdict; the diagnostic is captured before it.
+    pf._try_python_fallback = lambda *args, **kwargs: None
+
+    assert pf.route(start, end, net_class=nc) is None
+    info = pf.get_last_failure_info()
+    assert info is not None
+    assert info["failure_reason"] == int(router_cpp.FAILURE_PAIRWISE_BLOCKED)
+    assert info["blocking_via_net"] == 2
+
+    # And the human-readable form names the blocker for the router log.
+    class _Result:
+        failure_reason = int(router_cpp.FAILURE_PAIRWISE_BLOCKED)
+        blocking_via_net = 2
+
+    desc = pf._describe_cpp_failure(_Result())
+    assert "pairwise" in desc
+    assert "blocking net id 2" in desc
+
+
+def test_negotiated_records_the_pairwise_blocker_for_ripup() -> None:
+    """The new reason feeds the existing #2476 targeted-ripup queue."""
+    from kicad_tools.router.algorithms.negotiated import NegotiatedRouter
+
+    rules = DesignRules(
+        trace_width=TRACE_WIDTH,
+        trace_clearance=DRU,
+        via_clearance=DRU,
+        grid_resolution=RESOLUTION,
+    )
+    grid = RoutingGrid(width=10.0, height=10.0, rules=rules, layer_stack=LayerStack.two_layer())
+
+    class FakeRouter:
+        info: dict | None = None
+
+        def get_last_failure_info(self):
+            return self.info
+
+    fake = FakeRouter()
+    neg = NegotiatedRouter(grid, fake, rules, net_class_map={})
+
+    fake.info = {
+        "failure_reason": NegotiatedRouter._FAILURE_PAIRWISE_BLOCKED,
+        "blocking_via_net": LV_NET,
+        "failure_x": 1.0,
+        "failure_y": 2.0,
+    }
+    neg._record_via_blocked_failure(failed_net=HV_NET)
+    assert neg.get_and_clear_via_blocking_nets() == {(HV_NET, LV_NET)}
+
+    # A plain NO_PATH still yields nothing to rip up.
+    fake.info = {
+        "failure_reason": NegotiatedRouter._FAILURE_NO_PATH,
+        "blocking_via_net": LV_NET,
+    }
+    neg._record_via_blocked_failure(failed_net=HV_NET)
+    assert neg.get_and_clear_via_blocking_nets() == set()
+
+
+def test_negotiated_labels_the_new_reason() -> None:
+    from kicad_tools.router.algorithms.negotiated import NegotiatedRouter
+
+    label = NegotiatedRouter.describe_failure_reason(
+        {"failure_reason": NegotiatedRouter._FAILURE_PAIRWISE_BLOCKED}
+    )
+    assert label == "pairwise_blocked"


### PR DESCRIPTION
Part of #4507 (epic #4431 Phase 2). Fifth partial increment — **not** a close.

## What this slice fixes

Phase 2b (#4511) gave the C++ A* search hard cross-domain (HV-isolation)
blocking, but the refusal is **silent**. Unlike the #2476 stored-via check,
`cross_domain_trace_blocked` / `cross_domain_via_blocked` named no blocker, so
a net that failed *only* because a low-voltage neighbour crowded its widened HV
keepout surfaced as a bare `FAILURE_NO_PATH` — a reason code
`NegotiatedRouter` has no targeted response for, so it fell through to blanket
retry. That is precisely the negotiator thrash Phase 2 exists to end: the
search now avoids HV↔LV proximity, but when avoidance *fails* the outer loop
still learns nothing about why.

## What ships

- Both kernels record `(foreign net, refused candidate world position)`
  (`Pathfinder::note_pairwise_block`, `mutable` counters alongside the
  existing `pairwise_band_offsets_` cache).
- A search that **drains the open set** with such an observation reports the
  new `FAILURE_PAIRWISE_BLOCKED` (7) carrying the blocker in
  `RouteResult.blocking_via_net` — the *same field*
  `NegotiatedRouter.via_blocked_ripup` already drains, so the crowding
  neighbour gets ripped up and the HV net routed first. No new rip-up
  machinery.
- Precedence is deliberately conservative:
  - `FAILURE_VIA_VIA_BLOCKED` still wins when both were observed;
  - TIMEOUT / ITERATION_LIMIT are **never** overridden — those are budget
    artifacts per #2610, and "raise `--max-search-iterations`" is a different
    remedy from "rip up the LV neighbour";
  - an attach-zone-waived (#4506) pair records **nothing** (ripping it up
    could not help — the pair is licensed to neck down there).
- Reset discipline mirrors #2476 exactly: cleared at the start of `route()` /
  `route_resumable()` and in `clear_search_state()`, deliberately **preserved
  across `resume()`** so a blocker seen by the initial search still names the
  culprit when a later resume drains.
- Python side: `_REQUIRED_CPP_BUILD_VERSION` 20 → 21,
  `_describe_cpp_failure` gains the description + blocking-net suffix,
  `NegotiatedRouter._FAILURE_PAIRWISE_BLOCKED` / label `pairwise_blocked`,
  and `_record_via_blocked_failure` accepts both blocker-naming reasons via
  `_BLOCKER_FAILURE_REASONS`.

**Dormant without `--voltage-map`**: both kernels already short-circuit on the
single `grid_.pairwise_active()` boolean, so nothing here is reachable on a
board with no voltage map, and **route output is unchanged** — this is
diagnostics only. `ROUTER_CPP_BUILD_VERSION` is bumped because the module
constant + four `Pathfinder` accessors are new binding surface (a stale `.so`
would `AttributeError` in `_describe_cpp_failure`).

Value 7 skips 6, which the mirrored `ValidationResult::violation_type`
vocabulary uses for drill spacing.

## Criterion-by-criterion status of #4507

| # | Acceptance criterion (issue "Ask") | Status | Evidence |
|---|---|---|---|
| 1 | C++ `validate_route` + search-time check take a domain-id array + domain-pair clearance matrix; `max(scalar, matrix[a][b])` | **MET** (prior) | `Grid3D::set_pairwise_domains` / `pairwise_required_clearance` (`cpp/src/grid.cpp:470-511`), widening in `validate_route` (`grid.cpp:677+`) — #4510 via #4524/#4533 |
| 2 | Search-time avoidance: hard blocking + halo/pricing widening around HV copper | **MET** (prior) | C++ kernels + `pairwise_avoidance_cost` (#4511); Python-fallback mirrors (#4791); soft gradient mirror (#4849) and nearest-band-cell pricing (#4848/#4859); halo parity via `DesignRules.max_clearance` → `pairwise.max_required_clearance()` (`rules.py:425-433`) feeding `_rtree_clearance_inflation` (`grid.py:913`, re-derived `:4284`) |
| 2b | …"rather than thrashing the negotiator" — failed avoidance must be *actionable* | **THIS PR** | `FAILURE_PAIRWISE_BLOCKED` + blocker net → existing `via_blocked_ripup` |
| 3 | Attach-zone exemption (#4506) threaded into the C++ check | **MET** (prior) | `Grid3D::set_attach_zones` / `attach_zone_exempts(..., layer)`; layer scoping in #4780 |
| T1 | Parity: C++ and Python validators agree on HV↔LV-below-requirement + same-domain-at-DRU | **MET** (prior) | `tests/router/test_pairwise_cpp_parity.py` |
| T2 | Two-domain fixture **converges** (headline) | **MET** (prior) | `test_two_domain_board_converges_with_search_time_avoidance`, `test_rated_gap_board_converges_on_the_licensed_layer` |
| T3 | Backward compat: no `--voltage-map` → unchanged routes | **MET** (prior + here) | `test_no_voltage_map_route_leaves_grid_dormant`; new `test_no_matrix_drain_stays_no_path` / `test_dormant_kernel_records_nothing` |
| T4 | **Manual**: softstart rev-C loop, 0 board-level pairwise creepage census fails | **OPEN** | Local-only fixture with no CI presence — epic-owner call, unchanged since the #4780/#4785/#4791/#4849 builder notes |

Issue stays open for T4.

## Tests

New `tests/router/test_pairwise_ripup_diagnostics_4507.py` (14 tests):

- kernel recording for trace + via; **negative controls** — dormant matrix,
  same-domain copper, net 0, and an attach-zone waiver all record nothing;
  `clear_pairwise_block_diagnostics` resets.
- **Headline search-level proof**: an LV curtain with a 1.0 mm slot —
  routable at the DRU floor, impossible at the 1.6 mm IEC creepage
  requirement. The *same geometry* succeeds with the matrix dormant
  (`FAILURE_NONE`) and drains with it installed, reporting
  `FAILURE_PAIRWISE_BLOCKED` + `blocking_via_net == LV`. The contrast is what
  proves the diagnostic tracks the pairwise widening and nothing else.
- Precedence: a solid curtain with no matrix still reports `NO_PATH`;
  `max_search_iterations=5` still reports `ITERATION_LIMIT`, never the
  geometric blocker.
- Plumbing: constant exposed + mirrored (`== 7`, distinct from via-via);
  `CppPathfinder.get_last_failure_info()` carries the blocker end to end on a
  real `RoutingGrid` route (with `_try_python_fallback` stubbed — the fallback
  is HV-aware since #4791 and would only re-derive the same verdict);
  `_describe_cpp_failure` names the net; `NegotiatedRouter` records the pair
  for rip-up and still ignores a plain `NO_PATH`; label is `pairwise_blocked`.

Results (all local, C++ backend built at version 21):

- `tests/router/test_pairwise_ripup_diagnostics_4507.py` — **14 passed**
- `tests/router -k "pairwise or hv or validate"` — **281 passed**, 1025 deselected
- parity + gate suites (`test_pairwise_cpp_parity.py`,
  `test_pairwise_python_search.py`, `test_pairwise_clearance.py`,
  `test_post_pass_pairwise_gate_4766.py`, `test_router_cpp_via_blocked_failure.py`,
  `test_per_net_timeout_scaling.py`) — **217 passed**
- full `tests/router` — **1301 passed**, 5 skipped
- C++ backend + negotiated suites (`test_router_cpp_backend.py`,
  `test_router_cpp_auto_build.py`, `test_router_cpp_astar_flat_arrays_3309.py`,
  `test_router_cpp_via_clearance.py`, 5 × `test_negotiated_*`,
  `test_router_cpp_fallback_warning_3456.py`, `…_foreign_pad_metal_rejection.py`,
  `…_grid_keepalive_4485.py`, `…_per_pad_channel_budget.py`,
  `test_router_negotiated_high_current.py`) — **95 + 241 passed**, 6 skipped
- `ruff check src tests` + `ruff format --check src tests` — clean
- `scripts/ci/check_mypy_baseline.py` (no `--update`) — OK, 1464 within 1472

Reviewer note: `kct build-native` is required in a fresh worktree for this
branch — the build-version guard will otherwise disable the C++ backend
(version 20 `.so` vs required 21) and silently route through the Python
fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
