### PR TITLE
refactor(placement): use pad HPWL at multi-fidelity level 1 (audit M2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -723,6 +723,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Multi-fidelity level 1 now measures wirelength at the pads it already
+  required** (part of #4831, audit milestone M2) — `_evaluate_fidelity_1`
+  (`src/kicad_tools/placement/multi_fidelity.py`) was *handed*
+  `PlacedComponent` objects with fully transformed pads (fidelity ≥ 1 raises
+  `ValueError` without them, because the pad-to-pad DRC check needs them),
+  then projected every part down to its centre before calling
+  `compute_wirelength` — pure information loss. It now builds
+  `build_pad_position_map(placements_rich)` and passes it as `pad_positions`,
+  so fidelity 1 (and 2/3, which build on its breakdown) scores pad-anchored
+  HPWL. The most visible consequence: **rotation is no longer invisible to the
+  wirelength term** — rotating a part leaves `p.x`/`p.y` untouched, so the
+  centre-anchored estimate could not see a pad swing from a facing edge to the
+  far edge of a package. Fidelity 0 is deliberately unchanged (it accepts
+  centre-only placements, so it cannot assume pads exist), which also keeps the
+  historical estimate reachable via `FidelityLevel.HPWL`. Only the wirelength
+  term moves — overlap, boundary, area and DRC are untouched. **Unconditional,
+  unlike M1's opt-in `kct optimize-placement --pad-anchored-wirelength`**: the
+  multi-fidelity evaluator is library/test surface (nothing under `src/` calls
+  `evaluate_placement_multifidelity`), so a second opt-in switch would have
+  bought no safety while leaving the information loss on by default. As in M1
+  the pads are routed *through* `compute_wirelength` rather than calling
+  `compute_hpwl` directly, so per-net `Net.weight` survives and pins without a
+  pad still fall back to their component centre.
+  `docs/placement-pad-anchoring-audit.md` records M2 as landed; M3-M5 remain.
+
 - **The diff-pair shadow constructor stays default-OFF — measured, not
   assumed** (#4800, part of #4409) — all five correctness gates the
   `DifferentialPairConfig.enable_shadow_construction` flip was waiting on

--- a/docs/placement-pad-anchoring-audit.md
+++ b/docs/placement-pad-anchoring-audit.md
@@ -15,7 +15,14 @@ document rather than filed (issue creation is serialized in this repo).
 > pads the CLI already decoded. It is **opt-in**: with no map the score is
 > byte-identical to the centre-anchored objective. The line-number citations
 > below describe the tree *as audited*; `cost.py` line numbers shifted by the
-> M1 patch. M2-M5 are unchanged and still unfiled.
+> M1 patch. M3-M5 are unchanged and still unfiled.
+>
+> **Status update (2026-08-15): M2 has landed too.** `_evaluate_fidelity_1`
+> (`src/kicad_tools/placement/multi_fidelity.py`) now measures wirelength at
+> the pads it was already required to carry, **unconditionally** — see §6 M2
+> for why that needed no opt-in flag while M1 did. Fidelity 0 remains
+> centre-anchored. `multi_fidelity.py` line citations below predate that
+> patch; the symbol names are still the identity of each claim.
 
 ## Why this audit exists
 
@@ -133,12 +140,14 @@ Three centre-anchored terms; the rest are body geometry or bookkeeping.
 | Level | Symbol | Anchoring | Evidence |
 |---|---|---|---|
 | Fidelity 0 (HPWL) | `_evaluate_fidelity_0` (`multi_fidelity.py:266`) | **centre** | delegates to `compute_wirelength`, `multi_fidelity.py:276` |
-| Fidelity 1 (+DRC) | `_evaluate_fidelity_1` (`multi_fidelity.py:292`) | **centre** wirelength, **pad** DRC | builds `simple_placements` by dropping pads (`multi_fidelity.py:306-314`) then calls `compute_wirelength` at `multi_fidelity.py:316`, while `check_placement_drc` (`src/kicad_tools/placement/drc.py:205`) does real pad-to-pad clearance |
-| Fidelity 2/3 (routing) | `_evaluate_global_routing` (`multi_fidelity.py:511`) | n/a | routability ratio only |
+| Fidelity 1 (+DRC) | `_evaluate_fidelity_1` (`multi_fidelity.py:292`) | ~~**centre**~~ → **pad** wirelength (M2), **pad** DRC | *As audited*: built `simple_placements` by dropping pads (`multi_fidelity.py:306-314`) then called `compute_wirelength` at `multi_fidelity.py:316`, while `check_placement_drc` (`src/kicad_tools/placement/drc.py:205`) did real pad-to-pad clearance. **Since M2** it also passes `build_pad_position_map(placements_rich)` as `pad_positions`, so the wirelength term is pad-anchored too. |
+| Fidelity 2/3 (routing) | `_evaluate_global_routing` (`multi_fidelity.py:511`) | n/a (inherits the fidelity-1 breakdown) | routability ratio only |
 
-`_evaluate_fidelity_1` is the sharpest instance of the pattern: it is *handed*
+`_evaluate_fidelity_1` was the sharpest instance of the pattern: it is *handed*
 `PlacedComponent` objects with transformed pads (it needs them for DRC) and
-still measures wirelength between centres.
+still measured wirelength between centres. **M2 fixed this** (§6); fidelity 0
+remains centre-anchored, since it accepts centre-only placements and so cannot
+assume pads exist.
 
 Reachability note (honest scoping): `evaluate_placement_multifidelity`
 (`multi_fidelity.py:374`) is exported from `src/kicad_tools/placement/__init__.py:57`
@@ -316,9 +325,40 @@ which `compute_wirelength` honours (`cost.py:265`) and which the
 `--anchor-weight` feature depends on (§7). A straight swap would silently drop
 per-net weighting; the follow-up must carry the weight through.
 
-### M2 — Stop discarding pads in `_evaluate_fidelity_1`
+### M2 — Stop discarding pads in `_evaluate_fidelity_1` — **LANDED (unconditional)**
 
-> **Stub title:** `refactor(placement): use pad HPWL at multi-fidelity level 1, where pads are already required`
+> **Shipped as:** `_evaluate_fidelity_1` (`src/kicad_tools/placement/multi_fidelity.py`)
+> now builds `build_pad_position_map(placements_rich)` and passes it to
+> `compute_wirelength(..., pad_positions=...)`. Fidelity ≥ 1 is therefore
+> pad-anchored; fidelity 0 (which accepts centre-only placements) is
+> unchanged, so the historical estimate is still reachable by asking for
+> `FidelityLevel.HPWL`. Levels 2 and 3 build on the fidelity-1 breakdown and
+> inherit the pad-anchored term.
+>
+> **Flag decision — unconditional, unlike M1.** M1 is opt-in because
+> `evaluate_placement` is the objective of every production
+> `kct optimize-placement` / MCP run. The multi-fidelity module is
+> library/test surface: `rg -n "evaluate_placement_multifidelity"` matches
+> only `placement/multi_fidelity.py`, `placement/__init__.py` (re-export) and
+> `tests/test_multi_fidelity.py` — nothing else under `src/` calls it, which
+> is exactly the "low risk, good pathfinder" framing below. Adding a second
+> opt-in switch here would have bought no safety and left the information
+> loss in place by default.
+>
+> **Implementation note.** As in M1, the pad coordinates are passed *into*
+> `compute_wirelength` rather than calling `compute_hpwl(placements_rich, nets)`
+> as this stub originally proposed. `compute_hpwl` ignores `Net.weight`, so a
+> literal swap would have silently dropped per-net weighting at level 1 while
+> level 0 kept honouring it; routing the pads through `compute_wirelength`
+> keeps one net-iteration code path, preserves weights, and keeps the per-pin
+> fallback to the component centre for pins that have no pad. Only the
+> wirelength term moves — overlap/boundary/area/DRC are untouched (§7).
+>
+> **Tests:** `tests/test_multi_fidelity_pad_anchored.py` (level 0 vs level 1 on
+> the same input, rotation visible only at level 1, `Net.weight` survival,
+> missing-pad fallback, level-2 inheritance, determinism).
+
+> **Stub title (as filed):** `refactor(placement): use pad HPWL at multi-fidelity level 1, where pads are already required`
 > **Scope:** in `_evaluate_fidelity_1` (`multi_fidelity.py:292`), replace the
 > `compute_wirelength(simple_placements, nets)` call at `multi_fidelity.py:316`
 > with `compute_hpwl(placements_rich, nets)`.
@@ -430,7 +470,7 @@ to standardise on, kept clearly distinct from the "locked/immovable" sense above
 | Stub | Title | Depends on |
 |---|---|---|
 | M1 | `feat(placement): score the optimizer objective on pad-anchored HPWL` | **LANDED opt-in** (`--pad-anchored-wirelength`); MCP front-end + default-on remain |
-| M2 | `refactor(placement): use pad HPWL at multi-fidelity level 1, where pads are already required` | — (low risk, good pathfinder for M1) |
+| M2 | `refactor(placement): use pad HPWL at multi-fidelity level 1, where pads are already required` | **LANDED unconditional** (fidelity ≥ 1 pad-anchored; fidelity 0 unchanged) |
 | M3 | `feat(optim): allow max_distance constraints to target a pad, not a component centre` | overlaps #4831 item 4 |
 | M4 | `fix(optim): pick the shared-net pad instead of pins[0] for cluster springs` | M1 (only if `optim` stays in use) |
 | M5 | `feat(placement): report pad-anchored HPWL alongside the centre-anchored score` | — (de-risks M1) |

--- a/src/kicad_tools/placement/multi_fidelity.py
+++ b/src/kicad_tools/placement/multi_fidelity.py
@@ -16,6 +16,15 @@ Level  Method                      Approx Cost  Use
 3      + Full detailed routing     ~1 s         Final validation
 =====  ==========================  ===========  ==============================
 
+Wirelength anchoring differs by level (issue #4831 M2). Fidelity 0 accepts
+centre-only placements, so its HPWL is measured between component centres.
+Fidelity >= 1 *requires* :class:`~kicad_tools.placement.vector.PlacedComponent`
+inputs with transformed pads, so its HPWL is measured between the real pad
+coordinates -- which makes the estimate sensitive to rotation, something the
+centre-anchored form cannot see. Levels 2 and 3 build on the fidelity-1
+breakdown and inherit the pad-anchored term. See
+``docs/placement-pad-anchoring-audit.md``.
+
 Usage::
 
     from kicad_tools.placement.multi_fidelity import (
@@ -54,6 +63,7 @@ from .cost import (
 )
 from .drc import DrcResult, check_placement_drc
 from .vector import ComponentDef, PlacedComponent
+from .wirelength import build_pad_position_map
 
 if TYPE_CHECKING:
     from kicad_tools.router.global_router import GlobalRouter
@@ -301,6 +311,18 @@ def _evaluate_fidelity_1(
 
     Uses the richer PlacedComponent type with transformed pads for DRC.
     Falls back to fidelity 0 DRC score (0) if no design rules provided.
+
+    **Pad-anchored wirelength (issue #4831 M2).** Fidelity >= 1 already
+    *requires* :class:`~kicad_tools.placement.vector.PlacedComponent` inputs
+    carrying transformed pads, so the wirelength term is measured at the pads
+    rather than at component centres -- unconditionally, with no opt-in flag
+    (unlike :func:`kicad_tools.placement.cost.evaluate_placement`, whose
+    centre-anchored default protects every production placement run). The
+    body-geometry terms (overlap, boundary, area) stay centre/bbox-based:
+    pad anchoring is a *connectivity* notion and does not apply to them
+    (``docs/placement-pad-anchoring-audit.md`` §7). Fidelity 0 remains
+    centre-anchored, so the historical estimate is still reachable by asking
+    for :attr:`FidelityLevel.HPWL`.
     """
     # First compute fidelity-0 metrics using simple placement types
     simple_placements = [
@@ -313,7 +335,13 @@ def _evaluate_fidelity_1(
         for p in placements_rich
     ]
 
-    wirelength = compute_wirelength(simple_placements, nets)
+    # Pads are mandatory at this fidelity (see the ValueError raised by
+    # evaluate_placement_multifidelity), so anchoring wirelength to them costs
+    # one dict build -- not a new transform pass. Pins missing from the map
+    # fall back to their component centre inside compute_wirelength, and
+    # per-net Net.weight is preserved (which compute_hpwl would have dropped).
+    pad_positions = build_pad_position_map(placements_rich)
+    wirelength = compute_wirelength(simple_placements, nets, pad_positions=pad_positions)
     overlap = compute_overlap(simple_placements, config.footprint_sizes)
     boundary = compute_boundary_violation(simple_placements, board, config.footprint_sizes)
     area = compute_area(simple_placements)
@@ -386,6 +414,12 @@ def evaluate_placement_multifidelity(
 
     Each fidelity level includes all checks from lower levels and adds
     progressively more expensive analysis.
+
+    The wirelength term is centre-anchored at fidelity 0 and pad-anchored at
+    fidelity >= 1, where transformed pads are already mandatory (issue #4831
+    M2; see the module docstring). Passing the *same* rich placements at two
+    different fidelities can therefore yield two different wirelength values
+    -- that is the intended information gain, not a bug.
 
     Args:
         placements: Component positions.  For fidelity 0, simple

--- a/tests/test_multi_fidelity.py
+++ b/tests/test_multi_fidelity.py
@@ -704,7 +704,15 @@ class TestScoreMonotonicity:
         design_rules,
     ):
         """When no DRC violations exist, fidelity 0 and 1 should produce
-        similar base scores (wirelength + overlap + boundary + area)."""
+        similar base scores (wirelength + overlap + boundary + area).
+
+        Since #4831 M2 the two levels anchor wirelength differently (0 =
+        component centres, 1 = transformed pads), so they only agree when the
+        pad offsets cancel -- which they do for these fixtures: both parts put
+        pin "1" 0.5 mm to the left of their centre, so the net's bounding box
+        is translated, not resized. See ``test_multi_fidelity_pad_anchored.py``
+        for the cases where the two levels deliberately disagree.
+        """
         r0 = evaluate_placement_multifidelity(
             placements=placed_components,
             nets=simple_nets,
@@ -724,7 +732,7 @@ class TestScoreMonotonicity:
         assert r0.score.is_feasible is True
         assert r1.score.is_feasible is True
 
-        # Wirelength should be similar (both use component centers)
+        # Wirelength agrees here because the pad offsets cancel (see docstring)
         assert abs(r0.score.breakdown.wirelength - r1.score.breakdown.wirelength) < 0.01
 
     def test_drc_violations_increase_score(

--- a/tests/test_multi_fidelity_pad_anchored.py
+++ b/tests/test_multi_fidelity_pad_anchored.py
@@ -1,0 +1,477 @@
+"""Pad-anchored wirelength at multi-fidelity level 1 (issue #4831, M2).
+
+Fidelity >= 1 already *requires* :class:`PlacedComponent` inputs carrying
+transformed pads (it needs them for the pad-to-pad DRC check), then threw them
+away for the wirelength term by projecting every part down to its centre. M2
+stops that information loss: level 1 measures HPWL at the pads, level 0 keeps
+the historical centre-anchored estimate.
+
+Unlike M1 (``kct optimize-placement --pad-anchored-wirelength``) this is
+unconditional -- there is no opt-in flag -- because the multi-fidelity module
+is library/test surface: nothing under ``src/`` calls
+``evaluate_placement_multifidelity``. See
+``docs/placement-pad-anchoring-audit.md`` §6 M2.
+
+These tests pin down:
+
+* level 1 measures pads, level 0 measures centres, on the *same* input;
+* rotation -- invisible to a centre-anchored HPWL -- becomes visible at level 1;
+* only the wirelength term changes (overlap/boundary/area/DRC are untouched);
+* ``Net.weight`` survives (``compute_hpwl`` would have dropped it);
+* a pin with no pad falls back to its component centre rather than dropping;
+* levels 2/3 inherit the level-1 term, and every level stays deterministic.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from kicad_tools.placement.cost import (
+    BoardOutline,
+    ComponentPlacement,
+    Net,
+    compute_wirelength,
+)
+from kicad_tools.placement.multi_fidelity import (
+    FidelityLevel,
+    evaluate_placement_multifidelity,
+    make_fixed_fidelity_evaluator,
+)
+from kicad_tools.placement.vector import (
+    ComponentDef,
+    PadDef,
+    PlacedComponent,
+    TransformedPad,
+    decode,
+    encode,
+)
+from kicad_tools.placement.wirelength import compute_hpwl
+
+# ---------------------------------------------------------------------------
+# Fixtures / helpers
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def board() -> BoardOutline:
+    return BoardOutline(min_x=-50.0, min_y=-50.0, max_x=50.0, max_y=50.0)
+
+
+@pytest.fixture
+def design_rules():
+    from kicad_tools.router.rules import DesignRules
+
+    return DesignRules(trace_clearance=0.2)
+
+
+def _placed(
+    reference: str,
+    x: float,
+    y: float,
+    pads: list[tuple[str, float, float]],
+    rotation: float = 0.0,
+) -> PlacedComponent:
+    """A PlacedComponent whose pads are already in absolute coordinates."""
+    return PlacedComponent(
+        reference=reference,
+        x=x,
+        y=y,
+        rotation=rotation,
+        side=0,
+        pads=tuple(
+            TransformedPad(name=n, x=px, y=py, size_x=0.5, size_y=0.5) for n, px, py in pads
+        ),
+    )
+
+
+def _centres(placements: list[PlacedComponent]) -> list[ComponentPlacement]:
+    return [
+        ComponentPlacement(reference=p.reference, x=p.x, y=p.y, rotation=p.rotation)
+        for p in placements
+    ]
+
+
+def _defs_for(placements: list[PlacedComponent]) -> list[ComponentDef]:
+    """Component defs sized generously so DRC/overlap stay quiet."""
+    return [
+        ComponentDef(
+            reference=p.reference,
+            pads=tuple(
+                PadDef(
+                    name=pad.name, local_x=pad.x - p.x, local_y=pad.y - p.y, size_x=0.5, size_y=0.5
+                )
+                for pad in p.pads
+            ),
+            width=10.0,
+            height=10.0,
+        )
+        for p in placements
+    ]
+
+
+# Two 10x10 parts 20 mm apart on centres, wired pad-to-pad on their *facing*
+# edges: the copper only has to span 10 mm, which a centre-anchored HPWL
+# reports as 20 mm.
+#
+#   U1 centre (0,0), pad "1" at (+5,0)     U2 centre (20,0), pad "1" at (15,0)
+FACING = [
+    _placed("U1", 0.0, 0.0, [("1", 5.0, 0.0), ("2", -5.0, 0.0)]),
+    _placed("U2", 20.0, 0.0, [("1", 15.0, 0.0), ("2", 25.0, 0.0)]),
+]
+FACING_NETS = [Net(name="SIG", pins=[("U1", "1"), ("U2", "1")])]
+
+
+def _evaluate(
+    placements,
+    nets,
+    board,
+    fidelity,
+    design_rules=None,
+    component_defs=None,
+    global_router=None,
+):
+    return evaluate_placement_multifidelity(
+        placements=placements,
+        nets=nets,
+        board=board,
+        fidelity=fidelity,
+        component_defs=component_defs,
+        design_rules=design_rules,
+        global_router=global_router,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Level 1 measures pads; level 0 does not
+# ---------------------------------------------------------------------------
+
+
+def test_fidelity_0_stays_centre_anchored(board) -> None:
+    """Level 0 accepts centre-only placements, so it keeps measuring centres."""
+    r0 = _evaluate(FACING, FACING_NETS, board, FidelityLevel.HPWL)
+
+    assert r0.score.breakdown.wirelength == pytest.approx(20.0)
+    # Byte-identical to calling the centre-anchored estimator directly.
+    assert r0.score.breakdown.wirelength == compute_wirelength(_centres(FACING), FACING_NETS)
+
+
+def test_fidelity_1_measures_the_pads(board, design_rules) -> None:
+    r1 = _evaluate(
+        FACING,
+        FACING_NETS,
+        board,
+        FidelityLevel.DRC,
+        design_rules=design_rules,
+        component_defs=_defs_for(FACING),
+    )
+
+    # Pads are 10 mm apart even though the centres are 20 mm apart.
+    assert r1.score.breakdown.wirelength == pytest.approx(10.0)
+
+
+def test_fidelity_1_matches_compute_hpwl_for_unit_weight_nets(board, design_rules) -> None:
+    """With every ``Net.weight`` at its 1.0 default the level-1 term is HPWL."""
+    r1 = _evaluate(
+        FACING,
+        FACING_NETS,
+        board,
+        FidelityLevel.DRC,
+        design_rules=design_rules,
+        component_defs=_defs_for(FACING),
+    )
+
+    assert r1.score.breakdown.wirelength == pytest.approx(compute_hpwl(FACING, FACING_NETS))
+
+
+def test_pad_anchoring_can_increase_the_estimate(board, design_rules) -> None:
+    """Pads are not a uniform discount -- outward-facing pads make it worse."""
+    placements = [
+        _placed("U1", 0.0, 0.0, [("1", -5.0, 0.0)]),
+        _placed("U2", 20.0, 0.0, [("1", 25.0, 0.0)]),
+    ]
+    nets = [Net(name="SIG", pins=[("U1", "1"), ("U2", "1")])]
+
+    r0 = _evaluate(placements, nets, board, FidelityLevel.HPWL)
+    r1 = _evaluate(
+        placements,
+        nets,
+        board,
+        FidelityLevel.DRC,
+        design_rules=design_rules,
+        component_defs=_defs_for(placements),
+    )
+
+    assert r0.score.breakdown.wirelength == pytest.approx(20.0)
+    assert r1.score.breakdown.wirelength == pytest.approx(30.0)
+
+
+def test_intra_component_net_is_zero_on_centres_but_real_on_pads(board, design_rules) -> None:
+    placements = [_placed("U1", 0.0, 0.0, [("1", -5.0, 0.0), ("2", 5.0, 3.0)])]
+    nets = [Net(name="LOOP", pins=[("U1", "1"), ("U1", "2")])]
+
+    r0 = _evaluate(placements, nets, board, FidelityLevel.HPWL)
+    r1 = _evaluate(
+        placements,
+        nets,
+        board,
+        FidelityLevel.DRC,
+        design_rules=design_rules,
+        component_defs=_defs_for(placements),
+    )
+
+    assert r0.score.breakdown.wirelength == pytest.approx(0.0)
+    assert r1.score.breakdown.wirelength == pytest.approx(13.0)  # 10 in x + 3 in y
+
+
+# ---------------------------------------------------------------------------
+# Rotation: invisible to centres, visible to pads
+# ---------------------------------------------------------------------------
+
+
+def test_rotation_is_invisible_at_level_0_but_visible_at_level_1(board, design_rules) -> None:
+    """The optimizer searches a rotation axis level 0's wirelength cannot see.
+
+    Pads are produced by the production transform (``encode``/``decode``), not
+    hand-placed, so this exercises ``_transform_pad`` rather than a fixture.
+    """
+    defs = [
+        ComponentDef(
+            reference="U1",
+            pads=(PadDef(name="1", local_x=5.0, local_y=0.0, size_x=0.5, size_y=0.5),),
+            width=10.0,
+            height=10.0,
+        ),
+        ComponentDef(
+            reference="U2",
+            pads=(PadDef(name="1", local_x=-5.0, local_y=0.0, size_x=0.5, size_y=0.5),),
+            width=10.0,
+            height=10.0,
+        ),
+    ]
+    nets = [Net(name="SIG", pins=[("U1", "1"), ("U2", "1")])]
+
+    def _placements(rotation: float) -> list[PlacedComponent]:
+        raw = [
+            PlacedComponent("U1", 0.0, 0.0, rotation, 0, ()),
+            PlacedComponent("U2", 20.0, 0.0, 0.0, 0, ()),
+        ]
+        return decode(encode(raw), defs)
+
+    unrotated = _placements(0.0)
+    rotated = _placements(180.0)
+
+    l0_unrotated = _evaluate(unrotated, nets, board, FidelityLevel.HPWL)
+    l0_rotated = _evaluate(rotated, nets, board, FidelityLevel.HPWL)
+    l1_unrotated = _evaluate(
+        unrotated, nets, board, FidelityLevel.DRC, design_rules=design_rules, component_defs=defs
+    )
+    l1_rotated = _evaluate(
+        rotated, nets, board, FidelityLevel.DRC, design_rules=design_rules, component_defs=defs
+    )
+
+    # Level 0 reads only p.x/p.y, which rotation leaves untouched.
+    assert l0_unrotated.score.breakdown.wirelength == pytest.approx(
+        l0_rotated.score.breakdown.wirelength
+    )
+
+    # Level 1 sees the pad swing from the facing edge to the far edge.
+    assert l1_unrotated.score.breakdown.wirelength == pytest.approx(10.0)
+    assert l1_rotated.score.breakdown.wirelength == pytest.approx(20.0)
+    assert l1_rotated.score.breakdown.wirelength > l1_unrotated.score.breakdown.wirelength
+
+
+# ---------------------------------------------------------------------------
+# Only the wirelength term moves
+# ---------------------------------------------------------------------------
+
+
+def test_only_the_wirelength_term_changes_at_level_1(board, design_rules) -> None:
+    """Overlap/boundary/area stay body/centre-based -- §7 of the audit."""
+    r0 = _evaluate(FACING, FACING_NETS, board, FidelityLevel.HPWL)
+    r1 = _evaluate(
+        FACING,
+        FACING_NETS,
+        board,
+        FidelityLevel.DRC,
+        design_rules=design_rules,
+        component_defs=_defs_for(FACING),
+    )
+
+    assert r1.score.breakdown.wirelength != pytest.approx(r0.score.breakdown.wirelength)
+    assert r1.score.breakdown.overlap == pytest.approx(r0.score.breakdown.overlap)
+    assert r1.score.breakdown.boundary == pytest.approx(r0.score.breakdown.boundary)
+    assert r1.score.breakdown.area == pytest.approx(r0.score.breakdown.area)
+
+
+def test_net_weight_survives_pad_anchoring(board, design_rules) -> None:
+    """``compute_hpwl`` drops ``Net.weight``; the M2 path must not."""
+    weighted = [Net(name="SIG", pins=[("U1", "1"), ("U2", "1")], weight=3.0)]
+
+    r1 = _evaluate(
+        FACING,
+        weighted,
+        board,
+        FidelityLevel.DRC,
+        design_rules=design_rules,
+        component_defs=_defs_for(FACING),
+    )
+
+    assert r1.score.breakdown.wirelength == pytest.approx(30.0)  # 3 x 10 mm
+    assert r1.score.breakdown.wirelength != pytest.approx(compute_hpwl(FACING, weighted))
+
+
+def test_zero_weight_net_is_still_excluded(board, design_rules) -> None:
+    muted = [Net(name="SIG", pins=[("U1", "1"), ("U2", "1")], weight=0.0)]
+
+    r1 = _evaluate(
+        FACING,
+        muted,
+        board,
+        FidelityLevel.DRC,
+        design_rules=design_rules,
+        component_defs=_defs_for(FACING),
+    )
+
+    assert r1.score.breakdown.wirelength == pytest.approx(0.0)
+
+
+def test_pin_without_a_pad_falls_back_to_its_component_centre(board, design_rules) -> None:
+    """A partially-padded input degrades gracefully instead of dropping nets."""
+    placements = [
+        _placed("U1", 0.0, 0.0, [("1", 5.0, 0.0)]),
+        PlacedComponent("U2", 20.0, 0.0, 0.0, 0, ()),  # no pads at all
+    ]
+    nets = [Net(name="SIG", pins=[("U1", "1"), ("U2", "1")])]
+    defs = [
+        ComponentDef(
+            reference="U1",
+            pads=(PadDef(name="1", local_x=5.0, local_y=0.0, size_x=0.5, size_y=0.5),),
+            width=10.0,
+            height=10.0,
+        ),
+        ComponentDef(reference="U2", pads=(), width=10.0, height=10.0),
+    ]
+
+    r1 = _evaluate(
+        placements,
+        nets,
+        board,
+        FidelityLevel.DRC,
+        design_rules=design_rules,
+        component_defs=defs,
+    )
+
+    # U1 pad at x=5, U2 falls back to its centre at x=20 -> 15 mm.
+    assert r1.score.breakdown.wirelength == pytest.approx(15.0)
+
+
+def test_empty_nets_are_zero_with_pads_present(board, design_rules) -> None:
+    r1 = _evaluate(
+        FACING,
+        [],
+        board,
+        FidelityLevel.DRC,
+        design_rules=design_rules,
+        component_defs=_defs_for(FACING),
+    )
+
+    assert r1.score.breakdown.wirelength == pytest.approx(0.0)
+
+
+# ---------------------------------------------------------------------------
+# Higher levels inherit level 1; determinism
+# ---------------------------------------------------------------------------
+
+
+def test_fidelity_2_inherits_the_level_1_wirelength(board, design_rules) -> None:
+    """Levels 2/3 add routability on top of the level-1 breakdown."""
+    mock_router = MagicMock()
+    mock_result = MagicMock()
+    mock_result.failed_nets = []
+    mock_router.route_all.return_value = mock_result
+
+    defs = _defs_for(FACING)
+    r1 = _evaluate(
+        FACING,
+        FACING_NETS,
+        board,
+        FidelityLevel.DRC,
+        design_rules=design_rules,
+        component_defs=defs,
+    )
+    r2 = _evaluate(
+        FACING,
+        FACING_NETS,
+        board,
+        FidelityLevel.GLOBAL_ROUTE,
+        design_rules=design_rules,
+        component_defs=defs,
+        global_router=mock_router,
+    )
+
+    assert r2.score.breakdown.wirelength == pytest.approx(r1.score.breakdown.wirelength)
+    assert r2.score.breakdown.wirelength == pytest.approx(10.0)
+
+
+def test_repeated_evaluation_is_deterministic(board, design_rules) -> None:
+    defs = _defs_for(FACING)
+    results = [
+        _evaluate(
+            FACING,
+            FACING_NETS,
+            board,
+            FidelityLevel.DRC,
+            design_rules=design_rules,
+            component_defs=defs,
+        )
+        for _ in range(5)
+    ]
+
+    wirelengths = {r.score.breakdown.wirelength for r in results}
+    totals = {r.score.total for r in results}
+    assert len(wirelengths) == 1
+    assert len(totals) == 1
+
+
+def test_pad_order_does_not_change_the_estimate(board, design_rules) -> None:
+    """The pad map is keyed by (reference, pad_name), so ordering is irrelevant."""
+    shuffled = [
+        _placed("U1", 0.0, 0.0, [("2", -5.0, 0.0), ("1", 5.0, 0.0)]),
+        _placed("U2", 20.0, 0.0, [("2", 25.0, 0.0), ("1", 15.0, 0.0)]),
+    ]
+
+    baseline = _evaluate(
+        FACING,
+        FACING_NETS,
+        board,
+        FidelityLevel.DRC,
+        design_rules=design_rules,
+        component_defs=_defs_for(FACING),
+    )
+    reordered = _evaluate(
+        shuffled,
+        FACING_NETS,
+        board,
+        FidelityLevel.DRC,
+        design_rules=design_rules,
+        component_defs=_defs_for(shuffled),
+    )
+
+    assert reordered.score.breakdown.wirelength == pytest.approx(
+        baseline.score.breakdown.wirelength
+    )
+
+
+def test_fixed_fidelity_evaluator_closure_is_pad_anchored(board, design_rules) -> None:
+    """The optimizer-facing closure inherits the level-1 anchoring."""
+    evaluator = make_fixed_fidelity_evaluator(
+        fidelity=FidelityLevel.DRC,
+        nets=FACING_NETS,
+        board=board,
+        component_defs=_defs_for(FACING),
+        design_rules=design_rules,
+    )
+
+    assert evaluator(FACING).score.breakdown.wirelength == pytest.approx(10.0)


### PR DESCRIPTION
## Summary

Implements **M2** of the pad-anchoring audit (`docs/placement-pad-anchoring-audit.md` §6), following M1 (#4857).

`_evaluate_fidelity_1` (`src/kicad_tools/placement/multi_fidelity.py`) is *handed* `PlacedComponent` objects with fully transformed pads — `evaluate_placement_multifidelity` raises `ValueError` without them, because the pad-to-pad DRC check needs them — and then projected every part down to a centre-only `ComponentPlacement` before calling `compute_wirelength`. That downgrade was pure information loss, and it is the exact case the audit flagged as "low risk, good pathfinder".

Level 1 now builds `build_pad_position_map(placements_rich)` and passes it as `pad_positions`, so fidelity 1 (and 2/3, which build on its breakdown) scores pad-anchored HPWL.

The most visible consequence: **rotation is no longer invisible to the wirelength term.** Rotating a part leaves `p.x`/`p.y` untouched, so the centre-anchored estimate could not see a pad swing from the facing edge of a package to the far edge.

## Flag decision: unconditional, unlike M1

The audit's M2 scope is a straight, unflagged swap, and the reachability note in §3.2 explains why that is safe: the multi-fidelity evaluator is **library/test surface** — `rg -n "evaluate_placement_multifidelity"` matches only `placement/multi_fidelity.py`, `placement/__init__.py` (re-export) and `tests/test_multi_fidelity.py`. Nothing under `src/` calls it.

M1 is opt-in (`kct optimize-placement --pad-anchored-wirelength`) because `evaluate_placement` is the objective of every production optimize-placement / MCP run. Here a second opt-in switch would have bought no safety while leaving the information loss on by default, so M2 ships unconditional at level ≥ 1.

**Fidelity 0 is deliberately unchanged** — it accepts centre-only placements and so cannot assume pads exist. That also keeps the historical estimate reachable by asking for `FidelityLevel.HPWL`.

## Implementation note (deviation from the stub's literal text)

The stub said "replace `compute_wirelength(simple_placements, nets)` with `compute_hpwl(placements_rich, nets)`". As in M1, the pads are instead routed **through** `compute_wirelength` as a `pad_positions` map, because `compute_hpwl` ignores `Net.weight` — a literal swap would have silently dropped per-net weighting at level 1 while level 0 kept honouring it. Weights survive, one net-iteration code path is kept, and pins with no pad still fall back to their component centre. Only the wirelength term moves; overlap / boundary / area / DRC are untouched (audit §7).

## Tests

`tests/test_multi_fidelity_pad_anchored.py` — 15 new cases:

- level 0 stays centre-anchored (byte-identical to calling `compute_wirelength` directly) while level 1 measures the pads, on the **same** input (20 mm vs 10 mm on facing-pad parts);
- rotation invisible at level 0, visible at level 1 (10 → 20 mm), with pads produced by the production `encode`/`decode` transform rather than hand-placed;
- pad anchoring can *increase* the estimate (outward-facing pads: 20 → 30 mm) — it is not a uniform discount;
- an intra-component net scores 0 on centres and 13 mm on pads;
- only the wirelength term changes (overlap/boundary/area equal between levels);
- `Net.weight` survives (3× weight → 3× length, and explicitly *not* equal to `compute_hpwl`), zero-weight nets still excluded;
- a pin with no pad falls back to its component centre;
- level 2 inherits the level-1 wirelength; pad ordering is irrelevant; 5 repeats are bit-identical (determinism); the `make_fixed_fidelity_evaluator` closure is pad-anchored.

The pre-existing `test_fidelity_0_and_1_agree_when_no_drc_violations` still passes — its fixtures put both pins 0.5 mm left of centre, so the net's bounding box is translated, not resized — but its "both use component centers" comment was stale and is now corrected with the reason they still agree.

## Gates

- `uv run pytest tests -k "placement or optim or multi_fidelity or fidelity" -q --no-cov` → **2218 passed, 30 skipped** (3m57s)
- `uv run ruff check .` → All checks passed; `ruff format --check .` → 2060 files already formatted
- `scripts/ci/check_mypy_baseline.py` (no `--update`, `.mypy_cache` cleared first) → 1464 errors, all within the 1472 baseline

## Docs

`docs/placement-pad-anchoring-audit.md`: M2 marked **LANDED (unconditional)** with a shipped-as block (mirroring M1's pattern), the original stub text preserved beneath it, the §3.2 inventory row updated, the header status note extended, and the stub index refreshed. CHANGELOG `[Unreleased] → Changed` entry added.

## Remaining milestones

M3 (pad-addressed `max_distance`), M4 (cluster-spring pad choice), M5 (report both estimators), plus M1's deferred tail (the MCP front-end still discards its pads; pad anchoring in `evaluate_placement` is opt-in rather than default).

Part of #4831

🤖 Generated with [Claude Code](https://claude.com/claude-code)