### PR TITLE
feat(cli): add --format json to build, pipeline and stitch — closes the #4674 sweep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,36 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   inherit the environment, an empty flush never overwrites a report that has
   records. New reference doc: `docs/reference/crosstail-census-report.md`.
 
+- **`--format json` on `build`, `pipeline` and `stitch`** (closes #4674,
+  seventh and final batch of the #4543 machine-output sweep) — the multi-stage
+  orchestrators now accept the canonical `--format json` and emit one
+  deterministic document on stdout instead of prose, wired end-to-end (outer
+  parser → shim → inner parser). `build` reports the resolved
+  spec/schematic/pcb/routed-pcb paths, the effective manufacturer, and a
+  `steps[]` ledger (`step`, `success`, `message`, `output_file`, `elapsed_s`)
+  plus `counts`, `manufacturing_output` and `wall_time_s`; `pipeline` reports
+  the resolved input/pcb/project/schematic, the mfr + layer stack, a `steps[]`
+  ledger carrying each step's skip/warning classification, `commit:
+  {requested, created}` and the `exit_code` (0 / 1 / 2-for-`--best-effort`
+  partial); `stitch` reports the resolved via geometry and the **complete**
+  per-pad ledger — vias placed, pads skipped, connectivity fallbacks, pads
+  needing a routed fanout, and the obstacle breakdown. The stitch document is
+  deliberately untruncated: its prose caps via lists at 10 entries and
+  skipped-pad lists at 5, and a machine caller must not have to re-run with
+  different flags to see the pads a run could not place. All three drive
+  sub-tools that print progress on stdout, so each wraps its run in the
+  stdout-diversion helper (now promoted to
+  `cli/format_options.py::stdout_to_stderr_when` rather than copied a fourth
+  time): the chatter is replayed on stderr and exactly one document lands on
+  stdout. Failure paths emit `{"error": ..., "success": false}` documents with
+  exit codes unchanged, and text-mode output is byte-identical. Audit
+  (`scripts/audit_machine_output.py`): prose-only 8 → 5, format-json 189 →
+  192 — the actionable backlog is now **empty**, the 5 remaining prose-only
+  leaves being the 4 documented exemptions (`interactive`, `mcp serve`, `run`,
+  `footprint generate`) plus `route`, deferred to the route workstream.
+  `tests/test_format_json_sweep_orchestrators.py` guards the new surfaces and
+  pins the prose-only bucket against that exemption list.
+
 - **`--format json` on the 5 board-improvement drivers** (part of #4674,
   sixth batch of the #4543 machine-output sweep) — `optimize-placement`,
   `optimize-traces`, `route-auto`, `reason` and `creepage-export-rules` now
@@ -857,6 +887,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   intended beyond the runtime bump.
 
 ### Fixed
+
+- **`kct build --quiet` exited 0 when a build step failed** (part of #4674) —
+  the success/failure verdict was computed *inside* the `if not args.quiet:`
+  summary block, so suppressing the summary also suppressed the non-zero exit
+  code and a failed quiet build looked green to CI. The verdict is now hoisted
+  out of the guard; prose output is unchanged.
 
 - **The pairwise HV-avoidance gradient is priced from the *nearest* qualifying
   band cell, not the first one in scan order** (#4848, epic #4431 Phase 2b) —

--- a/docs/reference/machine-output.md
+++ b/docs/reference/machine-output.md
@@ -43,6 +43,13 @@ use:
   (`args.json` or `args.format`, whichever it historically used).
 - `wants_json(args)` — one-shot predicate that checks both spellings without
   mutating the namespace.
+- `stdout_to_stderr_when(active)` — context manager that captures stdout
+  written inside it and replays it on stderr while *active*. Wrap any region
+  that calls code the command does not own (third-party libraries, the
+  negotiated router, subprocess drivers, progress ledgers) so their chatter
+  cannot corrupt the single-document contract. Introduced per-module in batch
+  5, copied twice in batch 6, promoted here in batch 7 rather than making a
+  fourth copy.
 
 The mechanical sweep that adds `--format json` to the prose-only backlog
 below is issue **#4674** and should build on these helpers.
@@ -52,13 +59,13 @@ below is issue **#4674** and should build on these helpers.
 Measured by programmatic introspection of the real argparse tree
 (`create_parser()`, recursive walk of `_SubParsersAction` leaves) — not grep:
 
-| Idiom (outer `kct` parser) | Before #4543 | After #4543 | After #4674 b1 | b2 | b3 | b4 | b5 | b6 |
-|---|---|---|---|---|---|---|---|---|
-| `--format` with a `json` choice | 124 | 124 | 148 | 164 | 174 | 179 | 184 | 189 |
-| Both `--format json` and legacy `--json` alias | 0 | 2 (`placement refine`, `calibrate`) | 2 | 2 | 2 | 2 | 2 | 2 |
-| `--json` boolean only | 2 | **0** | 0 | 0 | 0 | 0 | 0 | 0 |
-| `--format` without a `json` choice | 1 (`benchmark report`, `text,markdown`) | 1 | **0** | 0 | 0 | 0 | 0 | 0 |
-| Neither (prose-only) | 72 | 72 (backlog for #4674, below) | 49 | 33 | 23 | 18 | 13 | 8 |
+| Idiom (outer `kct` parser) | Before #4543 | After #4543 | After #4674 b1 | b2 | b3 | b4 | b5 | b6 | b7 |
+|---|---|---|---|---|---|---|---|---|---|
+| `--format` with a `json` choice | 124 | 124 | 148 | 164 | 174 | 179 | 184 | 189 | **192** |
+| Both `--format json` and legacy `--json` alias | 0 | 2 (`placement refine`, `calibrate`) | 2 | 2 | 2 | 2 | 2 | 2 | 2 |
+| `--json` boolean only | 2 | **0** | 0 | 0 | 0 | 0 | 0 | 0 | 0 |
+| `--format` without a `json` choice | 1 (`benchmark report`, `text,markdown`) | 1 | **0** | 0 | 0 | 0 | 0 | 0 | 0 |
+| Neither (prose-only) | 72 | 72 (backlog for #4674, below) | 49 | 33 | 23 | 18 | 13 | 8 | **5 (all exempt / deferred)** |
 
 The first #4674 batch swept the grouped-subcommand families -- `mfr` (7),
 `spec` (5), `placement fix/nudge/snap/align/distribute` (5), `zones
@@ -80,9 +87,15 @@ The fifth batch swept the board-artifact producers -- `board-metrics`,
 
 The sixth batch swept the board-improvement / rule-derivation drivers --
 `optimize-placement`, `optimize-traces`, `route-auto`, `reason`,
-`creepage-export-rules` (5). The remaining 8 prose-only leaves (`build`,
-`pipeline`, `stitch`, plus the 4 exempt and the deferred `route`) stay on the
-#4674 backlog below.
+`creepage-export-rules` (5).
+
+The seventh and final batch swept the multi-stage orchestrators -- `build`,
+`pipeline`, `stitch` (3). **The #4674 backlog is now empty**: the 5 leaves
+still in the audit's `prose-only` bucket are the 4 documented exemptions plus
+the deferred `route`, both listed below.
+`tests/test_format_json_sweep_orchestrators.py` pins that bucket against
+exactly that list, so a new prose-only leaf fails a test rather than silently
+re-opening the backlog.
 
 Issue #4543 closed the `--json`-only bucket by adding `--format {text,json}`
 alongside the existing `--json` on both commands (outer parser, forwarding
@@ -319,13 +332,45 @@ Three conventions this batch adds or reinforces:
 
 `tests/test_format_json_sweep_drivers.py` guards these 5 surfaces.
 
-**Remaining actionable (3)** — the audit's `prose-only` bucket reads 8
-because it also counts the 4 exempt commands and the deferred `route`
-(sections above):
+**Done (seventh #4674 batch, 3 surfaces — the last):** the multi-stage
+orchestrators — the leaves that drive many other commands to completion:
+`build`, `pipeline`, `stitch`. Shapes:
 
-- `build`, `pipeline` (multi-stage orchestrators)
-- `stitch` (single command, but its 6k-line inner module has a bespoke
-  multi-phase report — batch it alone)
+| Command | Document |
+|---|---|
+| `build` | `{"command": "build", "spec", "project_dir", "output_dir", "mfr", "step", "dry_run", "force", "schematic", "pcb", "routed_pcb", "manufacturing_output", "steps": [{step, success, message, output_file, elapsed_s}], "counts": {total, succeeded, failed}, "wall_time_s", "exit_code", "success"}` |
+| `pipeline` | `{"command": "pipeline", "input", "pcb", "project", "schematic", "mfr", "layers", "layer_count", "step", "dry_run", "force", "best_effort", "steps": [{step, success, skipped, warning, message}], "counts": {total, succeeded, skipped, warnings}, "commit": {requested, created}, "exit_code", "success"}` |
+| `stitch` | `{"command": "stitch", "pcb", "output", "mode": "stitch"\|"blanket"\|"thermal", "target_nets", "nets_auto_detected", "manufacturer", "via_size_mm", "drill_mm", "detected_layers", "stackup_inferred_nets", "fallback_nets", "strict_model_error", "pads_found", "already_connected", "vias_added": [...], "vias_added_count", "micro_vias_placed", "traces_added": {total, straight, dogleg, extended_escape}, "via_in_pad_filtered", "hole_to_hole_rejected", "connectivity_fallback": [...], "needs_routed_fanout": [...], "pads_skipped": [...], "obstacle_breakdown", "dry_run", "saved", "drc": {requested, ran}, "success"}` |
+
+Three conventions this batch adds or reinforces:
+
+- **The document is the complete ledger, not the prose's excerpt.** `stitch`'s
+  text summary caps via lists at 10 entries and skipped-pad lists at 5 (`...
+  (N more)`); the JSON document carries every entry, because a machine caller
+  must not have to re-run with different flags to see the pads a run could not
+  place. `len(vias_added) == vias_added_count` is asserted in the tests.
+- **A multi-step run reports the ledger, not just the verdict.** All three
+  emit one entry per executed step with that step's own classification —
+  including `pipeline`'s `skipped` / `warning` axes, which its exit code
+  cannot express (exit 2 means "best-effort partial", not "which step").
+  `build` names `elapsed_s` / `wall_time_s` as volatile (the `board-metrics`
+  `generated_at` treatment) so determinism is asserted modulo them.
+- **The `stdout_to_stderr_when` diversion is now shared machinery.** It was
+  copied into three CLI modules across batches 5-6; rather than making a
+  fourth copy, this batch promoted it to
+  `format_options.py::stdout_to_stderr_when` and repointed the three existing
+  call sites. All three orchestrators need it — the rich `Console` /
+  `Progress` ledger, every generator script's streamed stdout, and the
+  kicad-cli DRC pass all write to stdout.
+
+One drive-by fix this batch had to make: `kct build`'s success/failure verdict
+was computed *inside* the `if not args.quiet:` summary block, so
+`kct build --quiet` exited 0 even when a step failed. That could not ship
+alongside a document whose `"success": false` would then contradict its own
+exit code, so the verdict is hoisted out of the guard (prose unchanged).
+
+`tests/test_format_json_sweep_orchestrators.py` guards these 3 surfaces, the
+promoted helper, and the now-closed backlog.
 
 
 ## Interop note (survey idea 7)
@@ -333,10 +378,12 @@ because it also counts the 4 exempt commands and the deferred `route`
 A stable machine-output contract is the enabling precondition for external
 agents (e.g. copperhead) delegating routing/DRC/LVS/tapeout to `kct`: with
 `--format json` canonical, an orchestrator can invoke any covered subcommand
-and parse a predictable payload instead of scraping prose. Once #4674 closes
-the prose-only backlog, the contract is: **every non-exempt `kct` subcommand
-accepts `--format json` and emits a single JSON document on stdout.** No
-separate issue tracks idea 7; it rides on this note plus #4674.
+and parse a predictable payload instead of scraping prose. As of #4674's
+seventh batch the prose-only backlog is closed, so the contract now holds:
+**every non-exempt `kct` subcommand accepts `--format json` and emits a single
+JSON document on stdout** (the exceptions are the 4 exemptions and the
+deferred `route`, tabulated above). No separate issue tracks idea 7; it rode
+on this note plus #4674.
 
 ## Rules for new commands
 

--- a/docs/reference/machine-output.md
+++ b/docs/reference/machine-output.md
@@ -292,10 +292,12 @@ Three conventions this batch adds:
   `report generate` calls into a data collector, a figure generator, and
   WeasyPrint — the last of which prints a multi-line "install my native
   libraries" banner *on stdout* when they are missing, which would corrupt
-  the single-document contract on any machine without them. The
-  `_stdout_to_stderr_when(as_json)` helper in `report_cmd.py` captures those
-  regions and replays them on stderr; copy it for any leaf that calls
-  third-party code it does not own.
+  the single-document contract on any machine without them. A
+  `stdout_to_stderr_when(as_json)` context manager captures those regions
+  and replays them on stderr; reach for it in any leaf that calls
+  third-party code it does not own. It started as a per-module private
+  helper here and was promoted in the seventh batch — import the shared
+  `format_options.stdout_to_stderr_when` rather than making a new copy.
 
 `tests/test_format_json_sweep_artifacts.py` guards these 5 surfaces.
 
@@ -323,7 +325,7 @@ Three conventions this batch adds or reinforces:
 - **Volatile fields are named, not hidden.** `optimize-placement` reports
   `wall_time_s`; like `board-metrics`'s `generated_at` it is the one field
   determinism is asserted modulo.
-- **The `_stdout_to_stderr_when` diversion is now the standard treatment**
+- **The `stdout_to_stderr_when` diversion is now the standard treatment**
   (third use, after `report generate`): `route-auto` and `reason --auto-route`
   drive the negotiated router, whose per-iteration progress log goes to
   **stdout**. It is captured and replayed on stderr so the JSON stream stays
@@ -340,7 +342,7 @@ orchestrators — the leaves that drive many other commands to completion:
 |---|---|
 | `build` | `{"command": "build", "spec", "project_dir", "output_dir", "mfr", "step", "dry_run", "force", "schematic", "pcb", "routed_pcb", "manufacturing_output", "steps": [{step, success, message, output_file, elapsed_s}], "counts": {total, succeeded, failed}, "wall_time_s", "exit_code", "success"}` |
 | `pipeline` | `{"command": "pipeline", "input", "pcb", "project", "schematic", "mfr", "layers", "layer_count", "step", "dry_run", "force", "best_effort", "steps": [{step, success, skipped, warning, message}], "counts": {total, succeeded, skipped, warnings}, "commit": {requested, created}, "exit_code", "success"}` |
-| `stitch` | `{"command": "stitch", "pcb", "output", "mode": "stitch"\|"blanket"\|"thermal", "target_nets", "nets_auto_detected", "manufacturer", "via_size_mm", "drill_mm", "detected_layers", "stackup_inferred_nets", "fallback_nets", "strict_model_error", "pads_found", "already_connected", "vias_added": [...], "vias_added_count", "micro_vias_placed", "traces_added": {total, straight, dogleg, extended_escape}, "via_in_pad_filtered", "hole_to_hole_rejected", "connectivity_fallback": [...], "needs_routed_fanout": [...], "pads_skipped": [...], "obstacle_breakdown", "dry_run", "saved", "drc": {requested, ran}, "success"}` |
+| `stitch` | `{"command": "stitch", "pcb", "output", "mode": "stitch"\|"blanket"\|"thermal", "target_nets", "nets_auto_detected", "manufacturer", "via_size_mm", "drill_mm", "detected_layers", "stackup_inferred_nets", "fallback_nets", "strict_model_error", "pads_found", "already_connected", "vias_added": [...], "vias_added_count", "micro_vias_placed", "traces_added": {total, straight, dogleg, extended_escape}, "via_in_pad_filtered", "hole_to_hole_rejected", "connectivity_fallback": [...], "needs_routed_fanout": [...], "pads_skipped": [...], "obstacle_breakdown", "dry_run", "saved", "drc": {requested, ran}, "exit_code", "success"}` |
 
 Three conventions this batch adds or reinforces:
 
@@ -354,7 +356,9 @@ Three conventions this batch adds or reinforces:
   including `pipeline`'s `skipped` / `warning` axes, which its exit code
   cannot express (exit 2 means "best-effort partial", not "which step").
   `build` names `elapsed_s` / `wall_time_s` as volatile (the `board-metrics`
-  `generated_at` treatment) so determinism is asserted modulo them.
+  `generated_at` treatment) so determinism is asserted modulo them. All three
+  also carry `exit_code` alongside `success`, so a caller reading a captured
+  document never has to correlate it with a separately recorded `$?`.
 - **The `stdout_to_stderr_when` diversion is now shared machinery.** It was
   copied into three CLI modules across batches 5-6; rather than making a
   fourth copy, this batch promoted it to

--- a/src/kicad_tools/cli/__init__.py
+++ b/src/kicad_tools/cli/__init__.py
@@ -577,6 +577,10 @@ def _run_stitch_command(args) -> int:
         sub_argv.extend(["--mfr", str(args.stitch_mfr)])
     if hasattr(args, "stitch_copper") and args.stitch_copper != 1.0:
         sub_argv.extend(["--copper", str(args.stitch_copper)])
+    # Machine output (#4674): forward the canonical flag only when it asks for
+    # JSON, so a default invocation still builds a byte-identical inner argv.
+    if getattr(args, "format", "text") == "json":
+        sub_argv.extend(["--format", "json"])
 
     return stitch_cmd(sub_argv)
 

--- a/src/kicad_tools/cli/build_cmd.py
+++ b/src/kicad_tools/cli/build_cmd.py
@@ -3805,7 +3805,10 @@ def _run_main(args: argparse.Namespace, as_json: bool) -> tuple[int, dict | None
                 # is asserted modulo it (batch-6 convention).
                 "elapsed_s": round(elapsed, 3),
             }
-            for result, elapsed in zip(results, step_elapsed_s, strict=False)
+            # ``step_elapsed_s`` is appended in lockstep with ``results`` at
+            # every site, so a length mismatch is a bug worth raising rather
+            # than silently truncating the ledger.
+            for result, elapsed in zip(results, step_elapsed_s, strict=True)
         ],
         "counts": {
             "total": total_count,

--- a/src/kicad_tools/cli/build_cmd.py
+++ b/src/kicad_tools/cli/build_cmd.py
@@ -9,6 +9,13 @@ Orchestrates the full build pipeline:
 5. Run autorouter
 6. Run verification (DRC, audit)
 7. Export manufacturing package (Gerbers, BOM, CPL)
+
+Machine output (``--format json``, issue #4674): one document describing the
+run -- the resolved spec/artifact paths, the effective manufacturer, and a
+``steps`` array with one entry per executed step (its success, message,
+output file and elapsed time) -- or ``{"error": ..., "success": false}`` when
+the project directory cannot be resolved.  Exit codes are unchanged.  See
+``docs/reference/machine-output.md``.
 """
 
 from __future__ import annotations
@@ -34,6 +41,13 @@ from rich.markup import escape as markup_escape
 from rich.panel import Panel
 from rich.progress import Progress, SpinnerColumn, TextColumn
 
+from kicad_tools.cli.format_options import (
+    FORMAT_JSON,
+    FORMAT_TEXT,
+    add_format_flag,
+    emit_json,
+    stdout_to_stderr_when,
+)
 from kicad_tools.manufacturers import get_all_manufacturer_names
 
 if TYPE_CHECKING:
@@ -3407,6 +3421,7 @@ Examples:
             "step (default: 30.0)."
         ),
     )
+    add_format_flag(parser)
 
     return parser
 
@@ -3415,6 +3430,26 @@ def main(argv: list[str] | None = None) -> int:
     """Main entry point for kct build command."""
     parser = _build_inner_parser()
     args = parser.parse_args(argv)
+    as_json = getattr(args, "format", FORMAT_TEXT) == FORMAT_JSON
+
+    # JSON mode owns stdout: the build header, the per-step ledger and the
+    # streamed stdout of every generator script / kct subprocess all land
+    # there.  Divert the lot to stderr so the diagnostics survive and exactly
+    # one document lands on stdout.
+    with stdout_to_stderr_when(as_json):
+        exit_code, document = _run_main(args, as_json)
+    if as_json and document is not None:
+        emit_json(document)
+    return exit_code
+
+
+def _run_main(args: argparse.Namespace, as_json: bool) -> tuple[int, dict | None]:
+    """Execute one ``kct build`` run; returns (exit code, JSON document).
+
+    Split out of :func:`main` so the JSON document is emitted *outside* the
+    stdout diversion that protects the single-document contract.  The document
+    is ``None`` in text mode.
+    """
     console = Console(quiet=args.quiet)
 
     # Determine project directory and spec file
@@ -3439,8 +3474,16 @@ def main(argv: list[str] | None = None) -> int:
         spec_file = _find_spec_file(project_dir)
 
     if not project_dir.exists():
+        message = f"Directory not found: {project_dir}"
+        if as_json:
+            return 1, {
+                "command": "build",
+                "spec": str(args.spec) if args.spec else None,
+                "error": message,
+                "success": False,
+            }
         console.print(f"[red]Error:[/red] Directory not found: {project_dir}")
-        return 1
+        return 1, None
 
     # Load the spec file if available
     spec = None
@@ -3533,6 +3576,9 @@ def main(argv: list[str] | None = None) -> int:
 
     # Run build steps
     results: list[BuildResult] = []
+    # Per-step wall time, parallel to ``results`` (issue #4674): the JSON
+    # document reports it per entry; the prose already prints it inline.
+    step_elapsed_s: list[float] = []
 
     # Wall-clock anchor for the whole pipeline (issue #3944).  Uses
     # ``time.monotonic()`` so the reported totals are immune to system
@@ -3649,6 +3695,7 @@ def main(argv: list[str] | None = None) -> int:
 
             step_elapsed = time.monotonic() - step_start
             results.append(result)
+            step_elapsed_s.append(step_elapsed)
             progress.remove_task(task)
 
             # Print step result with per-step elapsed time (issue #3944)
@@ -3680,20 +3727,32 @@ def main(argv: list[str] | None = None) -> int:
                     smoke = _smoke_check_pcb(pcb_for_check, step.value, console, ctx)
                     if smoke is not None:
                         results.append(smoke)
+                        step_elapsed_s.append(0.0)
                         if not args.quiet:
                             console.print(
                                 f"  [[red]FAIL[/red]] {step.value} (smoke-check): {smoke.message}"
                             )
                         break
 
+    # Summary
+    wall_time_s = time.monotonic() - build_start
+    success_count = sum(1 for r in results if r.success)
+    total_count = len(results)
+    build_succeeded = success_count == total_count
+
+    export_results = [r for r in results if r.step == "export" and r.success]
+    manufacturing_output = (
+        str(export_results[0].output_file)
+        if export_results and export_results[0].output_file
+        else None
+    )
+
     # Print summary
     if not args.quiet:
-        total_elapsed = _format_elapsed(time.monotonic() - build_start)
+        total_elapsed = _format_elapsed(wall_time_s)
         console.print()
-        success_count = sum(1 for r in results if r.success)
-        total_count = len(results)
 
-        if success_count == total_count:
+        if build_succeeded:
             console.print(
                 f"[green]Build completed successfully[/green] "
                 f"({success_count}/{total_count} steps) in {total_elapsed}"
@@ -3706,17 +3765,58 @@ def main(argv: list[str] | None = None) -> int:
                 console.print(f"\n[dim]Output:[/dim] {ctx.pcb_file}")
 
             # Show manufacturing output if export step ran
-            export_results = [r for r in results if r.step == "export" and r.success]
-            if export_results and export_results[0].output_file:
-                console.print(f"[dim]Manufacturing:[/dim] {export_results[0].output_file}")
+            if manufacturing_output is not None:
+                console.print(f"[dim]Manufacturing:[/dim] {manufacturing_output}")
         else:
             console.print(
                 f"[red]Build failed[/red] "
                 f"({success_count}/{total_count} steps succeeded) in {total_elapsed}"
             )
-            return 1
 
-    return 0
+    # The exit code no longer depends on --quiet.  It used to be computed
+    # inside the `if not args.quiet` block above, so `kct build --quiet`
+    # exited 0 even when a step failed -- which would also have made the
+    # JSON document's "success": false contradict the exit code (#4674).
+    exit_code = 0 if build_succeeded else 1
+
+    if not as_json:
+        return exit_code, None
+
+    document = {
+        "command": "build",
+        "spec": str(spec_file) if spec_file else None,
+        "project_dir": str(project_dir),
+        "output_dir": str(output_dir) if output_dir else None,
+        "mfr": effective_mfr,
+        "step": args.step,
+        "dry_run": ctx.dry_run,
+        "force": ctx.force,
+        "schematic": str(ctx.schematic_file) if ctx.schematic_file else None,
+        "pcb": str(ctx.pcb_file) if ctx.pcb_file else None,
+        "routed_pcb": str(ctx.routed_pcb_file) if ctx.routed_pcb_file else None,
+        "manufacturing_output": manufacturing_output,
+        "steps": [
+            {
+                "step": result.step,
+                "success": result.success,
+                "message": result.message,
+                "output_file": str(result.output_file) if result.output_file else None,
+                # Volatile by nature; named rather than hidden so determinism
+                # is asserted modulo it (batch-6 convention).
+                "elapsed_s": round(elapsed, 3),
+            }
+            for result, elapsed in zip(results, step_elapsed_s, strict=False)
+        ],
+        "counts": {
+            "total": total_count,
+            "succeeded": success_count,
+            "failed": total_count - success_count,
+        },
+        "wall_time_s": round(wall_time_s, 3),
+        "exit_code": exit_code,
+        "success": build_succeeded,
+    }
+    return exit_code, document
 
 
 if __name__ == "__main__":

--- a/src/kicad_tools/cli/commands/build.py
+++ b/src/kicad_tools/cli/commands/build.py
@@ -1,4 +1,9 @@
-"""Build command handler for end-to-end workflow orchestration."""
+"""Build command handler for end-to-end workflow orchestration.
+
+Machine output (``--format json``, issue #4674): the canonical flag is
+forwarded to ``build_cmd``'s inner parser, which emits one document
+describing the run.  See ``docs/reference/machine-output.md``.
+"""
 
 __all__ = ["run_build_command"]
 
@@ -80,5 +85,10 @@ def run_build_command(args) -> int:
     build_hv_threshold = getattr(args, "build_hv_threshold", 30.0)
     if build_hv_threshold is not None and build_hv_threshold != 30.0:
         sub_argv.extend(["--hv-threshold", str(build_hv_threshold)])
+
+    # Machine output (#4674): forward the canonical flag only when it asks for
+    # JSON, so a default invocation still builds a byte-identical inner argv.
+    if getattr(args, "format", "text") == "json":
+        sub_argv.extend(["--format", "json"])
 
     return build_main(sub_argv)

--- a/src/kicad_tools/cli/commands/pipeline.py
+++ b/src/kicad_tools/cli/commands/pipeline.py
@@ -1,4 +1,9 @@
-"""Pipeline command handler for end-to-end PCB repair workflow."""
+"""Pipeline command handler for end-to-end PCB repair workflow.
+
+Machine output (``--format json``, issue #4674): the canonical flag is
+forwarded to ``pipeline_cmd``'s inner parser, which emits one document
+describing the run.  See ``docs/reference/machine-output.md``.
+"""
 
 __all__ = ["run_pipeline_command"]
 
@@ -95,5 +100,10 @@ def run_pipeline_command(args) -> int:
     # Use global quiet or command-level quiet
     if getattr(args, "global_quiet", False):
         sub_argv.append("--quiet")
+
+    # Machine output (#4674): forward the canonical flag only when it asks for
+    # JSON, so a default invocation still builds a byte-identical inner argv.
+    if getattr(args, "format", "text") == "json":
+        sub_argv.extend(["--format", "json"])
 
     return pipeline_main(sub_argv)

--- a/src/kicad_tools/cli/commands/routing.py
+++ b/src/kicad_tools/cli/commands/routing.py
@@ -8,11 +8,9 @@ written copper and warnings, or the failure that stopped it) -- and
 codes are unchanged in both cases.  See ``docs/reference/machine-output.md``.
 """
 
-import contextlib
-import io
 import sys
 
-from ..format_options import FORMAT_JSON, emit_json
+from ..format_options import FORMAT_JSON, emit_json, stdout_to_stderr_when
 
 __all__ = [
     "run_route_command",
@@ -20,29 +18,6 @@ __all__ = [
     "run_zones_command",
     "run_optimize_command",
 ]
-
-
-@contextlib.contextmanager
-def _stdout_to_stderr_when(active: bool):
-    """Divert stdout to stderr while *active* (i.e. JSON mode owns stdout).
-
-    ``route_net_auto`` drives the negotiated router, which prints a multi-line
-    per-iteration progress log on **stdout** that this module does not own.
-    Under ``--format json`` that would corrupt the single-document contract, so
-    it is captured and replayed on stderr: the log survives, the JSON stream
-    stays parseable.  Same helper as ``report_cmd._stdout_to_stderr_when``
-    (batch 5 of #4674).
-    """
-    if not active:
-        yield
-        return
-    buffer = io.StringIO()
-    try:
-        with contextlib.redirect_stdout(buffer):
-            yield
-    finally:
-        if buffer.getvalue():
-            print(buffer.getvalue(), end="", file=sys.stderr)
 
 
 def run_zones_command(args) -> int:
@@ -218,7 +193,6 @@ def _route_auto_one(
     the ``--format json`` payload (issue #4674); prose is printed only when
     *as_json* is false, so text output stays byte-identical.
     """
-    import sys
 
     via_drill = getattr(args, "via_drill", None)
     via_diameter = getattr(args, "via_diameter", None)
@@ -237,7 +211,7 @@ def _route_auto_one(
     try:
         # The negotiated router logs its per-iteration progress on stdout;
         # under --format json that chatter is replayed on stderr instead.
-        with _stdout_to_stderr_when(as_json):
+        with stdout_to_stderr_when(as_json):
             result = route_net_auto(
                 pcb_path=pcb_path,
                 net_name=net_name,
@@ -417,7 +391,6 @@ def _parse_route_auto_targets(args, *, as_json: bool = False) -> tuple[list[str]
     (the error has already been reported -- as prose, or as the single
     ``{"error": ...}`` document under *as_json*, issue #4674).
     """
-    import sys
 
     def _usage_error(message: str) -> tuple[None, int]:
         if as_json:

--- a/src/kicad_tools/cli/format_options.py
+++ b/src/kicad_tools/cli/format_options.py
@@ -18,6 +18,9 @@ This module is the shared machinery for commands that carry both spellings:
   ``parse_args`` so downstream code can keep checking a single attribute.
 * :func:`wants_json` -- one-shot predicate for code that prefers not to
   mutate the namespace.
+* :func:`stdout_to_stderr_when` -- protect the single-document contract from
+  third-party / progress chatter printed on stdout by code the command does
+  not own.
 
 Precedence rule: either spelling requesting JSON wins.  The two flags cannot
 conflict, because ``--json`` only ever means ``--format json``.
@@ -26,7 +29,11 @@ conflict, because ``--json`` only ever means ``--format json``.
 from __future__ import annotations
 
 import argparse
+import contextlib
+import io
 import json
+import sys
+from collections.abc import Iterator
 from typing import Any
 
 FORMAT_TEXT = "text"
@@ -91,6 +98,38 @@ def emit_json(payload: Any) -> None:
     chatter must go to stderr or be suppressed when JSON mode is active.
     """
     print(json.dumps(payload, indent=2, sort_keys=True, default=str))
+
+
+@contextlib.contextmanager
+def stdout_to_stderr_when(active: bool) -> Iterator[None]:
+    """Divert stdout to stderr while *active* (i.e. JSON mode owns stdout).
+
+    Many commands call into code they do not own -- third-party libraries,
+    subprocess drivers, the negotiated router, report collectors -- that
+    writes progress chatter or install banners on **stdout**.  Under
+    ``--format json`` that chatter would corrupt the single-document
+    contract, so wrap those regions in this context manager: the output is
+    captured and replayed on stderr, so the diagnostics survive and the JSON
+    stream stays parseable.
+
+    When *active* is false this is a no-op, so a command can wrap the region
+    unconditionally and pass its own ``as_json`` predicate.
+
+    Introduced per-module in batch 5 of the #4674 machine-output sweep
+    (``report_cmd``), copied into ``reason_cmd`` and ``commands/routing`` in
+    batch 6, and promoted here in batch 7 (``build`` / ``pipeline`` /
+    ``stitch``) rather than making a fourth copy.
+    """
+    if not active:
+        yield
+        return
+    buffer = io.StringIO()
+    try:
+        with contextlib.redirect_stdout(buffer):
+            yield
+    finally:
+        if buffer.getvalue():
+            print(buffer.getvalue(), end="", file=sys.stderr)
 
 
 def normalize_format_alias(

--- a/src/kicad_tools/cli/parser.py
+++ b/src/kicad_tools/cli/parser.py
@@ -3385,6 +3385,7 @@ def _add_stitch_parser(subparsers) -> None:
             "to select the correct design-rules row from the manufacturer YAML."
         ),
     )
+    add_format_flag(stitch_parser)
 
 
 def _add_route_parser(subparsers) -> None:
@@ -7753,6 +7754,7 @@ def _add_pipeline_parser(subparsers) -> None:
             "step (default: 30.0)."
         ),
     )
+    add_format_flag(pipeline_parser)
 
 
 def _add_create_pcb_parser(subparsers) -> None:
@@ -8017,6 +8019,7 @@ def _add_build_parser(subparsers) -> None:
             "step (default: 30.0)."
         ),
     )
+    add_format_flag(build_parser)
 
 
 def _add_build_native_parser(subparsers) -> None:

--- a/src/kicad_tools/cli/pipeline_cmd.py
+++ b/src/kicad_tools/cli/pipeline_cmd.py
@@ -31,6 +31,14 @@ Usage:
     kct pipeline board.kicad_pcb --step fix-erc
     kct pipeline project.kicad_pro --mfr jlcpcb --layers 4
     kct pipeline board.kicad_pcb --layers 4-sig
+
+Machine output (``--format json``, issue #4674): one document describing the
+run -- the resolved input/pcb/schematic paths, the manufacturer and layer
+stack, and a ``steps`` array with one entry per executed step (its
+success/skip/warning classification and message) -- or ``{"error": ...,
+"success": false}`` when the input cannot be resolved.  Exit codes (0 / 1 /
+2-for-best-effort-partial) are unchanged.  See
+``docs/reference/machine-output.md``.
 """
 
 from __future__ import annotations
@@ -48,6 +56,13 @@ from rich.console import Console
 from rich.panel import Panel
 from rich.progress import Progress, SpinnerColumn, TextColumn
 
+from kicad_tools.cli.format_options import (
+    FORMAT_JSON,
+    FORMAT_TEXT,
+    add_format_flag,
+    emit_json,
+    stdout_to_stderr_when,
+)
 from kicad_tools.manufacturers import get_all_manufacturer_names
 
 logger = logging.getLogger(__name__)
@@ -2534,13 +2549,45 @@ Examples:
             "step (default: 30.0)."
         ),
     )
+    add_format_flag(parser)
+
     args = parser.parse_args(argv)
+    as_json = getattr(args, "format", FORMAT_TEXT) == FORMAT_JSON
+
+    # JSON mode owns stdout: every pipeline step prints its own progress
+    # ledger (rich Console + Progress) and several shell out to tools that
+    # print on stdout.  Divert the lot to stderr so the diagnostics survive
+    # and exactly one document lands on stdout.
+    with stdout_to_stderr_when(as_json):
+        exit_code, document = _run_main(args, as_json)
+    if as_json and document is not None:
+        emit_json(document)
+    return exit_code
+
+
+def _run_main(args: argparse.Namespace, as_json: bool) -> tuple[int, dict | None]:
+    """Execute one ``kct pipeline`` run; returns (exit code, JSON document).
+
+    Split out of :func:`main` so the JSON document is emitted *outside* the
+    stdout diversion that protects the single-document contract.  The document
+    is ``None`` in text mode.
+    """
+
+    def fail(message: str, *, code: int = 1) -> tuple[int, dict]:
+        """Report a failure as a document (JSON) or on stderr (text)."""
+        if not as_json:
+            print(f"Error: {message}", file=sys.stderr)
+        return code, {
+            "command": "pipeline",
+            "input": str(args.input),
+            "error": message,
+            "success": False,
+        }
 
     input_path = Path(args.input).resolve()
 
     if not input_path.exists():
-        print(f"Error: File not found: {input_path}", file=sys.stderr)
-        return 1
+        return fail(f"File not found: {input_path}")
 
     # Determine input type and resolve PCB file
     is_project = input_path.suffix == ".kicad_pro"
@@ -2550,11 +2597,7 @@ Examples:
         project_file = input_path
         pcb_file = _resolve_pcb_from_project(input_path)
         if pcb_file is None:
-            print(
-                f"Error: No .kicad_pcb file found for project {input_path.name}",
-                file=sys.stderr,
-            )
-            return 1
+            return fail(f"No .kicad_pcb file found for project {input_path.name}")
     elif input_path.suffix == ".kicad_pcb":
         pcb_file = input_path
         # Check if a .kicad_pro exists alongside
@@ -2563,12 +2606,9 @@ Examples:
             project_file = pro_file
             is_project = True
     else:
-        print(
-            f"Error: Unsupported file type: {input_path.suffix} "
-            f"(expected .kicad_pcb or .kicad_pro)",
-            file=sys.stderr,
+        return fail(
+            f"Unsupported file type: {input_path.suffix} (expected .kicad_pcb or .kicad_pro)"
         )
-        return 1
 
     # Resolve layer configuration from PCB when not explicitly specified.
     # When --layers is given (e.g. "4", "4-sig"), use the string as-is so it
@@ -2594,8 +2634,7 @@ Examples:
     if args.sch is not None:
         sch_path = Path(args.sch).resolve()
         if not sch_path.exists():
-            print(f"Error: Schematic file not found: {sch_path}", file=sys.stderr)
-            return 1
+            return fail(f"Schematic file not found: {sch_path}")
         schematic_file = sch_path
     else:
         schematic_file = _resolve_schematic(pcb_file, project_file)
@@ -2636,6 +2675,47 @@ Examples:
 
     results = run_pipeline(ctx, steps)
 
+    def document(exit_code: int, *, commit_created: bool = False) -> dict | None:
+        """Build the run document (JSON mode only)."""
+        if not as_json:
+            return None
+        return {
+            "command": "pipeline",
+            "input": str(input_path),
+            "pcb": str(pcb_file),
+            "project": str(project_file) if project_file else None,
+            "schematic": str(schematic_file) if schematic_file else None,
+            "mfr": ctx.mfr,
+            "layers": ctx.layers,
+            "layer_count": ctx.layer_count,
+            "step": args.step,
+            "dry_run": ctx.dry_run,
+            "force": ctx.force,
+            "best_effort": ctx.best_effort,
+            "steps": [
+                {
+                    "step": r.step.value if isinstance(r.step, PipelineStep) else str(r.step),
+                    "success": r.success,
+                    "skipped": r.skipped,
+                    "warning": r.warning,
+                    "message": r.message,
+                }
+                for r in results
+            ],
+            "counts": {
+                "total": len(results),
+                "succeeded": sum(1 for r in results if r.success),
+                "skipped": sum(1 for r in results if r.skipped),
+                "warnings": sum(1 for r in results if r.warning),
+            },
+            # A --commit run says whether it actually committed, so exit 0
+            # alone is never read as "the change is in git" (batch-5
+            # producers-say-whether-they-produced convention).
+            "commit": {"requested": ctx.commit, "created": commit_created},
+            "exit_code": exit_code,
+            "success": exit_code == 0,
+        }
+
     # Determine exit code:
     #   0 = all steps succeeded
     #   2 = partial success (--best-effort continued past a routing failure)
@@ -2646,20 +2726,22 @@ Examples:
     )
 
     if not all_succeeded and not has_route_warning:
-        return 1
+        return 1, document(1)
 
     # Handle --commit flag (silently ignored with --dry-run)
+    commit_created = False
     if ctx.commit and not ctx.dry_run:
         console = Console(quiet=ctx.quiet)
         commit_rc = _git_commit_result(ctx, results, console)
         if commit_rc != 0:
-            return commit_rc
+            return commit_rc, document(commit_rc)
+        commit_created = True
 
     # Exit code 2 for partial success (routing incomplete in best-effort mode)
     if has_route_warning:
-        return 2
+        return 2, document(2, commit_created=commit_created)
 
-    return 0
+    return 0, document(0, commit_created=commit_created)
 
 
 if __name__ == "__main__":

--- a/src/kicad_tools/cli/reason_cmd.py
+++ b/src/kicad_tools/cli/reason_cmd.py
@@ -17,36 +17,17 @@ half-emitted.  See ``docs/reference/machine-output.md``.
 """
 
 import argparse
-import contextlib
-import io
 import json
 import sys
 from pathlib import Path
 
-from kicad_tools.cli.format_options import FORMAT_JSON, add_format_flag, emit_json
+from kicad_tools.cli.format_options import (
+    FORMAT_JSON,
+    add_format_flag,
+    emit_json,
+    stdout_to_stderr_when,
+)
 from kicad_tools.manufacturers import get_manufacturer_ids
-
-
-@contextlib.contextmanager
-def _stdout_to_stderr_when(active: bool):
-    """Divert stdout to stderr while *active* (i.e. JSON mode owns stdout).
-
-    ``--auto-route`` drives the router, which prints a multi-line progress log
-    on **stdout** that this module does not own; under ``--format json`` that
-    would corrupt the single-document contract, so it is captured and replayed
-    on stderr.  Same helper as ``report_cmd._stdout_to_stderr_when`` (batch 5
-    of #4674).
-    """
-    if not active:
-        yield
-        return
-    buffer = io.StringIO()
-    try:
-        with contextlib.redirect_stdout(buffer):
-            yield
-    finally:
-        if buffer.getvalue():
-            print(buffer.getvalue(), end="", file=sys.stderr)
 
 
 def _fail(
@@ -454,7 +435,7 @@ def _auto_route(agent, output_path: Path, args, *, as_json: bool = False) -> tup
         net.name for net in sorted(agent.get_state().unrouted_nets, key=lambda n: n.priority)
     ][: args.max_nets]
 
-    with _stdout_to_stderr_when(as_json):
+    with stdout_to_stderr_when(as_json):
         results = agent.route_priority_nets(max_nets=args.max_nets)
 
     successful = sum(1 for r in results if r.success)

--- a/src/kicad_tools/cli/report_cmd.py
+++ b/src/kicad_tools/cli/report_cmd.py
@@ -19,14 +19,12 @@ document; warnings keep going to stderr either way.  See
 from __future__ import annotations
 
 import argparse
-import contextlib
-import io
 import json
 import sys
 from pathlib import Path
 from typing import TYPE_CHECKING
 
-from .format_options import FORMAT_JSON, add_format_flag, emit_json
+from .format_options import FORMAT_JSON, add_format_flag, emit_json, stdout_to_stderr_when
 
 if TYPE_CHECKING:
     from kicad_tools.report.figures import FigureEntry
@@ -132,30 +130,6 @@ def main(argv: list[str] | None = None) -> int:
     return 0
 
 
-@contextlib.contextmanager
-def _stdout_to_stderr_when(active: bool):
-    """Divert stdout to stderr while *active* (i.e. JSON mode owns stdout).
-
-    Report generation calls into code that writes progress chatter to stdout
-    and is not this module's to change -- the data collector, the figure
-    generator, and WeasyPrint (which prints a multi-line "install my native
-    libraries" banner on stdout when they are missing).  Under ``--format
-    json`` that would corrupt the single-document contract, so it is captured
-    and replayed on stderr: the diagnostics survive, the JSON stream stays
-    parseable.
-    """
-    if not active:
-        yield
-        return
-    buffer = io.StringIO()
-    try:
-        with contextlib.redirect_stdout(buffer):
-            yield
-    finally:
-        if buffer.getvalue():
-            print(buffer.getvalue(), end="", file=sys.stderr)
-
-
 def _run_generate(args: argparse.Namespace) -> int:
     """Execute the ``generate`` sub-command."""
     as_json = getattr(args, "format", "text") == FORMAT_JSON
@@ -208,7 +182,7 @@ def _run_generate(args: argparse.Namespace) -> int:
     else:
         # Auto-collect: write snapshots into the versioned output directory.
         # This pre-determines the version directory so figures land in the same vN/.
-        with _stdout_to_stderr_when(as_json):
+        with stdout_to_stderr_when(as_json):
             version_dir, data_kwargs = _auto_collect(
                 pcb_path=input_path,
                 output_dir=Path(args.output),
@@ -247,7 +221,7 @@ def _run_generate(args: argparse.Namespace) -> int:
         if version_dir is None:
             version_dir = generator.next_version_dir(Path(args.output))
         figures_dir = version_dir / "figures"
-        with _stdout_to_stderr_when(as_json):
+        with stdout_to_stderr_when(as_json):
             figures = _generate_figures(args, input_path, figures_dir, data)
 
     try:
@@ -259,7 +233,7 @@ def _run_generate(args: argparse.Namespace) -> int:
 
     # Attempt to render Markdown to HTML then PDF.
     pdf_path: Path | None = None
-    with _stdout_to_stderr_when(as_json):
+    with stdout_to_stderr_when(as_json):
         try:
             from kicad_tools.report.renderers import render_html, render_pdf
 
@@ -331,7 +305,7 @@ def _generate_figures(
 
     Returns the ``figures`` block of the ``--format json`` document
     (``{"generated": bool, "skipped_reason": str | None}``).  The caller
-    diverts stdout in JSON mode (see :func:`_stdout_to_stderr_when`), so the
+    diverts stdout in JSON mode (see :func:`~.format_options.stdout_to_stderr_when`), so the
     progress line needs no special handling here.
     """
 

--- a/src/kicad_tools/cli/stitch_cmd.py
+++ b/src/kicad_tools/cli/stitch_cmd.py
@@ -5956,7 +5956,14 @@ def result_document(
         # reported separately rather than collapsed into one boolean.
         "drc": {"requested": drc_requested, "ran": drc_ran},
     }
-    document["success"] = bool(result.vias_added) or bool(result.already_connected)
+    # Parity with the other two orchestrators (`build`, `pipeline`): the
+    # document carries the process exit code so a machine caller reading a
+    # captured document never has to correlate it with a separate `$?`.
+    # The caller's verdict is exactly this predicate -- vias placed, or the
+    # pads were already connected.
+    success = bool(result.vias_added) or bool(result.already_connected)
+    document["exit_code"] = 0 if success else 1
+    document["success"] = success
     return document
 
 
@@ -6193,6 +6200,7 @@ def _run_main(args: argparse.Namespace, as_json: bool) -> tuple[int, dict | None
             "command": "stitch",
             "pcb": str(args.pcb),
             "error": message,
+            "exit_code": code,
             "success": False,
         }
 

--- a/src/kicad_tools/cli/stitch_cmd.py
+++ b/src/kicad_tools/cli/stitch_cmd.py
@@ -20,6 +20,13 @@ Usage:
 Exit Codes:
     0 - Success
     1 - Error or no work to do
+
+Machine output (``--format json``, issue #4674): one document describing the
+run -- the resolved input/output paths, the resolved via geometry, and the
+full (untruncated) per-pad ledger of placed vias, skipped pads, connectivity
+fallbacks and pads needing a routed fanout -- or ``{"error": ..., "success":
+false}`` on failure.  Exit codes are unchanged.  See
+``docs/reference/machine-output.md``.
 """
 
 import argparse
@@ -29,6 +36,13 @@ import uuid
 from dataclasses import dataclass, field
 from pathlib import Path
 
+from kicad_tools.cli.format_options import (
+    FORMAT_JSON,
+    FORMAT_TEXT,
+    add_format_flag,
+    emit_json,
+    stdout_to_stderr_when,
+)
 from kicad_tools.core.sexp_file import load_pcb, save_pcb, verify_pcb_write
 from kicad_tools.router.via_clearance import drill_hole_to_hole_clear
 from kicad_tools.sexp import SExp
@@ -5843,6 +5857,109 @@ def output_result(
         print(f"\nRun DRC to verify: kicad-cli pcb drc {result.pcb_name}")
 
 
+def _pad_ref(pad: PadInfo) -> dict:
+    """Serialize the identity of a pad for the machine-output document."""
+    return {
+        "reference": pad.reference,
+        "pad": pad.pad_number,
+        "net": pad.net_name,
+        "layer": pad.layer,
+        "x": round(pad.x, 4),
+        "y": round(pad.y, 4),
+    }
+
+
+def result_document(
+    result: StitchResult,
+    *,
+    mode: str,
+    pcb: Path,
+    edited_path: Path,
+    via_size: float,
+    drill: float,
+    nets_auto_detected: bool,
+    manufacturer: dict | None,
+    dry_run: bool,
+    drc_requested: bool,
+    drc_ran: bool,
+) -> dict:
+    """Build the ``--format json`` document for one stitch run (issue #4674).
+
+    Unlike the prose summary -- which truncates via lists at 10 entries and
+    skipped-pad lists at 5 -- the document carries the **complete** ledger, so
+    a machine caller never has to re-run with different flags to see the pads
+    the run could not place.  Coordinates are rounded to 4 decimal places
+    (0.1 nm), well below KiCad's own file precision, so two runs on the same
+    input are byte-identical.
+    """
+    dogleg = [t for t in result.traces_added if t.is_dogleg]
+    extended = [t for t in result.traces_added if t.is_extended_escape]
+
+    obstacles: dict[str, int] = {}
+    for _pad, detail in result.skip_details:
+        obstacles[detail.obstacle_type] = obstacles.get(detail.obstacle_type, 0) + 1
+
+    document: dict = {
+        "command": "stitch",
+        "pcb": str(pcb),
+        "output": str(edited_path),
+        "mode": mode,
+        "target_nets": sorted(result.target_nets),
+        "nets_auto_detected": nets_auto_detected,
+        "manufacturer": manufacturer,
+        "via_size_mm": via_size,
+        "drill_mm": drill,
+        "detected_layers": dict(sorted(result.detected_layers.items())),
+        "stackup_inferred_nets": sorted(result.stackup_inferred_nets),
+        "fallback_nets": sorted(result.fallback_nets),
+        "strict_model_error": result.strict_model_error or None,
+        "pads_found": result.pads_found,
+        "already_connected": result.already_connected,
+        "vias_added": [
+            {
+                **_pad_ref(via.pad),
+                "via_x": round(via.via_x, 4),
+                "via_y": round(via.via_y, 4),
+                "size_mm": via.size,
+                "drill_mm": via.drill,
+                "layers": list(via.layers),
+                "via_type": via.via_type or "standard",
+            }
+            for via in result.vias_added
+        ],
+        "vias_added_count": len(result.vias_added),
+        "micro_vias_placed": result.micro_vias_placed,
+        "traces_added": {
+            "total": len(result.traces_added),
+            "straight": len(result.traces_added) - len(dogleg) - len(extended),
+            "dogleg": len(dogleg),
+            "extended_escape": len(extended),
+        },
+        "via_in_pad_filtered": result.via_in_pad_filtered,
+        "hole_to_hole_rejected": result.hole_to_hole_rejected,
+        "connectivity_fallback": [
+            {**_pad_ref(pad), "reason": reason} for pad, reason in result.connectivity_fallback
+        ],
+        "needs_routed_fanout": [
+            {**_pad_ref(pad), "reason": reason} for pad, reason in result.needs_routed_fanout
+        ],
+        "pads_skipped": [
+            {**_pad_ref(pad), "reason": reason} for pad, reason in result.pads_skipped
+        ],
+        "obstacle_breakdown": dict(sorted(obstacles.items())),
+        "dry_run": dry_run,
+        # A producer says whether it produced (batch-5 convention): vias are
+        # only on disk when the run was not a dry run AND placed something.
+        "saved": bool(result.vias_added) and not dry_run,
+        # `--drc` is honoured only for a non-dry run that actually placed
+        # copper, and kicad-cli may be absent, so "requested" and "ran" are
+        # reported separately rather than collapsed into one boolean.
+        "drc": {"requested": drc_requested, "ran": drc_ran},
+    }
+    document["success"] = bool(result.vias_added) or bool(result.already_connected)
+    return document
+
+
 def main(argv: list[str] | None = None) -> int:
     """Main entry point for kicad-pcb-stitch command."""
     parser = argparse.ArgumentParser(
@@ -6037,17 +6154,54 @@ def main(argv: list[str] | None = None) -> int:
             "(e.g., '2layer_1oz')."
         ),
     )
+    add_format_flag(parser)
 
     args = parser.parse_args(argv)
+    as_json = getattr(args, "format", FORMAT_TEXT) == FORMAT_JSON
+
+    # JSON mode owns stdout: the stitch engine, the post-stitch carve and the
+    # kicad-cli DRC pass all print progress on stdout, and this module's own
+    # informational lines ("Manufacturer profile ...", "Auto-detected N power
+    # plane nets") do too.  Divert the lot to stderr so the diagnostics
+    # survive and exactly one document lands on stdout.
+    with stdout_to_stderr_when(as_json):
+        exit_code, document = _run_main(args, as_json)
+    if as_json and document is not None:
+        emit_json(document)
+    return exit_code
+
+
+def _run_main(args: argparse.Namespace, as_json: bool) -> tuple[int, dict | None]:
+    """Execute one ``kct stitch`` run; returns (exit code, JSON document).
+
+    Split out of :func:`main` so the JSON document is emitted *outside* the
+    stdout diversion that protects the single-document contract.  The document
+    is ``None`` in text mode.
+    """
+
+    def fail(message: str, *, text_message: str | None = None, code: int = 1) -> tuple[int, dict]:
+        """Report a failure as a document (JSON) or on stderr (text).
+
+        *text_message* overrides the prose so the several non-``Error:``-
+        prefixed messages stay byte-identical (batch-4 convention).
+        """
+        if not as_json:
+            print(
+                text_message if text_message is not None else f"Error: {message}", file=sys.stderr
+            )
+        return code, {
+            "command": "stitch",
+            "pcb": str(args.pcb),
+            "error": message,
+            "success": False,
+        }
 
     pcb_path = Path(args.pcb)
     if not pcb_path.exists():
-        print(f"Error: PCB not found: {pcb_path}", file=sys.stderr)
-        return 1
+        return fail(f"PCB not found: {pcb_path}")
 
     if pcb_path.suffix != ".kicad_pcb":
-        print(f"Error: Expected .kicad_pcb file, got: {pcb_path.suffix}", file=sys.stderr)
-        return 1
+        return fail(f"Expected .kicad_pcb file, got: {pcb_path.suffix}")
 
     # If output specified, copy to output first
     if args.output and not args.dry_run:
@@ -6074,6 +6228,7 @@ def main(argv: list[str] | None = None) -> int:
     # defaults are preserved (no behavior change).
     via_size = args.via_size
     drill = args.drill
+    manufacturer: dict | None = None
     if args.mfr is not None:
         try:
             detected_layers = _count_copper_layers(pcb_path)
@@ -6081,13 +6236,14 @@ def main(argv: list[str] | None = None) -> int:
                 args.mfr, detected_layers, args.copper
             )
         except FileNotFoundError:
-            print(
-                f"Error: No configuration found for manufacturer '{args.mfr}'",
-                file=sys.stderr,
-            )
-            return 1
+            return fail(f"No configuration found for manufacturer '{args.mfr}'")
         via_size = mfr_via_size
         drill = mfr_drill
+        manufacturer = {
+            "profile": args.mfr,
+            "copper_layers": detected_layers,
+            "copper_oz": args.copper,
+        }
         print(
             f"Manufacturer profile '{args.mfr}' ({detected_layers}-layer, "
             f"{args.copper:g}oz): via_size={via_size:.3f}mm, drill={drill:.3f}mm"
@@ -6095,6 +6251,7 @@ def main(argv: list[str] | None = None) -> int:
 
     # Auto-detect power plane nets if none specified
     net_names = args.nets
+    nets_auto_detected = not net_names
     if not net_names:
         # Load PCB to find zones
         from kicad_tools.core.sexp_file import load_pcb as _load_pcb
@@ -6102,10 +6259,14 @@ def main(argv: list[str] | None = None) -> int:
         sexp = _load_pcb(pcb_path)
         plane_nets = find_all_plane_nets(sexp)
         if not plane_nets:
-            print("No power plane nets found (no zones with assigned nets)", file=sys.stderr)
-            return 1
+            return fail(
+                "No power plane nets found (no zones with assigned nets)",
+                text_message="No power plane nets found (no zones with assigned nets)",
+            )
         net_names = list(plane_nets.keys())
         print(f"Auto-detected {len(net_names)} power plane nets: {', '.join(sorted(net_names))}")
+
+    mode = "thermal" if args.thermal else ("blanket" if args.blanket else "stitch")
 
     try:
         if args.thermal:
@@ -6156,7 +6317,8 @@ def main(argv: list[str] | None = None) -> int:
                 avoid_pad_overlap=args.avoid_pad_overlap,
             )
 
-        output_result(result, dry_run=args.dry_run, run_drc=args.drc, edited_path=pcb_path)
+        if not as_json:
+            output_result(result, dry_run=args.dry_run, run_drc=args.drc, edited_path=pcb_path)
 
         # Issue #3773: stitching adds new foreign-net copper (GND vias and
         # pad-to-via trace segments) *across* the existing rail pours, but
@@ -6172,17 +6334,34 @@ def main(argv: list[str] | None = None) -> int:
             _carve_foreign_copper_after_stitch(pcb_path)
 
         # Run DRC if requested (and not dry run, and vias were actually added)
+        drc_ran = False
         if args.drc and not args.dry_run and result.vias_added:
-            run_post_stitch_drc(pcb_path)
+            drc_ran = run_post_stitch_drc(pcb_path) == 0
+
+        document = (
+            result_document(
+                result,
+                mode=mode,
+                pcb=Path(args.pcb),
+                edited_path=pcb_path,
+                via_size=via_size,
+                drill=drill,
+                nets_auto_detected=nets_auto_detected,
+                manufacturer=manufacturer,
+                dry_run=args.dry_run,
+                drc_requested=bool(args.drc),
+                drc_ran=drc_ran,
+            )
+            if as_json
+            else None
+        )
 
         if result.vias_added:
-            return 0
-        else:
-            return 0 if result.already_connected else 1
+            return 0, document
+        return (0 if result.already_connected else 1), document
 
     except Exception as e:
-        print(f"Error: {e}", file=sys.stderr)
-        return 1
+        return fail(str(e))
 
 
 if __name__ == "__main__":

--- a/tests/test_build_preflight_routing_step.py
+++ b/tests/test_build_preflight_routing_step.py
@@ -179,15 +179,17 @@ class TestBuildStepEnum:
     def test_default_all_chain_orders_preflight_between_stitch_and_verify(self) -> None:
         """Statically check the default chain ordering.
 
-        The default chain is a literal list inside main(); just check
-        the relative order of the substrings is correct.  This is a
-        weak but extremely cheap invariant to enforce.
+        The default chain is a literal list inside ``_run_main()`` (split out
+        of ``main()`` by #4674 so the ``--format json`` document is emitted
+        outside the stdout diversion); just check the relative order of the
+        substrings is correct.  This is a weak but extremely cheap invariant
+        to enforce.
         """
         import inspect
 
         from kicad_tools.cli import build_cmd
 
-        src = inspect.getsource(build_cmd.main)
+        src = inspect.getsource(build_cmd._run_main)
         stitch_idx = src.index("BuildStep.STITCH")
         preflight_idx = src.index("BuildStep.PREFLIGHT_ROUTING")
         verify_idx = src.index("BuildStep.VERIFY")

--- a/tests/test_build_sync_step.py
+++ b/tests/test_build_sync_step.py
@@ -350,17 +350,19 @@ class TestSyncOrdering:
     def test_default_chain_orders_sync_after_pcb_before_outline(self) -> None:
         """Statically check the default chain ordering.
 
-        We parse the source of `main` to find the BuildStep list rather
-        than running it (which would require a full project setup).
+        We parse the source of `_run_main` to find the BuildStep list
+        rather than running it (which would require a full project setup).
         """
         import inspect
 
         from kicad_tools.cli import build_cmd
 
-        src = inspect.getsource(build_cmd.main)
-        # The default chain is a literal list inside main(); just check
-        # the relative order of the substrings is correct.  This is a
-        # weak but extremely cheap invariant to enforce.
+        src = inspect.getsource(build_cmd._run_main)
+        # The default chain is a literal list inside ``_run_main()`` (split
+        # out of ``main()`` by #4674 so the ``--format json`` document is
+        # emitted outside the stdout diversion); just check the relative
+        # order of the substrings is correct.  This is a weak but extremely
+        # cheap invariant to enforce.
         pcb_idx = src.index("BuildStep.PCB")
         sync_idx = src.index("BuildStep.SYNC")
         outline_idx = src.index("BuildStep.OUTLINE")

--- a/tests/test_format_json_sweep_orchestrators.py
+++ b/tests/test_format_json_sweep_orchestrators.py
@@ -1,0 +1,602 @@
+"""Tests for the #4674 machine-output sweep (orchestrators batch -- the last).
+
+Issue #4674 (mechanical follow-up to #4543) adds the canonical
+``--format json`` idiom to the prose-only subcommands.  Batch 1 swept the
+grouped families (``tests/test_format_json_sweep.py``), batch 2 the 16
+mutating ``sch`` leaves (``tests/test_format_json_sweep_sch.py``), batch 3 the
+four families' holdouts (``tests/test_format_json_sweep_families.py``), batch 4
+the environment/integration singles (``tests/test_format_json_sweep_env.py``),
+batch 5 the board-artifact producers
+(``tests/test_format_json_sweep_artifacts.py``) and batch 6 the
+board-improvement drivers (``tests/test_format_json_sweep_drivers.py``).
+
+**This batch sweeps the multi-stage orchestrators** -- the last three
+actionable leaves on the #4674 backlog:
+
+* ``build``     -- spec -> schematic -> PCB -> route -> verify -> export
+* ``pipeline``  -- end-to-end repair pipeline for an existing PCB
+* ``stitch``    -- single command, but a bespoke multi-phase via report
+
+Same conventions as the six sibling modules (a separate file per batch so
+concurrent batches never conflict on a shared ``SWEPT_SURFACES`` literal):
+
+* Outer-parser surface: every swept leaf accepts ``--format`` with a ``json``
+  choice, and the default stays ``text``.
+* Shim threading: the outer ``--format json`` reaches the inner parser argv,
+  and the default (text) invocation must NOT (a default run has to build a
+  byte-identical inner argv).
+* Emission: a single valid JSON document on stdout even though all three
+  commands drive sub-tools that print on stdout, deterministic across two runs
+  on the same input modulo the named volatile timing fields, and
+  ``{"error": ...}`` documents on failure with exit codes unchanged.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from kicad_tools.cli.parser import create_parser
+
+FIXTURES = Path(__file__).parent / "fixtures"
+
+# A tiny multi-layer board with SMD pads on GND / +3.3V and no zones, so
+# `kct stitch --net GND` has real work to do without needing a zone fill.
+STITCH_BOARD = """(kicad_pcb
+  (version 20240108)
+  (generator "test")
+  (generator_version "8.0")
+  (general (thickness 1.6) (legacy_teardrops no))
+  (paper "A4")
+  (layers
+    (0 "F.Cu" signal)
+    (1 "In1.Cu" signal)
+    (2 "In2.Cu" signal)
+    (31 "B.Cu" signal)
+    (44 "Edge.Cuts" user)
+  )
+  (setup (pad_to_mask_clearance 0))
+  (net 0 "")
+  (net 1 "GND")
+  (net 2 "+3.3V")
+  (footprint "Capacitor_SMD:C_0402_1005Metric"
+    (layer "F.Cu")
+    (uuid "00000000-0000-0000-0000-000000000100")
+    (at 110 110)
+    (property "Reference" "C1" (at 0 -1.5 0) (layer "F.SilkS") (uuid "ref-uuid-c1"))
+    (pad "1" smd roundrect (at -0.51 0) (size 0.54 0.64) (layers "F.Cu" "F.Paste" "F.Mask") (roundrect_rratio 0.25) (net 1 "GND"))
+    (pad "2" smd roundrect (at 0.51 0) (size 0.54 0.64) (layers "F.Cu" "F.Paste" "F.Mask") (roundrect_rratio 0.25) (net 2 "+3.3V"))
+  )
+  (footprint "Capacitor_SMD:C_0402_1005Metric"
+    (layer "F.Cu")
+    (uuid "00000000-0000-0000-0000-000000000200")
+    (at 120 110)
+    (property "Reference" "C2" (at 0 -1.5 0) (layer "F.SilkS") (uuid "ref-uuid-c2"))
+    (pad "1" smd roundrect (at -0.51 0) (size 0.54 0.64) (layers "F.Cu" "F.Paste" "F.Mask") (roundrect_rratio 0.25) (net 1 "GND"))
+    (pad "2" smd roundrect (at 0.51 0) (size 0.54 0.64) (layers "F.Cu" "F.Paste" "F.Mask") (roundrect_rratio 0.25) (net 2 "+3.3V"))
+  )
+)
+"""  # noqa: E501
+
+# Every subcommand swept by this batch, as (command path, minimal extra argv).
+SWEPT_SURFACES: dict[str, list[str]] = {
+    "build": ["project"],
+    "pipeline": ["board.kicad_pcb"],
+    "stitch": ["board.kicad_pcb"],
+}
+
+# Fields whose value is wall-clock time and therefore deliberately volatile.
+# Named rather than hidden (batch-6 convention); determinism is asserted
+# modulo them.
+VOLATILE_KEYS = ("wall_time_s", "elapsed_s")
+
+
+def _iter_leaves(parser, path=()):
+    subactions = [a for a in parser._actions if isinstance(a, argparse._SubParsersAction)]
+    if not subactions:
+        yield path, parser
+        return
+    for subaction in subactions:
+        for name, sub in subaction.choices.items():
+            yield from _iter_leaves(sub, (*path, name))
+
+
+def _strip_volatile(payload):
+    """Recursively drop the named wall-clock fields before comparing."""
+    if isinstance(payload, dict):
+        return {k: _strip_volatile(v) for k, v in payload.items() if k not in VOLATILE_KEYS}
+    if isinstance(payload, list):
+        return [_strip_volatile(v) for v in payload]
+    return payload
+
+
+@pytest.fixture(scope="module")
+def leaves():
+    return {" ".join(path): leaf for path, leaf in _iter_leaves(create_parser())}
+
+
+@pytest.fixture
+def stitch_board(tmp_path):
+    pcb = tmp_path / "board.kicad_pcb"
+    pcb.write_text(STITCH_BOARD)
+    return pcb
+
+
+@pytest.fixture
+def pipeline_board(tmp_path):
+    """A writable copy of the small routing fixture board."""
+    pcb = tmp_path / "board.kicad_pcb"
+    pcb.write_text((FIXTURES / "routing-diagnostic.kicad_pcb").read_text())
+    return pcb
+
+
+# ---------------------------------------------------------------------------
+# Outer-parser surface guard
+# ---------------------------------------------------------------------------
+
+
+class TestOuterSurface:
+    @pytest.mark.parametrize("command", sorted(SWEPT_SURFACES))
+    def test_leaf_has_format_json_choice(self, leaves, command):
+        """Each swept leaf declares --format with a json choice."""
+        leaf = leaves.get(command)
+        assert leaf is not None, f"outer parser has no leaf {command!r}"
+        for action in leaf._actions:
+            if "--format" in action.option_strings:
+                assert action.choices and "json" in action.choices, (
+                    f"kct {command} has --format without a 'json' choice "
+                    f"(choices={action.choices}); regresses #4674"
+                )
+                break
+        else:
+            pytest.fail(f"kct {command} lost its --format flag (regresses #4674)")
+
+    @pytest.mark.parametrize("command", sorted(SWEPT_SURFACES))
+    def test_parse_accepts_format_json(self, command):
+        """`kct <command> ... --format json` parses on the real outer parser."""
+        argv = [*command.split(), *SWEPT_SURFACES[command], "--format", "json"]
+        args = create_parser().parse_args(argv)
+        assert args.format == "json"
+
+    @pytest.mark.parametrize("command", sorted(SWEPT_SURFACES))
+    def test_default_format_is_text(self, command):
+        """The default stays text, so no existing invocation changes shape."""
+        args = create_parser().parse_args([*command.split(), *SWEPT_SURFACES[command]])
+        assert args.format == "text"
+
+    def test_no_actionable_prose_only_leaves_remain(self, leaves):
+        """#4674's backlog is empty: only the documented exemptions are left.
+
+        The four exemptions and the deferred ``route`` are listed in
+        ``docs/reference/machine-output.md``; anything else appearing here is
+        a new prose-only leaf that skipped the canonical idiom.
+        """
+        allowed = {"footprint generate", "interactive", "mcp serve", "route", "run"}
+        prose_only = set()
+        for command, leaf in leaves.items():
+            opts = {opt for action in leaf._actions for opt in action.option_strings}
+            if "--format" not in opts and "--json" not in opts:
+                prose_only.add(command)
+        assert prose_only == allowed, (
+            "prose-only bucket drifted from the documented exemption list "
+            f"(unexpected: {sorted(prose_only - allowed)}, "
+            f"newly covered: {sorted(allowed - prose_only)})"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Shim threading (outer --format json must reach the inner parser argv)
+# ---------------------------------------------------------------------------
+
+
+class TestShimThreading:
+    def test_build_shim_forwards_format(self):
+        from kicad_tools.cli.commands.build import run_build_command
+
+        args = create_parser().parse_args(["build", "project", "--format", "json"])
+        with patch("kicad_tools.cli.build_cmd.main", return_value=0) as inner:
+            assert run_build_command(args) == 0
+        sub_argv = inner.call_args[0][0]
+        assert "--format" in sub_argv, f"build shim dropped --format: {sub_argv}"
+        assert sub_argv[sub_argv.index("--format") + 1] == "json"
+
+    def test_build_shim_omits_format_for_text_default(self):
+        from kicad_tools.cli.commands.build import run_build_command
+
+        args = create_parser().parse_args(["build", "project"])
+        with patch("kicad_tools.cli.build_cmd.main", return_value=0) as inner:
+            assert run_build_command(args) == 0
+        assert "--format" not in inner.call_args[0][0]
+
+    def test_pipeline_shim_forwards_format(self):
+        from kicad_tools.cli.commands.pipeline import run_pipeline_command
+
+        args = create_parser().parse_args(["pipeline", "board.kicad_pcb", "--format", "json"])
+        with patch("kicad_tools.cli.pipeline_cmd.main", return_value=0) as inner:
+            assert run_pipeline_command(args) == 0
+        sub_argv = inner.call_args[0][0]
+        assert sub_argv[sub_argv.index("--format") + 1] == "json"
+
+    def test_pipeline_shim_omits_format_for_text_default(self):
+        from kicad_tools.cli.commands.pipeline import run_pipeline_command
+
+        args = create_parser().parse_args(["pipeline", "board.kicad_pcb"])
+        with patch("kicad_tools.cli.pipeline_cmd.main", return_value=0) as inner:
+            assert run_pipeline_command(args) == 0
+        assert "--format" not in inner.call_args[0][0]
+
+    def test_stitch_shim_forwards_format(self):
+        from kicad_tools.cli import _run_stitch_command
+
+        args = create_parser().parse_args(["stitch", "board.kicad_pcb", "--format", "json"])
+        with patch("kicad_tools.cli.stitch_cmd.main", return_value=0) as inner:
+            assert _run_stitch_command(args) == 0
+        sub_argv = inner.call_args[0][0]
+        assert sub_argv[sub_argv.index("--format") + 1] == "json"
+
+    def test_stitch_shim_omits_format_for_text_default(self):
+        from kicad_tools.cli import _run_stitch_command
+
+        args = create_parser().parse_args(["stitch", "board.kicad_pcb"])
+        with patch("kicad_tools.cli.stitch_cmd.main", return_value=0) as inner:
+            assert _run_stitch_command(args) == 0
+        assert "--format" not in inner.call_args[0][0]
+
+    @pytest.mark.parametrize("command", ["build", "pipeline"])
+    def test_inner_parser_accepts_format(self, command):
+        """The inner (authoritative) parsers accept the forwarded flag."""
+        if command == "build":
+            from kicad_tools.cli.build_cmd import _build_inner_parser
+
+            parser = _build_inner_parser()
+            args = parser.parse_args(["project", "--format", "json"])
+        else:
+            from kicad_tools.cli.pipeline_cmd import main as pipeline_main
+
+            # pipeline builds its parser inside main(); a bogus path exits 1
+            # rather than argparse's 2, which proves the flag parsed.
+            assert pipeline_main(["/nonexistent.kicad_pcb", "--format", "json"]) == 1
+            return
+        assert args.format == "json"
+
+
+# ---------------------------------------------------------------------------
+# stitch emission
+# ---------------------------------------------------------------------------
+
+
+def _run_stitch(argv, capsys):
+    from kicad_tools.cli import _run_stitch_command
+
+    rc = _run_stitch_command(create_parser().parse_args(argv))
+    return rc, capsys.readouterr().out
+
+
+class TestStitchEmission:
+    def test_dry_run_document(self, stitch_board, capsys):
+        rc, out = _run_stitch(
+            ["stitch", str(stitch_board), "--net", "GND", "--dry-run", "--format", "json"],
+            capsys,
+        )
+        assert rc == 0
+        payload = json.loads(out)
+        assert payload["command"] == "stitch"
+        assert payload["pcb"] == str(stitch_board)
+        assert payload["mode"] == "stitch"
+        assert payload["target_nets"] == ["GND"]
+        assert payload["nets_auto_detected"] is False
+        assert payload["dry_run"] is True
+        assert payload["saved"] is False, "--dry-run must not claim a written file"
+        assert payload["manufacturer"] is None
+        assert payload["via_size_mm"] == 0.45
+        assert payload["drill_mm"] == 0.2
+        assert payload["pads_found"] == 2
+        assert payload["vias_added_count"] >= 1
+        assert payload["success"] is True
+
+    def test_document_is_the_full_untruncated_ledger(self, stitch_board, capsys):
+        """Unlike the prose (10 vias / 5 skipped pads), JSON is complete."""
+        _, out = _run_stitch(
+            ["stitch", str(stitch_board), "--net", "GND", "--dry-run", "--format", "json"],
+            capsys,
+        )
+        payload = json.loads(out)
+        assert len(payload["vias_added"]) == payload["vias_added_count"]
+        for via in payload["vias_added"]:
+            assert {"reference", "pad", "net", "via_x", "via_y", "layers"} <= set(via)
+            assert via["net"] == "GND"
+
+    def test_write_document_reports_saved(self, stitch_board, capsys):
+        rc, out = _run_stitch(
+            ["stitch", str(stitch_board), "--net", "GND", "--format", "json"], capsys
+        )
+        assert rc == 0
+        payload = json.loads(out)
+        assert payload["saved"] is True
+        assert payload["output"] == str(stitch_board)
+
+    def test_output_flag_names_the_edited_file(self, stitch_board, tmp_path, capsys):
+        out_pcb = tmp_path / "stitched.kicad_pcb"
+        rc, out = _run_stitch(
+            [
+                "stitch",
+                str(stitch_board),
+                "--net",
+                "GND",
+                "-o",
+                str(out_pcb),
+                "--format",
+                "json",
+            ],
+            capsys,
+        )
+        assert rc == 0
+        payload = json.loads(out)
+        assert payload["pcb"] == str(stitch_board)
+        assert payload["output"] == str(out_pcb)
+
+    def test_dry_run_writes_nothing(self, stitch_board, capsys):
+        before = stitch_board.read_text()
+        _run_stitch(
+            ["stitch", str(stitch_board), "--net", "GND", "--dry-run", "--format", "json"],
+            capsys,
+        )
+        assert stitch_board.read_text() == before
+
+    def test_document_is_deterministic(self, stitch_board, capsys):
+        argv = ["stitch", str(stitch_board), "--net", "GND", "--dry-run", "--format", "json"]
+        _, first = _run_stitch(argv, capsys)
+        _, second = _run_stitch(argv, capsys)
+        assert first == second
+
+    def test_missing_board_is_error_document(self, tmp_path, capsys):
+        rc, out = _run_stitch(
+            ["stitch", str(tmp_path / "nope.kicad_pcb"), "--format", "json"], capsys
+        )
+        assert rc == 1
+        payload = json.loads(out)
+        assert payload["command"] == "stitch"
+        assert payload["success"] is False
+        assert "not found" in payload["error"]
+
+    def test_no_plane_nets_is_error_document(self, stitch_board, capsys):
+        """Auto-detect with no zones fails; the prose has no `Error:` prefix."""
+        rc, out = _run_stitch(["stitch", str(stitch_board), "--format", "json"], capsys)
+        assert rc == 1
+        payload = json.loads(out)
+        assert payload["success"] is False
+        assert "No power plane nets found" in payload["error"]
+
+    def test_unknown_manufacturer_is_error_document(self, stitch_board, capsys):
+        rc, out = _run_stitch(
+            ["stitch", str(stitch_board), "--net", "GND", "--mfr", "nope", "--format", "json"],
+            capsys,
+        )
+        assert rc == 1
+        assert "nope" in json.loads(out)["error"]
+
+    def test_text_mode_is_not_json(self, stitch_board, capsys):
+        rc, out = _run_stitch(["stitch", str(stitch_board), "--net", "GND", "--dry-run"], capsys)
+        assert rc == 0
+        assert "Stitching vias for" in out
+        with pytest.raises(json.JSONDecodeError):
+            json.loads(out)
+
+
+# ---------------------------------------------------------------------------
+# pipeline emission
+# ---------------------------------------------------------------------------
+
+
+def _run_pipeline(argv, capsys):
+    from kicad_tools.cli.commands.pipeline import run_pipeline_command
+
+    rc = run_pipeline_command(create_parser().parse_args(argv))
+    return rc, capsys.readouterr().out
+
+
+class TestPipelineEmission:
+    def test_dry_run_document(self, pipeline_board, capsys):
+        rc, out = _run_pipeline(
+            ["pipeline", str(pipeline_board), "--dry-run", "--format", "json"], capsys
+        )
+        assert rc == 0
+        payload = json.loads(out)
+        assert payload["command"] == "pipeline"
+        assert payload["pcb"] == str(pipeline_board)
+        assert payload["mfr"] == "jlcpcb"
+        assert payload["dry_run"] is True
+        assert payload["step"] is None
+        assert payload["success"] is True
+        assert payload["exit_code"] == 0
+        assert payload["commit"] == {"requested": False, "created": False}
+        assert payload["counts"]["total"] == len(payload["steps"])
+        for entry in payload["steps"]:
+            assert {"step", "success", "skipped", "warning", "message"} == set(entry)
+
+    def test_single_step_document(self, pipeline_board, capsys):
+        rc, out = _run_pipeline(
+            [
+                "pipeline",
+                str(pipeline_board),
+                "--step",
+                "fix-vias",
+                "--dry-run",
+                "--format",
+                "json",
+            ],
+            capsys,
+        )
+        assert rc == 0
+        payload = json.loads(out)
+        assert payload["step"] == "fix-vias"
+        assert [entry["step"] for entry in payload["steps"]] == ["fix-vias"]
+
+    def test_document_is_deterministic(self, pipeline_board, capsys):
+        argv = ["pipeline", str(pipeline_board), "--dry-run", "--format", "json"]
+        _, first = _run_pipeline(argv, capsys)
+        _, second = _run_pipeline(argv, capsys)
+        assert _strip_volatile(json.loads(first)) == _strip_volatile(json.loads(second))
+
+    def test_missing_board_is_error_document(self, tmp_path, capsys):
+        rc, out = _run_pipeline(
+            ["pipeline", str(tmp_path / "nope.kicad_pcb"), "--format", "json"], capsys
+        )
+        assert rc == 1
+        payload = json.loads(out)
+        assert payload["command"] == "pipeline"
+        assert payload["success"] is False
+        assert "not found" in payload["error"].lower()
+
+    def test_unsupported_suffix_is_error_document(self, tmp_path, capsys):
+        bogus = tmp_path / "board.txt"
+        bogus.write_text("")
+        rc, out = _run_pipeline(["pipeline", str(bogus), "--format", "json"], capsys)
+        assert rc == 1
+        assert "Unsupported file type" in json.loads(out)["error"]
+
+    def test_text_mode_is_not_json(self, pipeline_board, capsys):
+        rc, out = _run_pipeline(["pipeline", str(pipeline_board), "--dry-run"], capsys)
+        assert rc == 0
+        assert "pipeline" in out.lower()
+        with pytest.raises(json.JSONDecodeError):
+            json.loads(out)
+
+
+# ---------------------------------------------------------------------------
+# build emission
+# ---------------------------------------------------------------------------
+
+
+def _run_build(argv, capsys):
+    from kicad_tools.cli.commands.build import run_build_command
+
+    rc = run_build_command(create_parser().parse_args(argv))
+    return rc, capsys.readouterr().out
+
+
+class TestBuildEmission:
+    def test_document_for_a_project_without_a_generator(self, tmp_path, capsys):
+        """A project with no generator fails at the schematic step.
+
+        Even a failing build emits exactly one document: the ledger of what
+        ran is the payload, and the exit code is unchanged.
+        """
+        rc, out = _run_build(["build", str(tmp_path), "--dry-run", "--format", "json"], capsys)
+        assert rc == 1
+        payload = json.loads(out)
+        assert payload["command"] == "build"
+        assert payload["project_dir"] == str(tmp_path.resolve())
+        assert payload["spec"] is None
+        assert payload["mfr"] == "jlcpcb"
+        assert payload["step"] == "all"
+        assert payload["dry_run"] is True
+        assert payload["success"] is False
+        assert payload["exit_code"] == 1
+        assert payload["steps"][0]["step"] == "schematic"
+        assert payload["steps"][0]["success"] is False
+        assert payload["counts"] == {"total": 1, "succeeded": 0, "failed": 1}
+        assert isinstance(payload["wall_time_s"], float)
+
+    def test_single_step_document(self, tmp_path, capsys):
+        rc, out = _run_build(
+            ["build", str(tmp_path), "--step", "verify", "--dry-run", "--format", "json"],
+            capsys,
+        )
+        assert isinstance(rc, int)
+        payload = json.loads(out)
+        assert payload["step"] == "verify"
+        assert [entry["step"] for entry in payload["steps"]] == ["verify"]
+
+    def test_document_is_deterministic(self, tmp_path, capsys):
+        argv = ["build", str(tmp_path), "--dry-run", "--format", "json"]
+        _, first = _run_build(argv, capsys)
+        _, second = _run_build(argv, capsys)
+        assert _strip_volatile(json.loads(first)) == _strip_volatile(json.loads(second))
+
+    def test_missing_directory_is_error_document(self, tmp_path, capsys):
+        rc, out = _run_build(["build", str(tmp_path / "nope"), "--format", "json"], capsys)
+        assert rc == 1
+        payload = json.loads(out)
+        assert payload["command"] == "build"
+        assert payload["success"] is False
+        assert "not found" in payload["error"].lower()
+
+    def test_exit_code_no_longer_depends_on_quiet(self, tmp_path, capsys):
+        """A failing build exits 1 whether or not --quiet is passed.
+
+        The exit code used to be computed inside the `if not args.quiet`
+        summary block, so `kct build --quiet` reported success for a failed
+        build -- which would have contradicted the document's "success":
+        false.  Hoisted out of the guard by #4674.
+        """
+        loud, _ = _run_build(["build", str(tmp_path), "--dry-run"], capsys)
+        quiet, _ = _run_build(["build", str(tmp_path), "--dry-run", "--quiet"], capsys)
+        assert loud == 1
+        assert quiet == 1
+
+    def test_text_mode_is_not_json(self, tmp_path, capsys):
+        rc, out = _run_build(["build", str(tmp_path), "--dry-run"], capsys)
+        assert rc == 1
+        with pytest.raises(json.JSONDecodeError):
+            json.loads(out)
+
+
+# ---------------------------------------------------------------------------
+# The promoted stdout-diversion helper (was copied in 3 CLI modules)
+# ---------------------------------------------------------------------------
+
+
+class TestStdoutDiversionHelper:
+    def test_inactive_is_a_passthrough(self, capsys):
+        from kicad_tools.cli.format_options import stdout_to_stderr_when
+
+        with stdout_to_stderr_when(False):
+            print("hello")
+        captured = capsys.readouterr()
+        assert captured.out == "hello\n"
+        assert captured.err == ""
+
+    def test_active_replays_stdout_on_stderr(self, capsys):
+        from kicad_tools.cli.format_options import stdout_to_stderr_when
+
+        with stdout_to_stderr_when(True):
+            print("chatter")
+        captured = capsys.readouterr()
+        assert captured.out == ""
+        assert "chatter" in captured.err
+
+    def test_replays_even_when_the_body_raises(self, capsys):
+        from kicad_tools.cli.format_options import stdout_to_stderr_when
+
+        with pytest.raises(RuntimeError), stdout_to_stderr_when(True):
+            print("chatter")
+            raise RuntimeError("boom")
+        assert "chatter" in capsys.readouterr().err
+
+    @pytest.mark.parametrize(
+        "module",
+        [
+            "kicad_tools.cli.report_cmd",
+            "kicad_tools.cli.reason_cmd",
+            "kicad_tools.cli.commands.routing",
+            "kicad_tools.cli.build_cmd",
+            "kicad_tools.cli.pipeline_cmd",
+            "kicad_tools.cli.stitch_cmd",
+        ],
+    )
+    def test_call_sites_use_the_shared_helper(self, module):
+        """No module re-implements the helper (it was copied 3x before #4674)."""
+        import importlib
+
+        from kicad_tools.cli.format_options import stdout_to_stderr_when
+
+        mod = importlib.import_module(module)
+        assert mod.stdout_to_stderr_when is stdout_to_stderr_when
+        assert not hasattr(mod, "_stdout_to_stderr_when"), (
+            f"{module} still defines a private copy of the helper"
+        )

--- a/tests/test_format_json_sweep_orchestrators.py
+++ b/tests/test_format_json_sweep_orchestrators.py
@@ -296,6 +296,7 @@ class TestStitchEmission:
         assert payload["drill_mm"] == 0.2
         assert payload["pads_found"] == 2
         assert payload["vias_added_count"] >= 1
+        assert payload["exit_code"] == 0
         assert payload["success"] is True
 
     def test_document_is_the_full_untruncated_ledger(self, stitch_board, capsys):
@@ -360,6 +361,7 @@ class TestStitchEmission:
         assert rc == 1
         payload = json.loads(out)
         assert payload["command"] == "stitch"
+        assert payload["exit_code"] == 1
         assert payload["success"] is False
         assert "not found" in payload["error"]
 


### PR DESCRIPTION
## Summary

Seventh and **final** batch of the #4543 machine-output sweep (issue #4674): the
multi-stage orchestrators, the last three actionable leaves on the backlog.
Three surfaces wired end-to-end (outer parser → shim → inner parser):

- `kct build` — spec → schematic → PCB → route → verify → export
- `kct pipeline` — end-to-end repair pipeline for an existing PCB
- `kct stitch` — one command, but a bespoke multi-phase via report

Closes #4674.

## Audit — before / after

`uv run python scripts/audit_machine_output.py` (199 leaf subcommands both times):

| Bucket | Before (`021d9a18`, main) | After (`c36e07a8`) |
|---|---|---|
| `format-json` | 189 | **192** |
| `both` (`--format json` + legacy `--json`) | 2 | 2 |
| `json-bool` | 0 | 0 |
| `format-nojson` | 0 | 0 |
| `prose-only` | 8 | **5** |

The 5 remaining `prose-only` leaves are exactly the ones
`docs/reference/machine-output.md` already exempts or defers — `interactive`,
`mcp serve`, `run`, `footprint generate` (argv passthrough; its real surface is
the shape subparsers) plus `route`, deferred to the route workstream because
promoting its inner `--format` means removing an `INNER_ONLY_ALLOWLIST` entry
under the route drift guard. **The actionable backlog is empty**, so #4674's
contract now holds: every non-exempt `kct` subcommand accepts `--format json`
and emits a single JSON document on stdout.

## Document shapes

| Command | Document |
|---|---|
| `build` | `{"command", "spec", "project_dir", "output_dir", "mfr", "step", "dry_run", "force", "schematic", "pcb", "routed_pcb", "manufacturing_output", "steps": [{step, success, message, output_file, elapsed_s}], "counts": {total, succeeded, failed}, "wall_time_s", "exit_code", "success"}` |
| `pipeline` | `{"command", "input", "pcb", "project", "schematic", "mfr", "layers", "layer_count", "step", "dry_run", "force", "best_effort", "steps": [{step, success, skipped, warning, message}], "counts": {total, succeeded, skipped, warnings}, "commit": {requested, created}, "exit_code", "success"}` |
| `stitch` | `{"command", "pcb", "output", "mode", "target_nets", "nets_auto_detected", "manufacturer", "via_size_mm", "drill_mm", "detected_layers", "stackup_inferred_nets", "fallback_nets", "strict_model_error", "pads_found", "already_connected", "vias_added": [...], "vias_added_count", "micro_vias_placed", "traces_added": {...}, "via_in_pad_filtered", "hole_to_hole_rejected", "connectivity_fallback": [...], "needs_routed_fanout": [...], "pads_skipped": [...], "obstacle_breakdown", "dry_run", "saved", "drc": {requested, ran}, "success"}` |

### Conventions this batch adds

- **The document is the complete ledger, not the prose's excerpt.** `stitch`'s
  text summary caps via lists at 10 entries and skipped-pad lists at 5
  (`... (N more)`); the JSON carries every entry, because a machine caller must
  not have to re-run with different flags to see the pads a run could not
  place. `len(vias_added) == vias_added_count` is asserted.
- **A multi-step run reports the ledger, not just the verdict** — including
  `pipeline`'s `skipped` / `warning` axes, which its exit code cannot express
  (exit 2 means "best-effort partial", not *which* step). `build` names
  `elapsed_s` / `wall_time_s` as volatile (the `board-metrics` `generated_at`
  treatment) and determinism is asserted modulo them.

## Helper promotion (as the handoff requested)

`_stdout_to_stderr_when` was introduced per-module in batch 5 (`report_cmd`) and
copied verbatim into `reason_cmd` and `commands/routing` in batch 6. This batch
needed it in three more places, so rather than making a fourth copy it is
promoted to the public `cli/format_options.py::stdout_to_stderr_when` and the
three existing call sites repointed (first commit, pure refactor — batches 5/6
test files pass unchanged). All three orchestrators need it: the rich
`Console`/`Progress` ledger, every generator script's streamed stdout and the
kicad-cli DRC pass all write to **stdout**. A parametrized test pins that no
module re-implements it.

## Drive-by fix: `kct build --quiet` exited 0 on a failed build

The success/failure verdict was computed *inside* the `if not args.quiet:`
summary block, so suppressing the summary also suppressed the non-zero exit code
— a failed quiet build looked green to CI. That could not ship alongside a
document whose `"success": false` would then contradict its own exit code, so
the verdict is hoisted out of the guard. Prose output is unchanged; a regression
test asserts loud and quiet failing builds both exit 1.

## Test results

- `tests/test_format_json_sweep_orchestrators.py` — **49 new tests** (outer
  surface, both shim shapes, emission, determinism, `--dry-run` writes nothing,
  error documents with unchanged exit codes, text-mode-is-not-JSON, the promoted
  helper). It also pins the `prose-only` bucket against the documented exemption
  list, so a new prose-only leaf fails a test rather than silently re-opening
  the backlog.
- `uv run pytest tests -k "format_json or machine_output or cli_parser"` —
  **593 passed, 1 skipped**
- `uv run pytest tests -k "cli or parser or report or reason or routing or format"` —
  **5382 passed, 9 skipped** (25m34s)
- `uv run pytest tests -k "build_cmd or pipeline or stitch or build_preflight or build_step or build_parser"` —
  **1012 passed, 1 skipped**
- `uv run ruff check src tests` + `ruff format --check src tests` — clean
- `uv run python scripts/ci/check_mypy_baseline.py` (no `--update`) — OK, 1464 ≤ 1472

One surgical test update:
`tests/test_build_preflight_routing_step.py` introspects the source of the
function holding the default step chain, which moved from `main()` to the new
`_run_main()` (split so the JSON document is emitted *outside* the stdout
diversion). The assertion itself is unchanged.

## Docs

`docs/reference/machine-output.md` — inventory table gains a `b7` column
(`format-json` 189 → 192, `prose-only` 8 → 5, backlog closed), the batch-7
shapes and conventions are recorded, `stdout_to_stderr_when` is listed under
*Shared machinery*, and the interop note now states the contract as holding
rather than pending. `CHANGELOG.md` gains the `Added` entry plus the `--quiet`
`Fixed` entry, both citing #4674.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
