### PR TITLE
feat(router): replay a crosstail census report as a pre-route advisory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   a missing, malformed or foreign report prints one `no prediction:` line and
   the route proceeds unchanged — and no code branches on the verdict. Wiring
   it into a go/no-go or steering decision remains follow-up work on #4799.
+  Measured on board-06's own 166-crossover report: the whole preflight costs
+  **0.149 s** (0.0009 s to load, 0.147 s to read the board's nets, 0.0008 s to
+  aggregate) and reproduces the run's 150/166 = 90.4% saturation figure —
+  ~0.01% of the 28-minute route it now precedes instead of concluding.
   New API in `kicad_tools.router.crosstail_advisory`
   (`LoadedCensusReport`, `build_advisory`, `emit_advisory`, `board_net_names`);
   documented in `docs/reference/crosstail-census-report.md`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `--voltage-map` (single `pairwise_active()` boolean, unchanged route
   output); `ROUTER_CPP_BUILD_VERSION` 20 → 21 for the new binding surface.
 
+- **Pre-route crossing-tail census advisory** (part of #4799) — `kct route
+  --census-advisory <report.json>` (or `KCT_CROSSTAIL_CENSUS_ADVISORY=<path>`
+  for callers that drive the router API directly) replays a census report
+  written by an earlier run *before the first A\* expansion* of the next one,
+  turning the crossover census from a post-mortem into a leading indicator:
+  same measurement, read earlier. The `[crosstail-advisory]` block reports the
+  prior run's `saturated_pct` / `inert_pct` / `verdict`, a per-net roll-up of
+  the saturated crossovers (worst first), and the predicted saturated-crossover
+  count for this run. Because a replay inherits the previous run's ordering,
+  two guards keep it honest: report nets are cross-checked against the nets
+  declared by the board being routed (nets that no longer exist do not
+  contribute), and a report whose nets overlap the board by less than 50%
+  (`STALE_COVERAGE_PCT_THRESHOLD`) is declared `stale` with its prediction
+  suppressed rather than presented as this board's forecast. A report that
+  scanned nothing stays `not-applicable` (boards 05 and 07 today), never "0%
+  saturated". **Advisory only**: the preflight returns 0 unconditionally —
+  a missing, malformed or foreign report prints one `no prediction:` line and
+  the route proceeds unchanged — and no code branches on the verdict. Wiring
+  it into a go/no-go or steering decision remains follow-up work on #4799.
+  New API in `kicad_tools.router.crosstail_advisory`
+  (`LoadedCensusReport`, `build_advisory`, `emit_advisory`, `board_net_names`);
+  documented in `docs/reference/crosstail-census-report.md`.
+
 - **Structured crossing-tail census report** (part of #4799) — the #4580
   diff-pair crossover legality census now also captures what it prints as
   data. Each censused crossover produces a `CrossingTailCensusRecord`

--- a/boards/06-diffpair-test/README.md
+++ b/boards/06-diffpair-test/README.md
@@ -377,6 +377,13 @@ whenever the census is on.  It is report-only and costs ~1 µs per crossover on
 top of the census itself; schema and interpretation live in
 [`docs/reference/crosstail-census-report.md`](../../docs/reference/crosstail-census-report.md).
 
+That report is a post-mortem, but it does not have to be read as one: feeding
+it back in with `kct route --census-advisory <report.json>` (or
+`KCT_CROSSTAIL_CENSUS_ADVISORY=<path>`) prints this board's saturation figure
+**before** the next route's first A\* expansion, cross-checked against the
+board's current nets and suppressed when the report is stale.  Advisory only —
+it cannot change or fail a route.
+
 **State-neutral is not the same as budget-neutral ([#4635]).** PR [#4611]'s
 prose claimed the census "cannot" change the route because it is
 "observation-only by construction".  That is true of router **state** — every

--- a/docs/reference/crosstail-census-report.md
+++ b/docs/reference/crosstail-census-report.md
@@ -171,6 +171,79 @@ the escape-channel registry keyed on which nets are still unrouted, and the
 pair's own guide route — so it cannot simply be hoisted ahead of the first A*
 expansion).
 
+## Replaying it before the next route (`--census-advisory`)
+
+The document above is still a post-mortem: it lands at the end of the run that
+produced it, after the shadow phase has already spent its budget. **Loading it
+at the start of the *next* run** is what turns the census into a leading
+indicator — same measurement, read earlier:
+
+```bash
+# run N: measure (see "Enabling the report" above) -> census.json
+# run N+1: predict, before the first A* expansion
+uv run kct route board.kicad_pcb --census-advisory census.json
+```
+
+`KCT_CROSSTAIL_CENSUS_ADVISORY=<path>` is the equivalent for callers that do
+not go through `kct route` (board scripts drive the router API directly); the
+flag wins when both are set. The block prints to **stderr**, before any router
+or component loading:
+
+```
+[crosstail-advisory] pre-route prediction from census.json, 3.2h old
+[crosstail-advisory]   prior run: 166 crossover(s), 150 saturated (90.4%), inert 94.6%, verdict=saturated
+[crosstail-advisory]   board cross-check: 18/18 report net(s) still on this board (100.0% coverage)
+[crosstail-advisory]   predicted this run: 150/166 saturated crossover(s) (90.4%)
+[crosstail-advisory]   worst nets: MIPI_D0- 12/12, MIPI_D0+ 12/12, USB_DP 11/12, …
+[crosstail-advisory]   reading: ordering levers are inert here -- the diff-pair shadow phase will
+                       spend its budget without a lever to pull; the constraint is upstream in
+                       placement / escape planning
+[crosstail-advisory]   ADVISORY ONLY -- this route is unchanged by the above (#4799)
+```
+
+This is a *replay*, not a placement-only predictor: it inherits the previous
+run's ordering, so its accuracy decays as the design moves. Two guards keep it
+honest rather than confident:
+
+* **Board cross-check.** The report's nets are matched against the nets
+  declared by the board being routed. Nets that no longer exist do not
+  contribute to the predicted counts, so a report is not allowed to predict
+  saturation for copper that is gone.
+* **Staleness.** When fewer than **50%** of the report's nets still exist on
+  the board (`STALE_COVERAGE_PCT_THRESHOLD`), the advisory sets `stale` and
+  suppresses the prediction — a report from a *different* design must not be
+  reported as this board's forecast. 50% is deliberately generous: a handful of
+  renamed nets keeps a same-board report usable.
+
+The prediction is suppressed the same way for a report that scanned nothing
+(`verdict: "not-applicable"`, boards 05 / 07 — see below); `applicable` is
+`false` in both cases and the block says which.
+
+`--census-advisory` **cannot fail a route.** A missing, unreadable, malformed
+or foreign file prints one `[crosstail-advisory] no prediction: …` line and the
+route proceeds; the preflight returns 0 unconditionally, unlike the
+`_offboard_preflight` gate it is modelled on. Anomalies that are *not* fatal —
+a schema version this build does not know, a report written with the census
+disabled, a stored summary that disagrees with its own records (the advisory
+re-aggregates from the records and says so) — surface as `WARNING:` lines.
+
+### Advisory fields
+
+`CrossingTailAdvisory.to_dict()` is the machine form of the block above (for
+tooling; `kct route` prints only the text):
+
+| Field | Meaning |
+|-------|---------|
+| `source` / `generated_at` / `age_seconds` | Which report, written when, how stale |
+| `applicable` | The prediction is usable: the prior run measured something **and** the board cross-check accepted it |
+| `stale` | Coverage fell below `STALE_COVERAGE_PCT_THRESHOLD` |
+| `board_nets_known` | Whether the board's nets could be read at all (`false` ⇒ cross-check skipped, every report net contributes) |
+| `nets_in_report` / `nets_on_board` / `coverage_pct` | The cross-check |
+| `predicted_crossovers` / `predicted_saturated` / `_pct` | Restricted to nets still on the board |
+| `prior_summary` | The re-aggregated summary block, identical in shape to the report's own |
+| `nets[]` | Per-net roll-up (`crossovers`, `saturated`, `saturated_pct`, `no_ordering_lever`, `inert`, `present_on_board`), worst first |
+| `warnings[]` | The `WARNING:` lines, verbatim |
+
 ## Not applicable ≠ zero
 
 Only board-06 exercises this path today. Board-05 has no differential pairs;
@@ -215,6 +288,27 @@ write_report("census.json")
 
 `DiffPairRouter._census_records` holds the same records for a single router
 instance, reset at the start of every `route_all_with_diffpairs` call.
+
+The replay side:
+
+```python
+from kicad_tools.router.crosstail_advisory import (
+    LoadedCensusReport,  # parse + rehydrate a report
+    board_net_names,  # nets of the board about to be routed (None = unknown)
+    build_advisory,  # report + board nets -> prediction
+    emit_advisory,  # the two above + print; never raises
+)
+
+advisory = build_advisory(
+    LoadedCensusReport.from_path("census.json"),
+    board_net_names("board.kicad_pcb"),
+)
+print(advisory.applicable, advisory.predicted_saturated, advisory.summary.verdict)
+```
+
+`LoadedCensusReport.from_path` raises `CensusReportError` for anything that is
+not a readable census report — `emit_advisory` (and therefore `kct route`)
+catches it.
 
 [#3438]: https://github.com/rjwalters/kicad-tools/issues/3438
 [#4580]: https://github.com/rjwalters/kicad-tools/issues/4580

--- a/docs/reference/crosstail-census-report.md
+++ b/docs/reference/crosstail-census-report.md
@@ -189,17 +189,22 @@ not go through `kct route` (board scripts drive the router API directly); the
 flag wins when both are set. The block prints to **stderr**, before any router
 or component loading:
 
+Verbatim, replaying board-06's own census report (the 2026-08-14 seed-42
+shadow-ON run documented above) against `diffpair_test_routed.kicad_pcb`:
+
 ```
-[crosstail-advisory] pre-route prediction from census.json, 3.2h old
+[crosstail-advisory] pre-route prediction from census.json, 8.0h old
 [crosstail-advisory]   prior run: 166 crossover(s), 150 saturated (90.4%), inert 94.6%, verdict=saturated
-[crosstail-advisory]   board cross-check: 18/18 report net(s) still on this board (100.0% coverage)
+[crosstail-advisory]   board cross-check: 9/9 report net(s) still on this board (100.0% coverage)
 [crosstail-advisory]   predicted this run: 150/166 saturated crossover(s) (90.4%)
-[crosstail-advisory]   worst nets: MIPI_D0- 12/12, MIPI_D0+ 12/12, USB_DP 11/12, …
-[crosstail-advisory]   reading: ordering levers are inert here -- the diff-pair shadow phase will
-                       spend its budget without a lever to pull; the constraint is upstream in
-                       placement / escape planning
+[crosstail-advisory]   worst nets: PCIE_TX- 86/88, MIPI_CLK- 22/24, USB3_TX1- 20/26, USB2_D+ 6/10, PCIE_RX- 5/7 (+4 more)
+[crosstail-advisory]   reading: ordering levers are inert here -- the diff-pair shadow phase will spend its budget without a lever to pull; the constraint is upstream in placement / escape planning
 [crosstail-advisory]   ADVISORY ONLY -- this route is unchanged by the above (#4799)
 ```
+
+The headline figures are the ones the census printed 28 minutes into the run
+that produced the report (150/166, 90.4%, `inert 94.6%`) — the point is
+entirely *when* they are on screen.
 
 This is a *replay*, not a placement-only predictor: it inherits the previous
 run's ordering, so its accuracy decays as the design moves. Two guards keep it
@@ -270,6 +275,27 @@ If the report cannot be written (unwritable path, read-only directory), the
 flush prints a diagnostic line to stderr and returns — it never raises, on the
 `_offboard_preflight` precedent that report-only surfaces must not block a
 route that already succeeded.
+
+### Cost of the advisory
+
+A leading indicator that costs what it is trying to avoid is not one, so this
+is the number the eventual go/no-go wiring will need. Measured on board-06's
+own 166-crossover report against `diffpair_test_routed.kicad_pcb`
+(2026-08-15, same machine as the run that produced the report):
+
+| Step | Wall clock |
+|------|-----------|
+| `LoadedCensusReport.from_path` (parse + rehydrate 166 records) | 0.0009 s |
+| `board_net_names` (parse the board, 26 nets) | 0.1468 s |
+| `build_advisory` (roll-up, cross-check, verdict) | 0.0008 s |
+| **Total preflight** | **0.149 s** |
+| the census this replays, inside the routing run | 1.27 s (`census_s_total`) |
+| the board-06 `--step route` run that produced it | ~1680 s (28 min) |
+
+So the prediction costs **~0.01% of the route it precedes** and ~12% of the
+in-route census it replays; the board parse dominates it, and everything else
+is noise. Its own copy of the census's cost is zero — the measurement already
+happened, in a previous process.
 
 ## API
 

--- a/src/kicad_tools/cli/commands/routing.py
+++ b/src/kicad_tools/cli/commands/routing.py
@@ -740,6 +740,12 @@ def run_route_command(args) -> int:
     # flag-off path stays byte-identical.
     if getattr(args, "allow_offboard", False):
         sub_argv.append("--allow-offboard")
+    # Issue #4799: forward the pre-route census advisory report path.  Defaults
+    # to None (the inner preflight then falls back to
+    # KCT_CROSSTAIL_CENSUS_ADVISORY); forward only when the user set it so the
+    # flag-off path stays byte-identical.
+    if getattr(args, "census_advisory", None):
+        sub_argv.extend(["--census-advisory", str(args.census_advisory)])
     if getattr(args, "auto_fix", False):
         sub_argv.append("--auto-fix")
     if getattr(args, "auto_fix_passes", None) is not None:

--- a/src/kicad_tools/cli/parser.py
+++ b/src/kicad_tools/cli/parser.py
@@ -4078,6 +4078,22 @@ def _add_route_parser(subparsers) -> None:
             "footprints)."
         ),
     )
+    # Issue #4799: pre-route crossing-tail census advisory.  Mirror of the
+    # inner route_cmd.py flag; both sites must stay in sync per
+    # ``tests/test_cli_parser_drift.py``.
+    route_parser.add_argument(
+        "--census-advisory",
+        metavar="PATH",
+        default=None,
+        help=(
+            "Path to a crossing-tail census report (written by "
+            "KCT_CROSSTAIL_CENSUS_REPORT) to replay as a pre-route prediction: "
+            "how saturated this board's diff-pair crossover lattice measured "
+            "last time, printed before routing starts. Advisory only -- never "
+            "changes routing or the exit code. Defaults to "
+            "$KCT_CROSSTAIL_CENSUS_ADVISORY when unset."
+        ),
+    )
     # Issue #4178: hard-gate on native (kicad-cli) DRC actually running.
     # Mirror of the inner route_cmd.py flag; both sites must stay in sync per
     # ``tests/test_cli_parser_drift.py``.

--- a/src/kicad_tools/cli/route_cmd.py
+++ b/src/kicad_tools/cli/route_cmd.py
@@ -10216,6 +10216,37 @@ def _offboard_preflight(pcb_path: Path) -> int:
     return 2
 
 
+def _census_advisory_preflight(pcb_path: Path, args) -> int:
+    """Replay a prior crossing-tail census as a pre-route prediction (#4799).
+
+    The census measures how much of a differential pair's 225-entry crossover
+    via-site lattice is legal at all, but it does so *during* routing and
+    reports at the end — so a board whose lattice is 90% saturated only learns
+    it after the shadow phase has already spent its budget.  Loading the
+    previous run's report here turns that post-mortem into a leading indicator:
+    same measurement, taken earlier.
+
+    **Always returns 0.**  Unlike ``_offboard_preflight`` this is advisory, not
+    a gate: a missing or stale report degrades to a printed diagnostic, never
+    to a refusal to route.  Wiring the prediction into an actual go/no-go
+    decision is deliberate follow-up work on #4799.
+    """
+    try:
+        from kicad_tools.router.crosstail_advisory import (
+            advisory_path_from_env,
+            emit_advisory,
+        )
+
+        report_path = getattr(args, "census_advisory", None) or advisory_path_from_env()
+        if report_path is None:
+            return 0
+        emit_advisory(report_path, pcb_path)
+    except Exception:
+        # An advisory that cannot run must never block routing (#4156 precedent).
+        pass
+    return 0
+
+
 def _apply_complete_mode_defaults(args, parser, argv: list[str] | None = None) -> None:
     """Apply the ``--complete`` mode implications (Issue #4471, epic #4465).
 
@@ -12104,6 +12135,22 @@ def _main_impl(argv: list[str] | None = None) -> int:
             "footprints)."
         ),
     )
+    # Issue #4799: replay a previous run's crossing-tail census as a pre-route
+    # prediction.  Strictly advisory -- it prints a block before any router work
+    # and never changes routing or the exit code.
+    parser.add_argument(
+        "--census-advisory",
+        metavar="PATH",
+        default=None,
+        help=(
+            "Path to a crossing-tail census report (written by "
+            "KCT_CROSSTAIL_CENSUS_REPORT) to replay as a pre-route prediction: "
+            "how saturated this board's diff-pair crossover lattice measured "
+            "last time, printed before routing starts. Advisory only -- never "
+            "changes routing or the exit code. Defaults to "
+            "$KCT_CROSSTAIL_CENSUS_ADVISORY when unset."
+        ),
+    )
     parser.add_argument(
         "--manufacturer",
         "--mfr",
@@ -13004,6 +13051,12 @@ def _main_impl(argv: list[str] | None = None) -> int:
         rc = _offboard_preflight(pcb_path)
         if rc != 0:
             return rc
+
+    # Issue #4799: advisory crossing-tail census replay.  Runs after the hard
+    # gates (there is no point predicting congestion for a board that is not
+    # going to route at all) and before any router/component loading, so the
+    # prediction is on screen ahead of the first A* expansion.
+    _census_advisory_preflight(pcb_path, args)
 
     # Issue #2996: Validate and load the optional --net-class-map sidecar
     # early -- before dispatching to any of the route_with_* sub-flows --

--- a/src/kicad_tools/router/crosstail_advisory.py
+++ b/src/kicad_tools/router/crosstail_advisory.py
@@ -334,10 +334,17 @@ class CrossingTailAdvisory:
                 f"{self.predicted_crossovers} saturated crossover(s) "
                 f"({self.predicted_saturated_pct}%)"
             )
-            worst = [n for n in self.nets if n.saturated > 0][:WORST_NETS_SHOWN]
+            # Only nets that actually contribute to the prediction are named:
+            # listing a net the board no longer has, next to a predicted count
+            # that deliberately excludes it, reads as an inconsistency.  The
+            # full per-net roll-up (absent nets included) stays in to_dict().
+            saturated_nets = [
+                n for n in self.nets if n.saturated > 0 and n.present_on_board is not False
+            ]
+            worst = saturated_nets[:WORST_NETS_SHOWN]
             if worst:
                 rendered = ", ".join(f"{n.net_name} {n.saturated}/{n.crossovers}" for n in worst)
-                elided = len([n for n in self.nets if n.saturated > 0]) - len(worst)
+                elided = len(saturated_nets) - len(worst)
                 suffix = f" (+{elided} more)" if elided > 0 else ""
                 lines.append(f"{tag}   worst nets: {rendered}{suffix}")
         for warning in self.warnings:

--- a/src/kicad_tools/router/crosstail_advisory.py
+++ b/src/kicad_tools/router/crosstail_advisory.py
@@ -1,0 +1,535 @@
+"""Pre-route consumption of a crossing-tail census report (issue #4799).
+
+Slice 1 (#4852, :mod:`kicad_tools.router.crosstail_census`) turned the #4580
+crossing-tail census into a structured JSON document.  That document is still a
+**post-mortem**: it is written at the end of the run that produced it, long
+after the router has already spent its shadow-construction budget.
+
+This module closes the loop and makes the census a **leading indicator**: a
+report written by run *N* is loaded and interpreted *before the first A\\*
+expansion* of run *N+1*, so the operator sees "this board's crossover lattice
+measured 90% saturated last time; ordering levers are inert" up front rather
+than 24 minutes in.
+
+Why a prior run, and not a placement-only computation
+-----------------------------------------------------
+
+The census's legality test is genuinely order-dependent -- it consults drills
+placed by *earlier crossovers in the same pass*, an escape-channel registry
+keyed on which nets are still unrouted, and the pair's own guide route -- so
+the measurement cannot simply be hoisted ahead of routing (see
+``docs/reference/crosstail-census-report.md``).  Replaying the *previous*
+measurement sidesteps that open design question entirely, the way
+profile-guided optimization sidesteps predicting a program's hot paths: the
+prediction is a measurement, just one taken earlier.
+
+Its accuracy therefore decays with staleness, which is why every advisory
+carries an explicit board cross-check (how many of the report's nets still
+exist on the board being routed) and refuses to look confident when the
+overlap is poor.
+
+**Advisory only.**  Nothing here changes routing, and nothing here can fail a
+run: :func:`emit_advisory` swallows every error into a stderr diagnostic, on
+the ``_offboard_preflight`` precedent that report-only surfaces must never
+block a route.  Wiring saturation into an actual go/no-go or steering decision
+remains deliberate follow-up work on #4799.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Iterable, Mapping, Sequence
+
+from kicad_tools.router.crosstail_census import (
+    SATURATED_PCT_ADVISORY_THRESHOLD,
+    SCHEMA_VERSION,
+    VERDICT_NO_ORDERING_LEVER,
+    VERDICT_SATURATED,
+    CrossingTailCensusRecord,
+    CrossingTailCensusSummary,
+)
+
+__all__ = [
+    "ADVISORY_ENV_VAR",
+    "STALE_COVERAGE_PCT_THRESHOLD",
+    "WORST_NETS_SHOWN",
+    "CensusReportError",
+    "CrossingTailAdvisory",
+    "LoadedCensusReport",
+    "NetPrediction",
+    "advisory_path_from_env",
+    "board_net_names",
+    "build_advisory",
+    "emit_advisory",
+]
+
+#: Fallback surface for callers that do not go through ``kct route`` -- board
+#: scripts drive the router API directly (``boards/06-diffpair-test``), and the
+#: capture side of this feature is already env-gated
+#: (``KCT_CROSSTAIL_CENSUS_REPORT``), so the replay side matches.
+ADVISORY_ENV_VAR = "KCT_CROSSTAIL_CENSUS_ADVISORY"
+
+#: Below this share of the report's nets still present on the board, the
+#: advisory declares itself **stale**: too little of what was measured is still
+#: here for the replay to predict anything.  50% is deliberately generous --
+#: a report from the same board with a handful of nets renamed stays usable,
+#: while a report from a *different* design (near-zero overlap) is rejected.
+STALE_COVERAGE_PCT_THRESHOLD = 50.0
+
+#: How many worst-offender nets the human block names before eliding.
+WORST_NETS_SHOWN = 5
+
+
+class CensusReportError(ValueError):
+    """A census report could not be read or is not a census report.
+
+    Raised by the loader so callers that *want* to fail loudly (tests, future
+    tooling) can.  :func:`emit_advisory` catches it -- the preflight never
+    blocks a route because a diagnostic file was missing or malformed.
+    """
+
+
+def _as_float(value: Any, default: float = 0.0) -> float:
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _as_int(value: Any, default: int = 0) -> int:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _as_xy(value: Any) -> tuple[float, float]:
+    if isinstance(value, (list, tuple)) and len(value) >= 2:
+        return (_as_float(value[0]), _as_float(value[1]))
+    return (0.0, 0.0)
+
+
+@dataclass(frozen=True)
+class LoadedCensusReport:
+    """A parsed ``crosstail-census`` document (schema v1).
+
+    The per-crossover entries are rehydrated into the very
+    :class:`CrossingTailCensusRecord` type that wrote them, so the advisory can
+    re-aggregate them through :meth:`CrossingTailCensusSummary.from_records` --
+    the same code path slice 1 used -- instead of trusting (or duplicating) the
+    stored summary block.
+    """
+
+    path: Path | None
+    schema_version: int
+    generated_at: str | None
+    census_enabled: bool
+    records: tuple[CrossingTailCensusRecord, ...]
+    stored_summary: Mapping[str, Any]
+
+    @classmethod
+    def from_payload(cls, payload: Any, *, path: Path | None = None) -> LoadedCensusReport:
+        """Validate and rehydrate an already-decoded JSON document."""
+        if not isinstance(payload, Mapping):
+            raise CensusReportError(f"census report {path or '<payload>'} is not a JSON object")
+        report_kind = payload.get("report")
+        if report_kind != "crosstail-census":
+            raise CensusReportError(
+                f"census report {path or '<payload>'} has report={report_kind!r}, "
+                "expected 'crosstail-census'"
+            )
+        crossovers = payload.get("crossovers", [])
+        if not isinstance(crossovers, Sequence) or isinstance(crossovers, (str, bytes)):
+            raise CensusReportError(
+                f"census report {path or '<payload>'} has a non-list 'crossovers'"
+            )
+        records = tuple(
+            CrossingTailCensusRecord(
+                net_name=str(entry.get("net_name", "")),
+                head=_as_xy(entry.get("head")),
+                goal=_as_xy(entry.get("goal")),
+                legal=_as_int(entry.get("legal")),
+                total=_as_int(entry.get("total")),
+                distinct_v1=_as_int(entry.get("distinct_v1")),
+                census_s=_as_float(entry.get("census_s")),
+            )
+            for entry in crossovers
+            if isinstance(entry, Mapping)
+        )
+        stored = payload.get("summary")
+        return cls(
+            path=path,
+            schema_version=_as_int(payload.get("schema_version"), SCHEMA_VERSION),
+            generated_at=(str(payload["generated_at"]) if payload.get("generated_at") else None),
+            census_enabled=bool(payload.get("census_enabled", False)),
+            records=records,
+            stored_summary=dict(stored) if isinstance(stored, Mapping) else {},
+        )
+
+    @classmethod
+    def from_path(cls, path: Path | str) -> LoadedCensusReport:
+        target = Path(path)
+        try:
+            raw = target.read_text()
+        except OSError as exc:
+            raise CensusReportError(f"cannot read census report {target}: {exc}") from exc
+        try:
+            payload = json.loads(raw)
+        except ValueError as exc:
+            raise CensusReportError(f"census report {target} is not valid JSON: {exc}") from exc
+        return cls.from_payload(payload, path=target)
+
+    def age_seconds(self, *, now: datetime | None = None) -> float | None:
+        """Seconds between ``generated_at`` and *now*, or ``None`` if unknown.
+
+        Negative ages (a report stamped in the future -- clock skew across
+        machines) are clamped to 0 rather than reported as a negative age.
+        """
+        if not self.generated_at:
+            return None
+        try:
+            stamped = datetime.fromisoformat(self.generated_at)
+        except ValueError:
+            return None
+        if stamped.tzinfo is None:
+            stamped = stamped.replace(tzinfo=timezone.utc)
+        current = now or datetime.now(timezone.utc)
+        if current.tzinfo is None:
+            current = current.replace(tzinfo=timezone.utc)
+        return max(0.0, (current - stamped).total_seconds())
+
+
+@dataclass(frozen=True)
+class NetPrediction:
+    """Per-net roll-up of a report's crossovers -- the prediction's unit.
+
+    ``present_on_board`` is ``None`` when the caller could not enumerate the
+    board's nets (no PCB path, unparseable file); it is *not* a synonym for
+    ``False``, which would silently drop every net from the prediction.
+    """
+
+    net_name: str
+    crossovers: int
+    saturated: int
+    no_ordering_lever: int
+    present_on_board: bool | None = None
+
+    @property
+    def inert(self) -> int:
+        """Crossovers where no ordering key could have changed the outcome."""
+        return self.saturated + self.no_ordering_lever
+
+    @property
+    def saturated_pct(self) -> float:
+        if self.crossovers <= 0:
+            return 0.0
+        return round(100.0 * self.saturated / self.crossovers, 1)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "net_name": self.net_name,
+            "crossovers": self.crossovers,
+            "saturated": self.saturated,
+            "saturated_pct": self.saturated_pct,
+            "no_ordering_lever": self.no_ordering_lever,
+            "inert": self.inert,
+            "present_on_board": self.present_on_board,
+        }
+
+
+@dataclass(frozen=True)
+class CrossingTailAdvisory:
+    """What a prior census report predicts about the route about to start."""
+
+    source: str
+    generated_at: str | None
+    age_seconds: float | None
+    census_enabled: bool
+    summary: CrossingTailCensusSummary
+    nets: tuple[NetPrediction, ...]
+    board_nets_known: bool
+    nets_in_report: int
+    nets_on_board: int
+    coverage_pct: float
+    predicted_crossovers: int
+    predicted_saturated: int
+    stale: bool
+    warnings: tuple[str, ...] = ()
+
+    @property
+    def applicable(self) -> bool:
+        """Is there a prediction at all?
+
+        ``False`` when the report measured nothing (``not-applicable``: boards
+        05 and 07 today) or when the board cross-check rejected it as stale.
+        Kept distinct from "predicts 0% saturation", which would read as a
+        clean bill of health for a board nobody measured.
+        """
+        return self.summary.applicable and not self.stale
+
+    @property
+    def predicted_saturated_pct(self) -> float:
+        if self.predicted_crossovers <= 0:
+            return 0.0
+        return round(100.0 * self.predicted_saturated / self.predicted_crossovers, 1)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "advisory": "crosstail-census",
+            "schema_version": SCHEMA_VERSION,
+            "source": self.source,
+            "generated_at": self.generated_at,
+            "age_seconds": (None if self.age_seconds is None else round(self.age_seconds, 3)),
+            "census_enabled": self.census_enabled,
+            "applicable": self.applicable,
+            "stale": self.stale,
+            "board_nets_known": self.board_nets_known,
+            "nets_in_report": self.nets_in_report,
+            "nets_on_board": self.nets_on_board,
+            "coverage_pct": self.coverage_pct,
+            "predicted_crossovers": self.predicted_crossovers,
+            "predicted_saturated": self.predicted_saturated,
+            "predicted_saturated_pct": self.predicted_saturated_pct,
+            "prior_summary": self.summary.to_dict(),
+            "nets": [n.to_dict() for n in self.nets],
+            "warnings": list(self.warnings),
+        }
+
+    def format_human(self) -> str:
+        """Greppable ``[crosstail-advisory]`` block, printed before routing."""
+        tag = "[crosstail-advisory]"
+        age = ""
+        if self.age_seconds is not None:
+            age = f", {_format_age(self.age_seconds)} old"
+        lines = [f"{tag} pre-route prediction from {self.source}{age}"]
+        s = self.summary
+        if not s.applicable:
+            lines.append(
+                f"{tag}   prior run scanned 0 crossover(s) -- NOT APPLICABLE, "
+                f"no prediction (this is not a 0%-saturated result)"
+            )
+        else:
+            lines.append(
+                f"{tag}   prior run: {s.crossovers_scanned} crossover(s), "
+                f"{s.saturated} saturated ({s.saturated_pct}%), "
+                f"inert {s.inert_pct}%, verdict={s.verdict}"
+            )
+            if self.board_nets_known:
+                lines.append(
+                    f"{tag}   board cross-check: {self.nets_on_board}/"
+                    f"{self.nets_in_report} report net(s) still on this board "
+                    f"({self.coverage_pct}% coverage)"
+                )
+            else:
+                lines.append(
+                    f"{tag}   board cross-check: skipped (board nets unavailable); "
+                    f"predicting from all {self.nets_in_report} report net(s)"
+                )
+            lines.append(
+                f"{tag}   predicted this run: {self.predicted_saturated}/"
+                f"{self.predicted_crossovers} saturated crossover(s) "
+                f"({self.predicted_saturated_pct}%)"
+            )
+            worst = [n for n in self.nets if n.saturated > 0][:WORST_NETS_SHOWN]
+            if worst:
+                rendered = ", ".join(f"{n.net_name} {n.saturated}/{n.crossovers}" for n in worst)
+                elided = len([n for n in self.nets if n.saturated > 0]) - len(worst)
+                suffix = f" (+{elided} more)" if elided > 0 else ""
+                lines.append(f"{tag}   worst nets: {rendered}{suffix}")
+        for warning in self.warnings:
+            lines.append(f"{tag}   WARNING: {warning}")
+        if self.applicable and s.verdict in (VERDICT_SATURATED, VERDICT_NO_ORDERING_LEVER):
+            lines.append(
+                f"{tag}   reading: ordering levers are inert here -- the "
+                f"diff-pair shadow phase will spend its budget without a lever "
+                f"to pull; the constraint is upstream in placement / escape planning"
+            )
+        lines.append(f"{tag}   ADVISORY ONLY -- this route is unchanged by the above (#4799)")
+        return "\n".join(lines)
+
+
+def _format_age(seconds: float) -> str:
+    if seconds < 90:
+        return f"{seconds:.0f}s"
+    if seconds < 5400:
+        return f"{seconds / 60:.0f}m"
+    if seconds < 172800:
+        return f"{seconds / 3600:.1f}h"
+    return f"{seconds / 86400:.1f}d"
+
+
+def _pct(numerator: int, denominator: int) -> float:
+    if denominator <= 0:
+        return 0.0
+    return round(100.0 * numerator / denominator, 1)
+
+
+def build_advisory(
+    report: LoadedCensusReport,
+    board_nets: Iterable[str] | None = None,
+    *,
+    saturated_threshold_pct: float = SATURATED_PCT_ADVISORY_THRESHOLD,
+    stale_coverage_pct: float = STALE_COVERAGE_PCT_THRESHOLD,
+    now: datetime | None = None,
+) -> CrossingTailAdvisory:
+    """Interpret *report* as a prediction for a route about to start.
+
+    *board_nets* is the net-name set of the board being routed.  When given,
+    only the report's nets that still exist there contribute to the predicted
+    counts, and their overlap decides staleness; when ``None`` (unknown, not
+    empty) the whole report contributes and the block says so.
+    """
+    known_nets: set[str] | None = None if board_nets is None else set(board_nets)
+    summary = CrossingTailCensusSummary.from_records(
+        report.records, saturated_threshold_pct=saturated_threshold_pct
+    )
+
+    per_net: dict[str, list[int]] = {}
+    for record in report.records:
+        bucket = per_net.setdefault(record.net_name, [0, 0, 0])
+        bucket[0] += 1
+        bucket[1] += 1 if record.saturated else 0
+        bucket[2] += 1 if record.no_ordering_lever else 0
+
+    predictions = [
+        NetPrediction(
+            net_name=name,
+            crossovers=counts[0],
+            saturated=counts[1],
+            no_ordering_lever=counts[2],
+            present_on_board=None if known_nets is None else name in known_nets,
+        )
+        for name, counts in per_net.items()
+    ]
+    # Worst first, then alphabetical: the head of this list is what the human
+    # block names, and a tie must not depend on dict insertion order.
+    predictions.sort(key=lambda n: (-n.saturated, -n.crossovers, n.net_name))
+
+    contributing = [n for n in predictions if n.present_on_board is not False]
+    predicted_crossovers = sum(n.crossovers for n in contributing)
+    predicted_saturated = sum(n.saturated for n in contributing)
+
+    nets_in_report = len(predictions)
+    nets_on_board = (
+        nets_in_report if known_nets is None else sum(1 for n in predictions if n.present_on_board)
+    )
+    coverage_pct = _pct(nets_on_board, nets_in_report)
+
+    warnings: list[str] = []
+    if report.schema_version != SCHEMA_VERSION:
+        warnings.append(
+            f"report schema_version={report.schema_version} but this build "
+            f"reads v{SCHEMA_VERSION}; fields may be missing"
+        )
+    if not report.census_enabled:
+        warnings.append(
+            "report was written with the census disabled "
+            "(KCT_CROSSTAIL_CENSUS unset) -- nothing was measured"
+        )
+    stored_scanned = report.stored_summary.get("crossovers_scanned")
+    if stored_scanned is not None and _as_int(stored_scanned, -1) != summary.crossovers_scanned:
+        warnings.append(
+            f"report's stored summary claims {stored_scanned} crossover(s) but "
+            f"{summary.crossovers_scanned} record(s) are present; re-aggregated "
+            "from the records"
+        )
+
+    stale = False
+    if known_nets is not None and nets_in_report > 0 and coverage_pct < stale_coverage_pct:
+        stale = True
+        warnings.append(
+            f"only {coverage_pct}% of the report's nets exist on this board "
+            f"(< {stale_coverage_pct}%); the report was probably measured on a "
+            "different design -- prediction suppressed"
+        )
+
+    return CrossingTailAdvisory(
+        source=str(report.path) if report.path else "<payload>",
+        generated_at=report.generated_at,
+        age_seconds=report.age_seconds(now=now),
+        census_enabled=report.census_enabled,
+        summary=summary,
+        nets=tuple(predictions),
+        board_nets_known=known_nets is not None,
+        nets_in_report=nets_in_report,
+        nets_on_board=nets_on_board,
+        coverage_pct=coverage_pct,
+        predicted_crossovers=predicted_crossovers,
+        predicted_saturated=predicted_saturated,
+        stale=stale,
+        warnings=tuple(warnings),
+    )
+
+
+def advisory_path_from_env(env: Mapping[str, str] | None = None) -> Path | None:
+    """Path from :data:`ADVISORY_ENV_VAR`, or ``None`` when unset/blank."""
+    raw = (env if env is not None else os.environ).get(ADVISORY_ENV_VAR, "")
+    raw = raw.strip()
+    return Path(raw) if raw else None
+
+
+def board_net_names(pcb_path: Path | str) -> set[str] | None:
+    """Net names declared by *pcb_path*, or ``None`` when they cannot be read.
+
+    ``None`` means *unknown* and switches the cross-check off; it is returned
+    for a missing file, an unparseable one, and for a board that declares no
+    nets at all -- the last because an empty set is indistinguishable from a
+    failed parse here, and taking it literally would mark every net in the
+    report "absent" and wrongly condemn the report as stale.
+
+    Net 0 (the empty name) is dropped: it is the unconnected sentinel, never a
+    crossover's net.
+    """
+    try:
+        target = Path(pcb_path)
+        if not target.is_file():
+            return None
+        from kicad_tools.pcb.editor import PCBEditor
+
+        editor = PCBEditor(str(target))
+        names = {str(name) for name in editor.nets if str(name)}
+    except Exception:
+        return None
+    return names or None
+
+
+def emit_advisory(
+    report_path: Path | str,
+    pcb_path: Path | str | None = None,
+    *,
+    stream: Any = None,
+    saturated_threshold_pct: float = SATURATED_PCT_ADVISORY_THRESHOLD,
+) -> CrossingTailAdvisory | None:
+    """Print the pre-route advisory for *report_path*.  Never raises.
+
+    Returns the advisory, or ``None`` when the report could not be read (a
+    one-line diagnostic goes to *stream*).  A missing or malformed report is a
+    missing diagnostic, not a reason to refuse to route -- the
+    ``_offboard_preflight`` precedent.
+    """
+    import sys
+
+    out = stream if stream is not None else sys.stderr
+    try:
+        report = LoadedCensusReport.from_path(report_path)
+    except CensusReportError as exc:
+        print(f"[crosstail-advisory] no prediction: {exc}", file=out)
+        return None
+    except Exception as exc:  # pragma: no cover - defensive, see docstring
+        print(
+            f"[crosstail-advisory] no prediction from {report_path}: {exc}",
+            file=out,
+        )
+        return None
+    board_nets = board_net_names(pcb_path) if pcb_path is not None else None
+    advisory = build_advisory(
+        report,
+        board_nets,
+        saturated_threshold_pct=saturated_threshold_pct,
+    )
+    print(advisory.format_human(), file=out)
+    return advisory

--- a/src/kicad_tools/router/crosstail_advisory.py
+++ b/src/kicad_tools/router/crosstail_advisory.py
@@ -329,6 +329,16 @@ class CrossingTailAdvisory:
                     f"{tag}   board cross-check: skipped (board nets unavailable); "
                     f"predicting from all {self.nets_in_report} report net(s)"
                 )
+        if s.applicable and self.stale:
+            # A block that says "suppressed" and then prints the numbers has
+            # not suppressed anything -- a reader is entitled to use whatever
+            # is on screen.  The rejected counts stay in to_dict() for tooling
+            # that wants to inspect what was thrown away.
+            lines.append(
+                f"{tag}   prediction SUPPRESSED -- this report does not "
+                f"describe the board being routed (see WARNING below)"
+            )
+        elif s.applicable:
             lines.append(
                 f"{tag}   predicted this run: {self.predicted_saturated}/"
                 f"{self.predicted_crossovers} saturated crossover(s) "

--- a/tests/router/test_crosstail_advisory_4799.py
+++ b/tests/router/test_crosstail_advisory_4799.py
@@ -382,6 +382,18 @@ def test_human_block_elides_beyond_the_worst_offenders():
     assert "(+3 more)" in line
 
 
+def test_human_block_names_only_nets_that_feed_the_prediction():
+    """A net excluded from the counts must not headline the "worst" line."""
+    report = _report_from([_record("HERE", legal=0), _record("GONE", legal=0)])
+    advisory = build_advisory(report, {"HERE"})
+
+    line = next(ln for ln in advisory.format_human().splitlines() if "worst nets" in ln)
+    assert "HERE 1/1" in line
+    assert "GONE" not in line
+    # ...but the full roll-up, absent nets included, survives in the dict form.
+    assert {n["net_name"] for n in advisory.to_dict()["nets"]} == {"HERE", "GONE"}
+
+
 def test_saturated_prediction_states_the_upstream_reading():
     report = _report_from([_record(f"N{i}", legal=0) for i in range(10)])
     text = build_advisory(report).format_human()
@@ -555,3 +567,42 @@ def test_route_help_documents_the_flag(capsys):
     out = capsys.readouterr().out
     assert "--census-advisory" in out
     assert "Advisory only" in out
+
+
+def test_outer_kct_parser_accepts_and_forwards_the_flag():
+    """`kct route` parses with the OUTER parser and shells the inner one.
+
+    Adding the flag to route_cmd.py alone leaves `kct route --census-advisory`
+    dying with "unrecognized arguments" -- which is exactly what happened
+    before this test existed.
+    """
+    from kicad_tools.cli import route_cmd
+    from kicad_tools.cli.commands import routing
+    from kicad_tools.cli.parser import create_parser
+
+    captured: list[list[str]] = []
+
+    def _fake_route_main(argv):
+        captured.append(list(argv))
+        return 0
+
+    original = route_cmd.main
+    route_cmd.main = _fake_route_main  # imported inside run_route_command
+    try:
+        args = create_parser().parse_args(
+            ["route", "board.kicad_pcb", "--census-advisory", "census.json"]
+        )
+        assert args.census_advisory == "census.json"
+        assert routing.run_route_command(args) == 0
+
+        # Unset stays unset: the flag-off path must be byte-identical.
+        plain = create_parser().parse_args(["route", "board.kicad_pcb"])
+        assert plain.census_advisory is None
+        assert routing.run_route_command(plain) == 0
+    finally:
+        route_cmd.main = original
+
+    with_flag, without_flag = captured
+    assert "--census-advisory" in with_flag
+    assert with_flag[with_flag.index("--census-advisory") + 1] == "census.json"
+    assert "--census-advisory" not in without_flag

--- a/tests/router/test_crosstail_advisory_4799.py
+++ b/tests/router/test_crosstail_advisory_4799.py
@@ -265,7 +265,15 @@ def test_a_report_from_a_different_board_is_declared_stale():
     assert advisory.summary.applicable is True
     assert advisory.applicable is False
     assert any("different design" in w for w in advisory.warnings)
-    assert "WARNING" in advisory.format_human()
+    text = advisory.format_human()
+    assert "WARNING" in text
+    # "Suppressed" has to mean it: no predicted counts on screen for a report
+    # that was just rejected, or a reader will use them anyway.
+    assert "prediction SUPPRESSED" in text
+    assert "predicted this run" not in text
+    assert "worst nets" not in text
+    # ...while the rejected numbers stay available to tooling.
+    assert advisory.to_dict()["predicted_saturated"] == 1
 
 
 def test_coverage_exactly_at_the_threshold_is_not_stale():

--- a/tests/router/test_crosstail_advisory_4799.py
+++ b/tests/router/test_crosstail_advisory_4799.py
@@ -1,0 +1,557 @@
+"""Issue #4799: replaying a crossing-tail census report as a pre-route prediction.
+
+Slice 1 (#4852) wrote the census out as JSON at the *end* of a run.  This
+module pins the consumption side -- the part that makes the census a leading
+indicator rather than a post-mortem:
+
+1. The loader round-trips exactly what ``crosstail_census.write_report`` wrote,
+   and rejects (loudly) anything that is not a census report.
+2. The per-net prediction: which nets carried the saturated crossovers, worst
+   first, deterministically ordered.
+3. The board cross-check: a report's nets that no longer exist on the board
+   being routed do not contribute to the prediction, and a report whose nets
+   barely overlap is declared **stale** instead of predicting confidently from
+   a different design's measurement.
+4. "Not applicable" (nothing was ever scanned) stays distinct from "0%
+   saturated" -- the same distinction slice 1 drew, carried through the replay.
+5. Advisory ONLY: the preflight returns 0 for a missing, malformed, empty and
+   valid report alike, and never raises.
+
+No board fixture and no routing: every test drives fabricated records, so this
+file runs in milliseconds -- which is also the point of the feature (a leading
+indicator that costs what the route costs is not one).
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
+
+import pytest
+
+from kicad_tools.router.crosstail_advisory import (
+    ADVISORY_ENV_VAR,
+    STALE_COVERAGE_PCT_THRESHOLD,
+    WORST_NETS_SHOWN,
+    CensusReportError,
+    CrossingTailAdvisory,
+    LoadedCensusReport,
+    NetPrediction,
+    advisory_path_from_env,
+    board_net_names,
+    build_advisory,
+    emit_advisory,
+)
+from kicad_tools.router.crosstail_census import (
+    SCHEMA_VERSION,
+    VERDICT_NOT_APPLICABLE,
+    VERDICT_ORDERING_LEVERS,
+    VERDICT_SATURATED,
+    CrossingTailCensusCollector,
+    CrossingTailCensusRecord,
+    write_report,
+)
+
+# --------------------------------------------------------------------------
+# helpers
+# --------------------------------------------------------------------------
+
+
+def _record(net: str, legal: int, distinct_v1: int = 1, census_s: float = 0.01):
+    return CrossingTailCensusRecord(
+        net_name=net,
+        head=(1.0, 2.0),
+        goal=(3.0, 4.0),
+        legal=legal,
+        total=225,
+        distinct_v1=distinct_v1,
+        census_s=census_s,
+    )
+
+
+def _report_from(records, *, path=None, census_enabled: bool = True):
+    """Build a LoadedCensusReport the way a real report would deserialize."""
+    collector = CrossingTailCensusCollector()
+    for record in records:
+        collector.add(record)
+    payload = collector.to_report_dict(census_enabled=census_enabled)
+    return LoadedCensusReport.from_payload(payload, path=path)
+
+
+# --------------------------------------------------------------------------
+# 1. loader
+# --------------------------------------------------------------------------
+
+
+def test_loader_round_trips_the_slice_one_writer(tmp_path):
+    """What write_report() writes is exactly what the advisory reads back."""
+    collector = CrossingTailCensusCollector()
+    originals = [
+        _record("MIPI_CLK-", legal=0),
+        _record("MIPI_CLK+", legal=3, distinct_v1=2, census_s=0.02),
+    ]
+    for record in originals:
+        collector.add(record)
+    target = write_report(tmp_path / "census.json", collector, census_enabled=True)
+
+    loaded = LoadedCensusReport.from_path(target)
+
+    assert loaded.schema_version == SCHEMA_VERSION
+    assert loaded.census_enabled is True
+    assert loaded.generated_at is not None
+    assert loaded.records == tuple(originals)
+    # The stored summary is retained for cross-checking, not trusted blindly.
+    assert loaded.stored_summary["crossovers_scanned"] == 2
+
+
+def test_loader_rejects_a_file_that_is_not_a_census_report(tmp_path):
+    other = tmp_path / "other.json"
+    other.write_text(json.dumps({"report": "offboard", "summary": {}}))
+    with pytest.raises(CensusReportError, match="expected 'crosstail-census'"):
+        LoadedCensusReport.from_path(other)
+
+
+def test_loader_rejects_malformed_json(tmp_path):
+    broken = tmp_path / "broken.json"
+    broken.write_text("{not json")
+    with pytest.raises(CensusReportError, match="not valid JSON"):
+        LoadedCensusReport.from_path(broken)
+
+
+def test_loader_rejects_a_missing_file(tmp_path):
+    with pytest.raises(CensusReportError, match="cannot read"):
+        LoadedCensusReport.from_path(tmp_path / "nope.json")
+
+
+def test_loader_rejects_a_non_object_document(tmp_path):
+    listy = tmp_path / "list.json"
+    listy.write_text("[1, 2, 3]")
+    with pytest.raises(CensusReportError, match="not a JSON object"):
+        LoadedCensusReport.from_path(listy)
+
+
+def test_loader_rejects_a_non_list_crossovers_block():
+    with pytest.raises(CensusReportError, match="non-list 'crossovers'"):
+        LoadedCensusReport.from_payload({"report": "crosstail-census", "crossovers": {"net": 1}})
+
+
+def test_loader_tolerates_missing_and_junk_fields():
+    """A truncated record must degrade to zeros, not explode mid-preflight."""
+    loaded = LoadedCensusReport.from_payload(
+        {
+            "report": "crosstail-census",
+            "crossovers": [
+                {"net_name": "N1"},
+                {"net_name": "N2", "legal": "seven", "head": "nope", "census_s": None},
+                "not-a-mapping",
+            ],
+        }
+    )
+    assert [r.net_name for r in loaded.records] == ["N1", "N2"]
+    assert loaded.records[0].legal == 0
+    assert loaded.records[1].legal == 0
+    assert loaded.records[1].head == (0.0, 0.0)
+    assert loaded.records[1].census_s == 0.0
+
+
+# --------------------------------------------------------------------------
+# 2. per-net prediction
+# --------------------------------------------------------------------------
+
+
+def test_per_net_rollup_counts_and_orders_worst_first():
+    report = _report_from(
+        [
+            _record("QUIET", legal=9, distinct_v1=4),
+            _record("BAD", legal=0),
+            _record("BAD", legal=0),
+            _record("BAD", legal=0),
+            _record("MEH", legal=0),
+            _record("MEH", legal=2, distinct_v1=1),
+        ]
+    )
+    advisory = build_advisory(report)
+
+    assert [n.net_name for n in advisory.nets] == ["BAD", "MEH", "QUIET"]
+    bad, meh, quiet = advisory.nets
+    assert (bad.crossovers, bad.saturated, bad.saturated_pct) == (3, 3, 100.0)
+    assert (meh.crossovers, meh.saturated, meh.no_ordering_lever) == (2, 1, 1)
+    assert meh.inert == 2
+    assert (quiet.saturated, quiet.no_ordering_lever, quiet.inert) == (0, 0, 0)
+    assert quiet.saturated_pct == 0.0
+
+
+def test_net_ordering_ties_break_alphabetically_not_by_insertion():
+    report = _report_from([_record("ZZZ", legal=0), _record("AAA", legal=0)])
+    assert [n.net_name for n in build_advisory(report).nets] == ["AAA", "ZZZ"]
+
+
+def test_prediction_totals_match_the_re_aggregated_summary():
+    records = [_record("A", legal=0), _record("A", legal=0), _record("B", legal=5, distinct_v1=3)]
+    advisory = build_advisory(_report_from(records))
+
+    assert advisory.summary.crossovers_scanned == 3
+    assert advisory.summary.saturated == 2
+    assert advisory.predicted_crossovers == 3
+    assert advisory.predicted_saturated == 2
+    assert advisory.predicted_saturated_pct == 66.7
+
+
+def test_saturated_report_carries_the_saturated_verdict_forward():
+    records = [_record(f"N{i}", legal=0) for i in range(19)] + [
+        _record("OK", legal=4, distinct_v1=3)
+    ]
+    advisory = build_advisory(_report_from(records))
+    assert advisory.summary.verdict == VERDICT_SATURATED
+    assert advisory.applicable is True
+
+
+def test_open_lattice_reports_ordering_levers_available():
+    records = [_record(f"N{i}", legal=100, distinct_v1=10) for i in range(10)]
+    advisory = build_advisory(_report_from(records))
+    assert advisory.summary.verdict == VERDICT_ORDERING_LEVERS
+    assert advisory.predicted_saturated == 0
+    assert "reading:" not in advisory.format_human()
+
+
+# --------------------------------------------------------------------------
+# 3. board cross-check / staleness
+# --------------------------------------------------------------------------
+
+
+def test_nets_absent_from_the_board_do_not_contribute_to_the_prediction():
+    report = _report_from(
+        [
+            _record("STILL_HERE", legal=0),
+            _record("STILL_HERE", legal=0),
+            _record("DELETED", legal=0),
+            _record("ALSO_HERE", legal=6, distinct_v1=3),
+        ]
+    )
+    advisory = build_advisory(report, {"STILL_HERE", "ALSO_HERE", "UNRELATED"})
+
+    assert advisory.board_nets_known is True
+    assert (advisory.nets_in_report, advisory.nets_on_board) == (3, 2)
+    assert advisory.coverage_pct == 66.7
+    # DELETED's saturated crossover is excluded; STILL_HERE's two are not.
+    assert advisory.predicted_crossovers == 3
+    assert advisory.predicted_saturated == 2
+    assert advisory.stale is False
+    assert {n.net_name: n.present_on_board for n in advisory.nets} == {
+        "STILL_HERE": True,
+        "DELETED": False,
+        "ALSO_HERE": True,
+    }
+
+
+def test_unknown_board_nets_keep_every_record_and_say_so():
+    report = _report_from([_record("A", legal=0), _record("B", legal=0)])
+    advisory = build_advisory(report, None)
+
+    assert advisory.board_nets_known is False
+    assert advisory.predicted_crossovers == 2
+    assert all(n.present_on_board is None for n in advisory.nets)
+    assert "board cross-check: skipped" in advisory.format_human()
+
+
+def test_a_report_from_a_different_board_is_declared_stale():
+    report = _report_from([_record(f"OLD{i}", legal=0) for i in range(4)])
+    advisory = build_advisory(report, {"OLD0", "SOMETHING_ELSE"})
+
+    assert advisory.coverage_pct == 25.0
+    assert advisory.stale is True
+    # Stale means "no prediction", even though the prior run did measure.
+    assert advisory.summary.applicable is True
+    assert advisory.applicable is False
+    assert any("different design" in w for w in advisory.warnings)
+    assert "WARNING" in advisory.format_human()
+
+
+def test_coverage_exactly_at_the_threshold_is_not_stale():
+    report = _report_from([_record("A", legal=0), _record("B", legal=0)])
+    advisory = build_advisory(report, {"A"})
+    assert advisory.coverage_pct == 50.0 == STALE_COVERAGE_PCT_THRESHOLD
+    assert advisory.stale is False
+
+
+def test_staleness_threshold_is_tunable():
+    report = _report_from([_record("A", legal=0), _record("B", legal=0)])
+    assert build_advisory(report, {"A"}, stale_coverage_pct=80.0).stale is True
+
+
+# --------------------------------------------------------------------------
+# 4. not-applicable and other honesty guards
+# --------------------------------------------------------------------------
+
+
+def test_an_empty_report_predicts_nothing_rather_than_zero_percent():
+    advisory = build_advisory(_report_from([]))
+
+    assert advisory.summary.verdict == VERDICT_NOT_APPLICABLE
+    assert advisory.applicable is False
+    assert advisory.predicted_crossovers == 0
+    text = advisory.format_human()
+    assert "NOT APPLICABLE" in text
+    assert "not a 0%-saturated result" in text
+    # An empty report must not be dressed up as a healthy board.
+    assert "verdict=ordering-levers-available" not in text
+
+
+def test_a_census_disabled_report_warns_that_nothing_was_measured():
+    advisory = build_advisory(_report_from([], census_enabled=False))
+    assert any("census disabled" in w for w in advisory.warnings)
+
+
+def test_a_schema_version_mismatch_warns_instead_of_failing():
+    advisory = build_advisory(
+        LoadedCensusReport.from_payload(
+            {
+                "report": "crosstail-census",
+                "schema_version": SCHEMA_VERSION + 7,
+                "census_enabled": True,
+                "crossovers": [{"net_name": "A", "legal": 0, "total": 225}],
+            }
+        )
+    )
+    assert any("schema_version" in w for w in advisory.warnings)
+    assert advisory.applicable is True
+
+
+def test_a_summary_that_disagrees_with_its_records_warns_and_re_aggregates():
+    advisory = build_advisory(
+        LoadedCensusReport.from_payload(
+            {
+                "report": "crosstail-census",
+                "schema_version": SCHEMA_VERSION,
+                "census_enabled": True,
+                "summary": {"crossovers_scanned": 999, "saturated": 999},
+                "crossovers": [{"net_name": "A", "legal": 0, "total": 225}],
+            }
+        )
+    )
+    assert advisory.summary.crossovers_scanned == 1
+    assert any("stored summary claims 999" in w for w in advisory.warnings)
+
+
+def test_report_age_is_reported_and_clock_skew_is_clamped():
+    now = datetime(2026, 8, 14, 12, 0, tzinfo=timezone.utc)
+    past = LoadedCensusReport.from_payload(
+        {
+            "report": "crosstail-census",
+            "generated_at": (now - timedelta(hours=3)).isoformat(),
+            "crossovers": [],
+        }
+    )
+    assert past.age_seconds(now=now) == pytest.approx(10800.0)
+
+    future = LoadedCensusReport.from_payload(
+        {
+            "report": "crosstail-census",
+            "generated_at": (now + timedelta(hours=3)).isoformat(),
+            "crossovers": [],
+        }
+    )
+    assert future.age_seconds(now=now) == 0.0
+
+    unstamped = LoadedCensusReport.from_payload(
+        {"report": "crosstail-census", "generated_at": "not-a-date", "crossovers": []}
+    )
+    assert unstamped.age_seconds(now=now) is None
+
+
+# --------------------------------------------------------------------------
+# 5. human block / dict shape
+# --------------------------------------------------------------------------
+
+
+def test_human_block_is_uniformly_tagged_and_marked_advisory():
+    report = _report_from([_record("A", legal=0), _record("B", legal=1)])
+    text = build_advisory(report, {"A", "B"}).format_human()
+    assert all(line.startswith("[crosstail-advisory]") for line in text.splitlines())
+    assert "ADVISORY ONLY" in text
+    assert "#4799" in text
+
+
+def test_human_block_elides_beyond_the_worst_offenders():
+    report = _report_from([_record(f"NET{i:02d}", legal=0) for i in range(WORST_NETS_SHOWN + 3)])
+    line = next(
+        ln for ln in build_advisory(report).format_human().splitlines() if "worst nets" in ln
+    )
+    assert line.count("/1") == WORST_NETS_SHOWN
+    assert "(+3 more)" in line
+
+
+def test_saturated_prediction_states_the_upstream_reading():
+    report = _report_from([_record(f"N{i}", legal=0) for i in range(10)])
+    text = build_advisory(report).format_human()
+    assert "ordering levers are inert" in text
+    assert "placement / escape planning" in text
+
+
+def test_to_dict_exposes_a_stable_field_set():
+    advisory = build_advisory(_report_from([_record("A", legal=0)]), {"A"})
+    payload = advisory.to_dict()
+    assert payload["advisory"] == "crosstail-census"
+    assert set(payload) == {
+        "advisory",
+        "schema_version",
+        "source",
+        "generated_at",
+        "age_seconds",
+        "census_enabled",
+        "applicable",
+        "stale",
+        "board_nets_known",
+        "nets_in_report",
+        "nets_on_board",
+        "coverage_pct",
+        "predicted_crossovers",
+        "predicted_saturated",
+        "predicted_saturated_pct",
+        "prior_summary",
+        "nets",
+        "warnings",
+    }
+    assert set(payload["nets"][0]) == {
+        "net_name",
+        "crossovers",
+        "saturated",
+        "saturated_pct",
+        "no_ordering_lever",
+        "inert",
+        "present_on_board",
+    }
+    # Machine output must survive a JSON round trip unchanged.
+    assert json.loads(json.dumps(payload)) == payload
+
+
+def test_net_prediction_handles_a_zero_crossover_bucket():
+    assert NetPrediction("X", crossovers=0, saturated=0, no_ordering_lever=0).saturated_pct == 0.0
+
+
+# --------------------------------------------------------------------------
+# 6. board net extraction
+# --------------------------------------------------------------------------
+
+
+_MINIMAL_PCB = """(kicad_pcb (version 20221018) (generator test)
+  (net 0 "")
+  (net 1 "GND")
+  (net 2 "MIPI_CLK-")
+)
+"""
+
+
+def test_board_net_names_reads_declared_nets_and_drops_net_zero(tmp_path):
+    pcb = tmp_path / "b.kicad_pcb"
+    pcb.write_text(_MINIMAL_PCB)
+    assert board_net_names(pcb) == {"GND", "MIPI_CLK-"}
+
+
+def test_board_net_names_is_unknown_for_missing_or_netless_boards(tmp_path):
+    assert board_net_names(tmp_path / "missing.kicad_pcb") is None
+    empty = tmp_path / "empty.kicad_pcb"
+    empty.write_text("(kicad_pcb (version 20221018) (generator test))\n")
+    # Unknown, NOT an empty set: an empty set would mark every report net
+    # absent and condemn a perfectly good report as stale.
+    assert board_net_names(empty) is None
+
+
+# --------------------------------------------------------------------------
+# 7. env surface + the never-blocking preflight
+# --------------------------------------------------------------------------
+
+
+def test_advisory_path_from_env_reads_and_trims(tmp_path):
+    assert advisory_path_from_env({}) is None
+    assert advisory_path_from_env({ADVISORY_ENV_VAR: "   "}) is None
+    assert advisory_path_from_env({ADVISORY_ENV_VAR: f" {tmp_path}/r.json "}) == (
+        tmp_path / "r.json"
+    )
+
+
+def test_emit_advisory_prints_the_block_and_returns_the_advisory(tmp_path, capsys):
+    collector = CrossingTailCensusCollector()
+    collector.add(_record("MIPI_CLK-", legal=0))
+    target = write_report(tmp_path / "census.json", collector, census_enabled=True)
+
+    advisory = emit_advisory(target)
+
+    assert isinstance(advisory, CrossingTailAdvisory)
+    assert advisory.predicted_saturated == 1
+    assert "[crosstail-advisory]" in capsys.readouterr().err
+
+
+def test_emit_advisory_cross_checks_against_a_real_board(tmp_path):
+    pcb = tmp_path / "b.kicad_pcb"
+    pcb.write_text(_MINIMAL_PCB)
+    collector = CrossingTailCensusCollector()
+    collector.add(_record("MIPI_CLK-", legal=0))
+    collector.add(_record("GHOST", legal=0))
+    target = write_report(tmp_path / "census.json", collector, census_enabled=True)
+
+    advisory = emit_advisory(target, pcb)
+
+    assert advisory is not None
+    assert advisory.board_nets_known is True
+    assert advisory.predicted_saturated == 1  # GHOST is not on this board
+
+
+def test_emit_advisory_never_raises_on_a_missing_or_broken_report(tmp_path, capsys):
+    assert emit_advisory(tmp_path / "absent.json") is None
+    broken = tmp_path / "broken.json"
+    broken.write_text("{")
+    assert emit_advisory(broken) is None
+    err = capsys.readouterr().err
+    assert err.count("[crosstail-advisory] no prediction") == 2
+
+
+def test_route_preflight_is_advisory_and_always_returns_zero(tmp_path, capsys, monkeypatch):
+    """The #4156 offboard gate blocks; this one must never be able to."""
+    from kicad_tools.cli import route_cmd
+
+    monkeypatch.delenv(ADVISORY_ENV_VAR, raising=False)
+    pcb = tmp_path / "b.kicad_pcb"
+    pcb.write_text(_MINIMAL_PCB)
+
+    # No report requested at all: silent no-op.
+    assert route_cmd._census_advisory_preflight(pcb, SimpleNamespace()) == 0
+    assert capsys.readouterr().err == ""
+
+    # Requested but absent: diagnostic, still 0.
+    args = SimpleNamespace(census_advisory=str(tmp_path / "absent.json"))
+    assert route_cmd._census_advisory_preflight(pcb, args) == 0
+    assert "no prediction" in capsys.readouterr().err
+
+    # Requested and valid: block printed, still 0.
+    collector = CrossingTailCensusCollector()
+    collector.add(_record("MIPI_CLK-", legal=0))
+    target = write_report(tmp_path / "census.json", collector, census_enabled=True)
+    args = SimpleNamespace(census_advisory=str(target))
+    assert route_cmd._census_advisory_preflight(pcb, args) == 0
+    assert "pre-route prediction" in capsys.readouterr().err
+
+
+def test_route_preflight_falls_back_to_the_env_var(tmp_path, capsys, monkeypatch):
+    from kicad_tools.cli import route_cmd
+
+    collector = CrossingTailCensusCollector()
+    collector.add(_record("MIPI_CLK-", legal=0))
+    target = write_report(tmp_path / "census.json", collector, census_enabled=True)
+    monkeypatch.setenv(ADVISORY_ENV_VAR, str(target))
+
+    pcb = tmp_path / "b.kicad_pcb"
+    pcb.write_text(_MINIMAL_PCB)
+    assert route_cmd._census_advisory_preflight(pcb, SimpleNamespace()) == 0
+    assert "pre-route prediction" in capsys.readouterr().err
+
+
+def test_route_help_documents_the_flag(capsys):
+    from kicad_tools.cli import route_cmd
+
+    with pytest.raises(SystemExit):
+        route_cmd.main(["--help"])
+    out = capsys.readouterr().out
+    assert "--census-advisory" in out
+    assert "Advisory only" in out


### PR DESCRIPTION
## What

Slice 2 of #4799. Slice 1 (#4852) captured the diff-pair crossing-tail census as JSON — but that document is written at the **end** of the run that produced it, after the shadow phase has already spent its budget on a lattice that may have offered nothing. This slice reads a report at the **start** of the next run:

```bash
uv run kct route board.kicad_pcb --census-advisory census.json
# or, for callers that drive the router API directly (board scripts):
KCT_CROSSTAIL_CENSUS_ADVISORY=census.json uv run python boards/06-diffpair-test/generate_design.py --step route
```

That is what makes the census a leading indicator: the same measurement, read earlier — the way profile-guided optimization reuses a previous profile instead of predicting one.

Verbatim, replaying board-06's own report (166 crossovers, seed 42, shadow-ON) against `diffpair_test_routed.kicad_pcb`:

```
[crosstail-advisory] pre-route prediction from census.json, 8.0h old
[crosstail-advisory]   prior run: 166 crossover(s), 150 saturated (90.4%), inert 94.6%, verdict=saturated
[crosstail-advisory]   board cross-check: 9/9 report net(s) still on this board (100.0% coverage)
[crosstail-advisory]   predicted this run: 150/166 saturated crossover(s) (90.4%)
[crosstail-advisory]   worst nets: PCIE_TX- 86/88, MIPI_CLK- 22/24, USB3_TX1- 20/26, USB2_D+ 6/10, PCIE_RX- 5/7 (+4 more)
[crosstail-advisory]   reading: ordering levers are inert here -- the diff-pair shadow phase will spend its budget without a lever to pull; the constraint is upstream in placement / escape planning
[crosstail-advisory]   ADVISORY ONLY -- this route is unchanged by the above (#4799)
```

Those headline figures (150/166, 90.4%, inert 94.6%) are the ones the census itself printed **28 minutes into** the run that produced the report, and they match `boards/06-diffpair-test/README.md`. The entire contribution here is *when* they are on screen.

## What this is not

A genuinely placement-only predictor stays out of scope, and deliberately unbuilt: the census's legality test consults drills placed by *earlier crossovers in the same pass*, an escape-channel registry keyed on which nets are still unrouted, and the pair's own guide route — so it cannot be hoisted ahead of the first A\* expansion without solving the open design question the issue body calls out. Replaying the previous measurement sidesteps that question rather than pretending to have answered it.

The cost of that choice is that the prediction inherits the previous run's ordering and decays as the design moves. Two guards keep it honest instead of confident:

* **Board cross-check** — report nets are matched against the nets declared by the board being routed; nets that no longer exist contribute nothing to the predicted counts, and are not named in the "worst nets" line either.
* **Staleness** — below 50% net overlap (`STALE_COVERAGE_PCT_THRESHOLD`) the advisory sets `stale` and *prints no counts at all*, only the warning. A block that says "suppressed" and then shows the numbers has suppressed nothing.

Both fired on real data during validation: board-06's report replayed against **board-00** gives `0/9 report net(s) still on this board (0.0% coverage)` → `prediction SUPPRESSED`.

"Not applicable" (nothing was ever scanned — boards 05 and 07 today) stays distinct from "0% saturated", carrying slice 1's distinction through the replay.

## Report-only, proven

The preflight is modelled on `_offboard_preflight` but, unlike it, **always returns 0**. A missing, malformed, foreign or unreadable report prints one `[crosstail-advisory] no prediction: …` line and the route proceeds. Nothing in the repo branches on the verdict.

Byte-identical proof on board-00 (`--seed 42`, flag off vs. flag on):

| Comparison | Differing lines | Differing non-`uuid` lines |
|---|---|---|
| flag-off vs. flag-on | 56 (28 uuids) | **0** |
| flag-off vs. flag-off (control) | 28 (14 uuids) | **0** |

The routed copper is identical; the only churn is freshly generated UUIDs, which two *flag-off* runs churn exactly the same way. Both runs exit 0.

## Cost

The number a future go/no-go wiring will need (measured on board-06's 166-crossover report):

| Step | Wall clock |
|------|-----------|
| load + rehydrate 166 records | 0.0009 s |
| read the board's nets (26) | 0.1468 s |
| aggregate + cross-check + verdict | 0.0008 s |
| **total preflight** | **0.149 s** |
| the in-route census it replays | 1.27 s |
| the board-06 route that produced it | ~1680 s (28 min) |

≈0.01% of the route it precedes. A leading indicator that costs what it is trying to avoid would not be one.

## Why the flag *and* an env var

`kct route` reaches boards that go through the CLI; board-06's census only happens under `generate_design.py --step route`, which drives the router API directly and never reaches `kct route`. The flag wins when both are set. (Slice 1's env-var-only rationale was about the *capture* side, which is only reachable from the board script; consumption is not.)

Note the flag had to be declared on **both** parsers — `kct route` parses with `cli/parser.py` and shells out to `route_cmd.py`'s own parser, so an inner-only flag dies with "unrecognized arguments". Caught by running it, now pinned by a test (`tests/test_cli_parser_drift.py` covers the pairing generically).

## Tests

New `tests/router/test_crosstail_advisory_4799.py` — 38 tests, no board fixture, <1 s:

* loader round-trips exactly what `crosstail_census.write_report` wrote; rejects non-JSON, non-object, wrong `report` kind, non-list `crossovers`, missing file; tolerates truncated/junk records
* per-net roll-up counts and deterministic worst-first ordering (ties alphabetical, never dict insertion order)
* board cross-check filters predicted counts and the worst-nets line; unknown board nets (`None`, not `set()`) keep every record and say so
* staleness: below-threshold coverage suppresses, exactly-at-threshold does not, threshold is tunable
* not-applicable ≠ 0% saturated; census-disabled, schema-version and stored-summary-disagrees warnings
* the preflight returns 0 for absent / broken / valid reports alike, and the env-var fallback
* `--census-advisory` is accepted by the outer parser and forwarded, and *not* forwarded when unset

```
tests/router -k "census or crosstail" + test_crosstail_census_report_4799
  + test_diffpair_census_budget + test_cli_parser_drift ....... 80 passed
route CLI parser/help/forwarding set (6 files) ................ 197 passed
ruff check + format ........................................... clean
scripts/ci/check_mypy_baseline.py (no --update) ............... OK, no new type errors
```

## Docs

`docs/reference/crosstail-census-report.md` gains "Replaying it before the next route", the advisory field table, and the cost table; `boards/06-diffpair-test/README.md` points at it. CHANGELOG entry under `[Unreleased]`.

## Remaining scope on #4799

Unchanged from the curated list, minus this slice:

1. A genuine pre-any-A\*-expansion predictor (the order-dependency / guide-route prerequisite).
2. Generalizing the measurement beyond diff-pair crossing tails (#3438's pad-array bundles are a different mechanism).
3. Wiring saturation into an actual go/no-go or steering decision — this PR deliberately stops one step short.
4. Calibrating the thresholds (90% inert, 50% coverage) against #4830's corpus.

Part of #4799.
