### PR TITLE
docs(research): OmniLayout/OmniRouting recon — adapt the protocol, drop the data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -192,6 +192,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   listed as stubs **inside the doc** and deliberately not filed as issues.
   No source changes.
 
+- **OmniLayout / OmniRouting recon** (`docs/research/omnilayout-recon.md`, part
+  of #4830, slice 3) — the external LLM layout/routing benchmark at
+  omnieda.com was downloaded, characterized and **declined as a corpus**;
+  verdict: *adapt the protocol, drop the data*. Evidence: the release carries
+  **no data licence at all** (no licence text on either site page, none in
+  either archive, none in the released scripts; the only stated licence is
+  CC BY-NC-ND 4.0 — non-commercial *and* no-derivatives — on the two papers,
+  arXiv:2607.03261 / arXiv:2608.04434), and the redistribution does not surface
+  the upstream hardware licences of the third-party boards it is derived from.
+  The public drop is also 5 hand-picked boards behind Google Drive links, not
+  the advertised 1,681 designs, and the payload is **not KiCad** — every record
+  is a JSON transcription of an Eagle 9.6.2 `.brd`, so no slice-1/2 tooling
+  applies. Three findings that would have bitten a naive harness are recorded
+  with counts: 61 of one board's "routing wires" sit on Eagle layer 19
+  (*Unrouted* ratsnest stubs, not copper), *no* record carries a schematic
+  despite the "schematic-coupled" billing, and two boards declare an inner
+  copper layer that carries neither trace nor pour. What is worth keeping is
+  the metric vocabulary (DRC-attributed net routability NRR, pad-pair
+  routability PRR, open/physical-short/logical-short split, violation split by
+  cause) — mapped field-by-field onto `BenchmarkResult` in the doc, and
+  implementable against our own boards and the CC-BY-4.0 open-schematics
+  manifest with no licence exposure. `scripts/corpus/omnieda_sample.py` (new,
+  **offline**, covered by `tests/test_corpus_omnieda.py`) is the instrument
+  that produced the numbers and the re-evaluation trigger if the promised
+  open-source release ever lands: it reports per-board contents plus a census
+  of fields with no `kicad_tools.schema.pcb` counterpart. No third-party bytes
+  are fetched, cached or committed.
+
 - **Curated open-schematics sample manifest + parser scorecard** (part of
   #4830, slice 2) — the corpus probe's one-off sample is now a *standing*
   regression set. `scripts/corpus/manifests/open-schematics-sample.json` is a

--- a/docs/README.md
+++ b/docs/README.md
@@ -48,6 +48,7 @@ Point-in-time working documents — dated entries describe the tree as of their 
 | Document | Description |
 |----------|-------------|
 | [Placement Pad-Anchoring Audit (2026-08)](placement-pad-anchoring-audit.md) | Centre- vs pad-anchored placement objective terms (#4831) |
+| [OmniLayout / OmniRouting Recon (2026-08)](research/omnilayout-recon.md) | External LLM layout/routing benchmark (#4830); verdict: adapt the metric protocol, drop the data (no licence) |
 | [Board Fleet Parity Audit (2026-06)](board-fleet-parity-audit-2026-06.md) | Fleet-wide board status snapshot |
 | [Install Pilot: chorus](install-pilot-chorus.md) | Consumer-repo install pilot for Epic #4054 acceptance |
 | [Atopile Build System Research](research-atopile-build-system.md) | Survey of Atopile's build DAG and targets |

--- a/docs/research/omnilayout-recon.md
+++ b/docs/research/omnilayout-recon.md
@@ -1,0 +1,255 @@
+# OmniLayout / OmniRouting recon (2026-08-15)
+
+*Point-in-time working document — issue [#4830](https://github.com/rjwalters/kicad-tools/issues/4830),
+slice 3 of 4. Describes omnieda.com as of 2026-08-15.*
+
+## Verdict: **adapt the protocol, drop the data**
+
+| Question | Answer |
+|----------|--------|
+| Adopt the dataset as a corpus? | **No** — no licence grant of any kind, and the public drop is 5 hand-picked boards behind Google Drive links. |
+| Adopt the tooling? | **No** — the only code released is a matplotlib board renderer; the evaluation harness that computes the leaderboard metrics is not published. |
+| Adapt anything? | **Yes** — the *metric vocabulary and evaluation protocol*, which is the sharpest external definition of "routed well" we have found, and which we can implement against our own boards and the (properly licensed) open-schematics corpus at zero licence risk. |
+| Build a JSON → `.kicad_pcb` converter? | **Not now.** It is technically feasible (gap list below is short and bounded), but there is nothing licensed to convert. Re-evaluate on the trigger below. |
+
+**Re-evaluation trigger.** Both papers promise a release ("We will open-source
+all benchmark data, evaluation code, and tool interfaces" — OmniRouting
+abstract). If the 1,681-design set lands with an explicit data licence — on
+Hugging Face, versioned — this recon should be re-run: the converter work is
+estimated at days, not weeks, and the reference routings would be the first
+human-authored copper this repo has ever measured against.
+
+---
+
+## 1. What was actually measured
+
+Everything below was downloaded on **2026-08-15** and characterized locally.
+Nothing from these archives is committed to this repository.
+
+| Artifact | Source | Bytes | SHA-256 |
+|----------|--------|-------|---------|
+| OmniLayout sample data (5 JSON boards) | Drive `1Lz6Cbjd4ea78fUHPVNIP4rX3yvrIahEs` | 76,029 | `6b360b4ffffa9f78f5d1a1e441ae31907eef4c85d2261c908ca4baf8977fc77d` |
+| OmniLayout visualization code | Drive `1B12M7Gutv7xn9l956G8caaWkmyMJ0Gb3` | 26,166 | `5a7eac5f45fe88c29dd1a9501274c970099d6d9531f0785dd945b7cace2aa000` |
+| OmniRouting sample data (`five_boards.zip`) | Drive `1ECPGYEQNGtf1Y6FA5otz73DyYL_N20Rb` | 49,031,553 | `31f69023f5557af319b90cc36d0d5116f962809cb3485d29f5542fca453fc81e` |
+| OmniRouting visualization code | Drive `1FtoFcszuL10ngoBfbJ0b2aBfy9Yt_lto` | 19,252 | `8cd6ae756e80ab2dd8fed5f5f7dc3b0a0664ab0559dfca760a9312283753d63b` |
+
+Reproduce (the Drive links are interactive; the `confirm=t` form bypasses the
+virus-scan interstitial for the large archive — **download to scratch space,
+never into the repo**):
+
+```bash
+SCRATCH=$(mktemp -d)
+curl -sSL "https://drive.google.com/uc?export=download&id=1Lz6Cbjd4ea78fUHPVNIP4rX3yvrIahEs" \
+  -o "$SCRATCH/omnilayout-data.zip"
+curl -sSL "https://drive.usercontent.google.com/download?id=1ECPGYEQNGtf1Y6FA5otz73DyYL_N20Rb&export=download&confirm=t" \
+  -o "$SCRATCH/omnirouting-data.zip"
+unzip -q "$SCRATCH/omnilayout-data.zip" -d "$SCRATCH/layout"
+unzip -q "$SCRATCH/omnirouting-data.zip" -d "$SCRATCH/routing"
+chmod -R u+rwX "$SCRATCH/routing"   # the zip ships mode-0444 directories
+
+uv run python scripts/corpus/omnieda_sample.py --sample "$SCRATCH/layout"
+uv run python scripts/corpus/omnieda_sample.py \
+  --sample "$SCRATCH/routing/five_boards/source_conversion/graph" --out "$SCRATCH/audit.json"
+```
+
+Two gotchas worth recording: the "visualization code" downloads are named
+`.zip` by Drive but are plain `.py` files, and the OmniRouting archive uses
+Windows path separators and read-only directory modes.
+
+## 2. What OmniLayout is
+
+Two sibling LLM benchmarks published from the same 1,681-design collection by
+Lu et al. (Penn State / SJTU / Microsoft Research / Binghamton), hosted at
+<https://www.omnieda.com/>:
+
+- **OmniLayout** — *placement* reasoning. [arXiv:2607.03261v2](https://arxiv.org/abs/2607.03261)
+  (3 Jul 2026, ACL ARR 2026). 1,681 schematic-coupled layouts, 77.24K placement
+  instances; four tasks (geometric IC placement, routability-aware placement,
+  electrical functionality, agentic tool use).
+- **OmniRouting** — *routing* reasoning. [arXiv:2608.04434v1](https://arxiv.org/abs/2608.04434)
+  (5 Aug 2026). Same 1,681 designs, stated as 2–8 routing layers, 109.9K
+  components, 245.4K pads/SMDs, 219.8K annotated nets, with engineer-authored
+  reference routings.
+
+The site's `arXiv` / `Code` / `Data` / `Hugging Face` buttons are dead
+(`href="#"`); the *only* live artifacts are the four Drive files above. A
+Hugging Face API search for `omnilayout` / `omnirouting` returns nothing, and no
+public GitHub repository exists — the OmniRouting manifest even records its
+pipeline by local path (`D:\github\Omnirouting\...`).
+
+**These are not KiCad designs.** Every record is a JSON transcription of an
+Eagle 9.6.2 `.brd`: Eagle layer numbers (1 Top, 16 Bottom, 19 Unrouted, 20
+Dimension), Eagle rotation strings (`R90`, `MR270`), Eagle `contactref`
+netlists, Eagle arc "curve" bulges, Eagle DRU parameter names (`mdWireVia`,
+`rvViaOuter`). The five sample boards are public open hardware: Adafruit
+FunHouse, Adafruit HalloWing M4, SparkFun Qwiic Ultrasonic (TCT40), Tiny BLE
+v1.0, Seeed WM1302 LoRa concentrator.
+
+### The two drops are not the same data
+
+The OmniRouting drop is a **strictly richer re-export of the same five boards**
+and is the one to look at if this is ever revisited. Beyond adding reference
+copper it back-fills geometry the OmniLayout drop omits — e.g. FunHouse pad
+`U3/43_10` is `{drill: 0.4}` in the OmniLayout record and
+`{drill: 0.4, diameter: 0.908, diameter_source: "drc_restring"}` in the
+OmniRouting one. All 12 diameter-less through-hole pads on that board are
+resolved in the routing export.
+
+## 3. Schema vs KiCad-native
+
+Measured with `scripts/corpus/omnieda_sample.py` (offline; ships with this PR).
+
+**OmniLayout drop** — placement only, no copper:
+
+| Board | Components | Nets | Pads |
+|-------|-----------:|-----:|-----:|
+| Adafruit FunHouse | 88 | 61 | 332 |
+| Adafruit HalloWing M4 | 78 | 81 | 370 |
+| SparkFun Ultrasonic TCT40 | 62 | 40 | 166 |
+| Tiny BLE v1.0 | 122 | 123 | 389 |
+| Seeed WM1302 915 SPI | 226 | 242 | 697 |
+
+**OmniRouting drop** — same boards plus reference copper:
+
+| Board | Copper wires | Vias | Pours | Copper layers | Min clearance (mm) |
+|-------|-------------:|-----:|------:|---------------|-------------------:|
+| Adafruit FunHouse | 857 | 124 | 2 | 1, 16 | 0.2032 |
+| Adafruit HalloWing M4 | 1287 | 157 | 2 | 1, 16 | 0.2032 |
+| SparkFun Ultrasonic TCT40 | 411 | 73 | 3 | 1, 16 | 0.1778 |
+| Tiny BLE v1.0 | 690 | 146 | 5 | 1, 15, 16 | 0.1524 |
+| Seeed WM1302 915 SPI | 1857 | 747 | 7 | 1, 15, 16 | 0.0889 |
+
+Field-level mapping onto `kicad_tools.schema.pcb`:
+
+| OmniEDA field | KiCad-native counterpart | Convertible? |
+|---------------|--------------------------|--------------|
+| `ic_library[].smd/pads/holes` | `Footprint` + `Pad` | Yes — rect/round SMD and drilled pads all fit `Pad(shape=…)` |
+| `ic_position[]` (`position`, `rotation` `R*`/`MR*`) | `Footprint.position` / rotation / layer flip | Yes — `MR*` is a back-side mirror |
+| `netlist[].contactref` | `Net` + pad net assignment | Yes |
+| `board_boundary.segment_details` (+ `curve`) | `EdgeContour` / `GraphicArc` | Yes — Eagle bulge → arc |
+| `routing_wires[]` on layers 1..16 | `Segment` | Yes, **except** curved wires (see gaps) |
+| `routing_vias[]` (`extent: "1-16"`) | `Via` | Yes |
+| `copper_pours[]` (Eagle polygon) | `Zone` | Partly — `rank`/`isolate`/`thermals` have no 1:1 KiCad meaning |
+| `Clearance.rules`, `board_semantics.designrules` | `Setup` / manufacturer rules | Partly — Eagle DRU names need a translation table |
+| `board_semantics.classes` | net classes | Yes |
+| `board_semantics.layers` (134–184 entries) | `StackupLayer` | Needs synthesis; only 2 of 16 copper layers are populated on 3/5 boards |
+| *schematic* | `Schematic` | **Absent** — see gaps |
+
+### Mappability gap census (pooled over the 5 routing-drop boards)
+
+| Gap | Count | Boards | Consequence |
+|-----|------:|-------:|-------------|
+| `component-missing-rotation` | 121 | 5/5 | `ic_library` entry has no rotation; converter must fall back to `ic_position` |
+| `airwire-counted-as-routing` | 61 | 1/5 | Eagle layer-19 "Unrouted" stubs shipped inside `routing_wires` |
+| `placement-without-footprint-geometry` | 32 | 5/5 | element is placed but has no library entry — no pads to emit |
+| `curved-copper-segment` | 25 | 1/5 | `schema.pcb` models copper as `(segment …)` only; needs polyline approximation |
+| `copper-pour-polygon` | 19 | 5/5 | Eagle polygon → KiCad `Zone`, parameters lossy |
+| `no-schematic-payload` | 5 | 5/5 | no schematic in *any* record, despite "schematic-coupled" |
+| `inner-copper-layer` | 2 | 2/5 | >2-layer stackup must be synthesized |
+| `through-hole-pad-without-diameter` | 16 (OmniLayout drop only) | 2/5 | annular ring must be inferred from the DRU |
+
+Three of these are more than converter chores:
+
+1. **The airwires make the "ground truth" not fully routed.** The SparkFun
+   board ships 61 GND wires on Eagle layer 19 (*Unrouted* — ratsnest stubs with
+   `width: 0.0`), and its `board_semantics.errors.approved` list carries matching
+   `19,…` approved-error hashes. The GND net is pour-connected, not
+   trace-connected. Any route-vs-human harness that treats `routing_wires`
+   as copper would both inflate wire counts and mis-score net completion.
+2. **"Schematic-coupled" is a property of the paper, not of the release.** No
+   record in either drop carries a schematic, so the LVS / net-status
+   validation-breadth motivation in #4830 gets nothing from this data.
+3. **The declared layer count is not the populated layer count.** Tiny BLE and
+   WM1302 declare layers 1, 2, 15, 16 active, but no reference copper *or* pour
+   appears on layer 2 in the export. Either those boards route on 1/15/16, or
+   the export dropped a plane. Unresolved — and it must be resolved before any
+   layer-count-sensitive metric derived from this data is trusted.
+
+## 4. Licence: none granted
+
+| Asset | Licence found | Evidence |
+|-------|---------------|----------|
+| omnieda.com site | none | no licence/terms text anywhere in either page's source |
+| Sample data archives | none | no `LICENSE`/`COPYING` in either zip (5 JSONs; 89 files) |
+| Visualization scripts | none | no header, no licence string |
+| Both papers | **CC BY-NC-ND 4.0** | arXiv licence link on 2607.03261 and 2608.04434 |
+| Underlying boards | third-party, non-SPDX | e.g. `adafruit/Adafruit-FunHouse-PCB` and `sparkfun/SparkFun_Ultrasonic_Distance_Sensor-Qwiic` are `NOASSERTION` (custom hardware licences, typically CC BY-SA with attribution/share-alike duties) |
+
+The only *stated* licence covers the papers and is both **non-commercial** and
+**no-derivatives** — the two properties a benchmark corpus most needs to not
+have. The data itself carries no grant at all, and the redistribution does not
+surface the upstream hardware licences it is derived from. That is
+disqualifying for vendoring, for a committed pointer manifest, and for
+publishing any derived board artifact.
+
+Contrast with what slice 2 already landed: `bshada/open-schematics` is
+**CC-BY-4.0**, KiCad-native, versioned on Hugging Face, and pinned by
+`sha256` in `scripts/corpus/manifests/open-schematics-sample.json`. For every
+purpose #4830 lists — parser hardening, routability ground truth,
+placement/router benchmarking, LVS breadth — it is the better corpus and it is
+already wired up.
+
+## 5. The part worth keeping: the metric protocol
+
+OmniRouting's metric vocabulary is well specified and close to ours. Mapping it
+onto `BenchmarkResult` (see [Routing Benchmark Suite](../guides/benchmarking.md)):
+
+| OmniEDA metric | Definition | kicad-tools today |
+|----------------|------------|-------------------|
+| NRR | % of required nets connected **and** free of DRC violations | partial — `nets_fully_routed / nets_total` does **not** require DRC-clean |
+| PRR | % of DRC-clean pad-to-pad connections | missing — we score at net granularity only |
+| Open / PShort / NShort | % of nets affected by opens / physical shorts / logical shorts | partial — `kct net-status` and LVS decide this per net, but not as a rate split |
+| Total / Clr. / Dist. | mean violation counts, split by cause | partial — `drc_violations` is a single board-level `error_count` |
+| Polygon | % of outputs carrying a copper pour | available via zones; not reported |
+| TWL | routed centerline length | `total_length_mm` |
+| #Vias / #Layers | via and layer counts | `total_vias`; layers not reported |
+| PR | fraction of inputs producing a loadable output | n/a for a deterministic router |
+| RT | runtime | `routing_time_sec` |
+| OO / OoB / HPWL / NC / NS (placement) | overlap area, out-of-bounds count, half-perimeter wirelength, crossings, net separation | HPWL yes (`optim`); overlap/OoB enforced but not *scored*; NC/NS missing |
+
+The three worth adopting, in order, all of which are generic library capability
+and none of which need their data:
+
+1. **DRC-attributed net completion (NRR).** Today a net counts as routed if its
+   pads share a connected component; a net routed *through* a clearance
+   violation still scores. Attributing DRC errors to nets and reporting a
+   clean-completion rate is a strictly better regression signal.
+2. **Pad-pair routability (PRR).** Net-level completion hides partial progress
+   on high-fanout nets; a pad-pair denominator makes a 40-pad GND net comparable
+   to a 2-pad signal.
+3. **Violation split by cause (Clr. / Dist.) and the open/physical-short/
+   logical-short split.** We have all the underlying checks; we report a scalar.
+
+## 6. Recommended next steps
+
+1. **Do not** add OmniEDA data to `scripts/corpus/manifests/` or any fetch path.
+   Slice 4's capacity-predictor calibration and route-vs-human harness should be
+   built on the open-schematics manifest instead — it is CC-BY-4.0, KiCad-native,
+   and each record already pairs a schematic with a human-completed board.
+2. **File the metric work as its own issue(s)** against the benchmark suite:
+   DRC-attributed NRR, pad-pair PRR, and the violation-cause split, citing this
+   document for the external definitions. These are the durable outcome of this
+   recon.
+3. **Keep `scripts/corpus/omnieda_sample.py`.** It is the re-evaluation
+   instrument: point it at any future drop and the gap census answers "has the
+   blocking data actually appeared?" in one run.
+4. **Watch for the promised open-source release.** Concretely: a Hugging Face
+   dataset under an explicit licence, or a GitHub repo with the evaluation
+   harness. On either, re-run this recon; the converter scope is the gap table
+   in §3 (footprint synthesis, Eagle rotation/mirror semantics, arc bulges,
+   pours, stackup) and the airwire filter is a hard prerequisite.
+5. **If a converter is ever built**, put it in `scripts/corpus/` as a dev tool,
+   not in the installed package — this repo emits KiCad; an Eagle-JSON reader is
+   research scaffolding, not product surface.
+
+## Attribution
+
+- T. Lu, K. Lin, M. Wang, et al., "OmniLayout: A Schematic-Coupled Multimodal
+  Benchmark for Constraint-Aware Geometric Reasoning in PCB Layout,"
+  arXiv:2607.03261, 2026.
+- T. Lu, K. Lin, Z. Dong, et al., "OmniRouting: A Semantic-Coupled Multimodal
+  Benchmark for Constraint-Aware Spatial Reasoning in PCB Routing,"
+  arXiv:2608.04434, 2026.
+
+Sample boards are third-party open hardware (Adafruit, SparkFun, Seeed); their
+own hardware licences govern any use of the underlying designs.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -62,8 +62,19 @@ uv run python scripts/corpus/check_manifest.py --offline  # cache only, ~8 s
 uv run python scripts/corpus/build_manifest.py --n 30 --scan 90 --seed 4830
 ```
 
+`omnieda_sample.py` — **offline**; characterize a manually-downloaded
+OmniLayout / OmniRouting sample (Eagle-derived JSON, *not* KiCad files) and
+census the fields that have no `schema.pcb` counterpart. Download steps, the
+measured numbers, and the adopt/adapt/drop verdict live in
+[`docs/research/omnilayout-recon.md`](../docs/research/omnilayout-recon.md):
+
+```bash
+uv run python scripts/corpus/omnieda_sample.py --sample /path/to/extracted --out /tmp/omni
+```
+
 The pure helpers `corpus/parse_taxonomy.py` and `corpus/corpus_manifest.py` (no
-network, no CLI) are unit-tested by `tests/test_corpus_manifest.py`.
+network, no CLI) are unit-tested by `tests/test_corpus_manifest.py`;
+`corpus/omnieda_sample.py` (offline) by `tests/test_corpus_omnieda.py`.
 
 ### `research/`
 

--- a/scripts/corpus/README.md
+++ b/scripts/corpus/README.md
@@ -13,6 +13,7 @@ in CI — the network scripts are run by hand and are never imported from `tests
 | `hf_hub.py` | library, network | Hugging Face datasets-server access (retry/backoff) |
 | `parse_taxonomy.py` | library, **pure** | Outcome buckets, format sniffing, exception classification |
 | `corpus_manifest.py` | library, **pure** | Manifest schema/validation, cache integrity, scoring, rendering |
+| `omnieda_sample.py` | CLI + library, **offline** | Characterize an OmniLayout/OmniRouting sample and census its KiCad-mappability gaps (slice 3) |
 
 These scripts import each other by plain module name (the script's own directory
 is `sys.path[0]` when you run `python scripts/corpus/<script>.py`). Type-check
@@ -25,7 +26,9 @@ MYPYPATH=scripts/corpus uv run mypy scripts/corpus/   # Success: no issues found
 The two pure modules are the tested surface (`tests/test_corpus_manifest.py`);
 they do no network I/O and have no CLI, which is why importing them from the test
 suite does not violate the "no network in pytest" rule that keeps the network
-scripts out of `tests/`.
+scripts out of `tests/`. `omnieda_sample.py` is tested for the same reason
+(`tests/test_corpus_omnieda.py`): it has a CLI but no network — its input is a
+sample you downloaded by hand.
 
 ## `probe_open_schematics.py`
 
@@ -208,3 +211,28 @@ Before redistributing (or vendoring) an *individual* board, verify that specific
 project's license — the dataset license covers the collection, not necessarily
 every constituent design. Per issue #4830 the corpus is referenced by URL +
 revision sha, never mirrored into this repo.
+
+## `omnieda_sample.py` — OmniLayout / OmniRouting recon (slice 3)
+
+Different corpus, different rules. The [OmniLayout benchmark](https://www.omnieda.com/)
+does **not** ship KiCad files: its records are JSON transcriptions of Eagle
+`.brd` boards, so none of the tooling above (which drives `PCB.load` /
+`Schematic.load`) can be pointed at them. This script is the substitute
+measurement — per record it reports what the data contains and which fields have
+no counterpart in `kicad_tools.schema.pcb`:
+
+```bash
+uv run python scripts/corpus/omnieda_sample.py --sample /path/to/extracted --out /tmp/omni
+```
+
+It is **offline**: the sample lives behind interactive Google Drive links, so
+you download and extract by hand and pass the directory. The download commands,
+the SHA-256 of the archives that were measured, the full gap census, and the
+adopt / adapt / drop verdict are in
+[`docs/research/omnilayout-recon.md`](../../docs/research/omnilayout-recon.md).
+
+**Do not add OmniEDA data to `manifests/`.** Unlike open-schematics (CC-BY-4.0),
+the OmniEDA release carries no data license at all — the only stated license is
+CC BY-NC-ND 4.0 on the papers. The script exists as the re-evaluation
+instrument for a future, properly licensed release; nothing from that corpus is
+fetched, cached or committed here.

--- a/scripts/corpus/omnieda_sample.py
+++ b/scripts/corpus/omnieda_sample.py
@@ -1,0 +1,398 @@
+#!/usr/bin/env python3
+"""Characterize an OmniEDA (OmniLayout / OmniRouting) sample drop (issue #4830, slice 3).
+
+The OmniLayout benchmark (https://www.omnieda.com/) does **not** distribute
+KiCad files: its records are JSON transcriptions of Eagle ``.brd`` boards, so
+none of the slice-1/slice-2 corpus tooling (which drives
+``kicad_tools.schema.PCB.load`` / ``Schematic.load``) can be pointed at them.
+This module is the substitute measurement: it reads an already-downloaded
+sample directory and reports, per board, what the records actually contain and
+which fields have **no representation** in ``kicad_tools.schema.pcb`` today.
+
+That second half is the point. A "can we convert this to ``.kicad_pcb``?"
+question is only answerable as a list of concrete gaps, each of which maps to a
+different piece of converter work (or to a decision not to do it). The gap
+constants below are chosen on that basis -- see ``docs/research/omnilayout-recon.md``
+for the resulting adopt / adapt / drop recommendation.
+
+**Offline by construction.** The sample lives behind interactive Google Drive
+links, so there is no fetch step here to get wrong: you download by hand (the
+recon doc records the exact commands and the SHA-256 of what we measured) and
+point ``--sample`` at the extracted directory. No network, no repo writes
+outside the caller-supplied output path -- which is why ``tests/`` may import
+this module while the slice-1/2 network scripts stay out of the test suite.
+
+Usage::
+
+    python scripts/corpus/omnieda_sample.py --sample /path/to/extracted --out /tmp/omni
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+# ---------------------------------------------------------------------------
+# Record flavors
+# ---------------------------------------------------------------------------
+
+FLAVOR_LAYOUT = "omnilayout-placement"  # placement-only record (OmniLayout drop)
+FLAVOR_ROUTING = "omnirouting-graph"  # + reference routing (OmniRouting drop)
+FLAVOR_UNKNOWN = "unknown"
+
+_LAYOUT_KEYS = frozenset({"netlist", "board_boundary", "ic_library", "ic_position"})
+_ROUTING_KEYS = frozenset({"routing_wires", "routing_vias"})
+
+# Eagle numbers copper layers 1..16 (1 = Top, 16 = Bottom, 2..15 inner).
+# Everything above 16 is documentation/system: 17 Pads, 18 Vias, 19 *Unrouted*,
+# 20 Dimension, 21 tPlace.  A "wire" on 19 is a ratsnest airwire, not copper --
+# counting it as routed copper would silently inflate any route-vs-human score.
+EAGLE_COPPER_LAYERS = frozenset(str(n) for n in range(1, 17))
+EAGLE_TOP = "1"
+EAGLE_BOTTOM = "16"
+EAGLE_UNROUTED = "19"
+
+# ---------------------------------------------------------------------------
+# Mappability gaps -- one constant per *distinct* piece of converter work.
+# ---------------------------------------------------------------------------
+
+GAP_PLACEMENT_WITHOUT_GEOMETRY = "placement-without-footprint-geometry"
+GAP_MISSING_ROTATION = "component-missing-rotation"
+GAP_TH_PAD_NO_DIAMETER = "through-hole-pad-without-diameter"
+GAP_AIRWIRE_AS_ROUTING = "airwire-counted-as-routing"
+GAP_CURVED_COPPER = "curved-copper-segment"
+GAP_INNER_LAYER = "inner-copper-layer"
+GAP_BLIND_BURIED_VIA = "blind-or-buried-via"
+GAP_COPPER_POUR = "copper-pour-polygon"
+GAP_NO_SCHEMATIC = "no-schematic-payload"
+
+#: Every gap, with the converter work it implies.  Ordered from "blocks a
+#: faithful conversion" to "cosmetic".
+GAP_NOTES: dict[str, str] = {
+    GAP_PLACEMENT_WITHOUT_GEOMETRY: (
+        "element is placed but has no ic_library entry -- no pads to emit, so the "
+        "footprint cannot be reconstructed from the record alone"
+    ),
+    GAP_MISSING_ROTATION: (
+        "ic_library entry has no rotation key; the converter must fall back to the "
+        "ic_position rotation or assume R0"
+    ),
+    GAP_TH_PAD_NO_DIAMETER: (
+        "through-hole pad gives a drill but no diameter; annular ring has to be "
+        "inferred from the Eagle design rules (rvPad*/rlMinPad*)"
+    ),
+    GAP_AIRWIRE_AS_ROUTING: (
+        "wire sits on Eagle layer 19 (Unrouted) -- a ratsnest stub, not copper; it "
+        "must be excluded from routed-length and completion metrics"
+    ),
+    GAP_CURVED_COPPER: (
+        "wire has a non-zero Eagle curve (arc bulge); schema.pcb models copper as "
+        "(segment ...) only, so an arc needs polyline approximation"
+    ),
+    GAP_INNER_LAYER: (
+        "board uses Eagle inner copper (layers 2..15); the converter must synthesize "
+        "a >2-layer KiCad stackup rather than the default two"
+    ),
+    GAP_BLIND_BURIED_VIA: (
+        "via extent is not the full 1-16 stack; needs blind/buried via emission"
+    ),
+    GAP_COPPER_POUR: (
+        "record carries Eagle polygon pours; these map to KiCad zones but the pour "
+        "parameters (rank/isolate/thermals) do not translate one-to-one"
+    ),
+    GAP_NO_SCHEMATIC: (
+        "record has no schematic payload despite the benchmark being billed as "
+        "schematic-coupled; LVS/net-status validation cannot be exercised on it"
+    ),
+}
+
+
+@dataclass
+class BoardAudit:
+    """Per-record characterization plus the KiCad-mappability gap census."""
+
+    name: str
+    flavor: str
+    components: int = 0
+    placements: int = 0
+    nets: int = 0
+    connections: int = 0
+    smd_pads: int = 0
+    th_pads: int = 0
+    holes: int = 0
+    boundary_segments: int = 0
+    boundary_closed: bool = False
+    copper_wires: int = 0
+    vias: int = 0
+    pours: int = 0
+    copper_layers: list[str] = field(default_factory=list)
+    clearance_mm: float | None = None
+    eagle_version: str = ""
+    designrule_set: str = ""
+    gaps: dict[str, int] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "name": self.name,
+            "flavor": self.flavor,
+            "components": self.components,
+            "placements": self.placements,
+            "nets": self.nets,
+            "connections": self.connections,
+            "smd_pads": self.smd_pads,
+            "th_pads": self.th_pads,
+            "holes": self.holes,
+            "boundary_segments": self.boundary_segments,
+            "boundary_closed": self.boundary_closed,
+            "copper_wires": self.copper_wires,
+            "vias": self.vias,
+            "pours": self.pours,
+            "copper_layers": self.copper_layers,
+            "clearance_mm": self.clearance_mm,
+            "eagle_version": self.eagle_version,
+            "designrule_set": self.designrule_set,
+            "gaps": dict(sorted(self.gaps.items())),
+        }
+
+
+def sniff_flavor(record: Any) -> str:
+    """Classify a decoded JSON record as a layout / routing / unknown drop."""
+    if not isinstance(record, dict):
+        return FLAVOR_UNKNOWN
+    keys = frozenset(record)
+    if not keys >= _LAYOUT_KEYS:
+        return FLAVOR_UNKNOWN
+    if _ROUTING_KEYS & keys:
+        return FLAVOR_ROUTING
+    return FLAVOR_LAYOUT
+
+
+def _as_list(value: Any) -> list[Any]:
+    """Eagle-derived JSON collapses single-element lists to a bare object."""
+    if value is None:
+        return []
+    if isinstance(value, list):
+        return value
+    return [value]
+
+
+def _bump(gaps: dict[str, int], key: str, count: int = 1) -> None:
+    if count:
+        gaps[key] = gaps.get(key, 0) + count
+
+
+def audit_record(name: str, record: Any) -> BoardAudit:
+    """Characterize one decoded record and census its KiCad-mappability gaps."""
+    flavor = sniff_flavor(record)
+    audit = BoardAudit(name=name, flavor=flavor)
+    if flavor == FLAVOR_UNKNOWN:
+        return audit
+
+    assert isinstance(record, dict)  # narrowed by sniff_flavor
+    gaps = audit.gaps
+
+    library = _as_list(record.get("ic_library"))
+    placements = _as_list(record.get("ic_position"))
+    audit.components = len(library)
+    audit.placements = len(placements)
+
+    known = {entry.get("element_name") for entry in library if isinstance(entry, dict)}
+    orphan_placements = sum(
+        1
+        for entry in placements
+        if isinstance(entry, dict) and entry.get("element_name") not in known
+    )
+    _bump(gaps, GAP_PLACEMENT_WITHOUT_GEOMETRY, orphan_placements)
+
+    for entry in library:
+        if not isinstance(entry, dict):
+            continue
+        smd = _as_list(entry.get("smd"))
+        pads = _as_list(entry.get("pads"))
+        audit.smd_pads += len(smd)
+        audit.th_pads += len(pads)
+        audit.holes += len(_as_list(entry.get("holes")))
+        if entry.get("rotation") is None:
+            _bump(gaps, GAP_MISSING_ROTATION)
+        for pad in pads:
+            if isinstance(pad, dict) and pad.get("diameter") is None:
+                _bump(gaps, GAP_TH_PAD_NO_DIAMETER)
+
+    nets = _as_list(record.get("netlist"))
+    audit.nets = len(nets)
+    audit.connections = sum(
+        len(_as_list(net.get("contactref"))) for net in nets if isinstance(net, dict)
+    )
+
+    boundary = record.get("board_boundary")
+    if isinstance(boundary, dict):
+        audit.boundary_segments = len(_as_list(boundary.get("segment_details")))
+        audit.boundary_closed = bool(boundary.get("closed"))
+
+    layers: set[str] = set()
+    for wire in _as_list(record.get("routing_wires")):
+        if not isinstance(wire, dict):
+            continue
+        layer = str(wire.get("layer"))
+        if layer in EAGLE_COPPER_LAYERS:
+            audit.copper_wires += 1
+            layers.add(layer)
+            if wire.get("curve"):
+                _bump(gaps, GAP_CURVED_COPPER)
+        elif layer == EAGLE_UNROUTED:
+            _bump(gaps, GAP_AIRWIRE_AS_ROUTING)
+    inner = sorted(layers - {EAGLE_TOP, EAGLE_BOTTOM}, key=int)
+    _bump(gaps, GAP_INNER_LAYER, len(inner))
+    audit.copper_layers = sorted(layers, key=int)
+
+    vias = _as_list(record.get("routing_vias"))
+    audit.vias = len(vias)
+    for via in vias:
+        if isinstance(via, dict) and str(via.get("extent")) not in (
+            f"{EAGLE_TOP}-{EAGLE_BOTTOM}",
+            "None",
+        ):
+            _bump(gaps, GAP_BLIND_BURIED_VIA)
+
+    pours = _as_list(record.get("copper_pours"))
+    audit.pours = len(pours)
+    _bump(gaps, GAP_COPPER_POUR, len(pours))
+
+    clearance = record.get("Clearance")
+    if isinstance(clearance, dict):
+        rules = clearance.get("rules")
+        if isinstance(rules, dict):
+            widths = [v for v in rules.values() if isinstance(v, (int, float)) and v > 0]
+            if widths:
+                audit.clearance_mm = min(widths)
+
+    semantics = record.get("board_semantics")
+    if isinstance(semantics, dict):
+        audit.eagle_version = str(semantics.get("eagle_version") or "")
+        rules_block = semantics.get("designrules")
+        if isinstance(rules_block, dict):
+            audit.designrule_set = str(rules_block.get("name") or "")
+
+    # No OmniEDA record shipped so far carries a schematic payload, despite the
+    # "schematic-coupled" billing; assert it per record so a future drop that
+    # *does* include one shows up as the gap disappearing.
+    if not any(key in record for key in ("schematic", "sch", "schematic_graph")):
+        _bump(gaps, GAP_NO_SCHEMATIC)
+
+    return audit
+
+
+def load_sample(sample_dir: Path) -> list[tuple[str, Any]]:
+    """Load every ``*.json`` under ``sample_dir`` (recursively), sorted by path."""
+    records: list[tuple[str, Any]] = []
+    for path in sorted(sample_dir.rglob("*.json")):
+        try:
+            with path.open(encoding="utf-8") as handle:
+                records.append((str(path.relative_to(sample_dir)), json.load(handle)))
+        except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
+            records.append((str(path.relative_to(sample_dir)), {"__error__": str(exc)}))
+    return records
+
+
+def render_report(audits: list[BoardAudit]) -> str:
+    """Human-readable summary: per-board table, then the pooled gap census."""
+    lines: list[str] = []
+    lines.append("OmniEDA sample audit")
+    lines.append("=" * 72)
+    scored = [a for a in audits if a.flavor != FLAVOR_UNKNOWN]
+    lines.append(
+        f"records: {len(audits)}  recognized: {len(scored)}  "
+        f"unrecognized: {len(audits) - len(scored)}"
+    )
+    if not scored:
+        lines.append("")
+        lines.append("No OmniEDA records found -- is --sample pointing at the extract?")
+        return "\n".join(lines) + "\n"
+
+    lines.append("")
+    header = (
+        f"{'board':<44}{'flavor':<22}{'cmp':>5}{'nets':>6}"
+        f"{'pads':>6}{'wires':>7}{'vias':>6}{'cu':>10}"
+    )
+    lines.append(header)
+    lines.append("-" * len(header))
+    for audit in scored:
+        name = audit.name if len(audit.name) <= 43 else audit.name[:40] + "..."
+        cu = ",".join(audit.copper_layers) or "-"
+        lines.append(
+            f"{name:<44}{audit.flavor:<22}{audit.components:>5}{audit.nets:>6}"
+            f"{audit.smd_pads + audit.th_pads:>6}{audit.copper_wires:>7}"
+            f"{audit.vias:>6}{cu:>10}"
+        )
+
+    pooled: dict[str, int] = {}
+    affected: dict[str, int] = {}
+    for audit in scored:
+        for key, count in audit.gaps.items():
+            pooled[key] = pooled.get(key, 0) + count
+            affected[key] = affected.get(key, 0) + 1
+
+    lines.append("")
+    lines.append("KiCad-mappability gaps (occurrences / boards affected)")
+    lines.append("-" * 72)
+    if not pooled:
+        lines.append("  none -- every field in this sample has a schema.pcb counterpart")
+    for key, count in sorted(pooled.items(), key=lambda kv: (-kv[1], kv[0])):
+        lines.append(f"  {key:<38} {count:>6}  on {affected[key]}/{len(scored)} boards")
+        lines.append(f"      {GAP_NOTES.get(key, '(no note)')}")
+    return "\n".join(lines) + "\n"
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Characterize a manually-downloaded OmniLayout/OmniRouting sample "
+            "(offline; see docs/research/omnilayout-recon.md for the download steps)."
+        )
+    )
+    parser.add_argument(
+        "--sample",
+        required=True,
+        type=Path,
+        help="directory holding the extracted sample JSON files",
+    )
+    parser.add_argument(
+        "--out",
+        type=Path,
+        default=None,
+        help="write the machine-readable audit here (default: stdout summary only)",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    sample_dir: Path = args.sample
+    if not sample_dir.is_dir():
+        print(f"error: --sample is not a directory: {sample_dir}", file=sys.stderr)
+        return 2
+
+    audits = [audit_record(name, record) for name, record in load_sample(sample_dir)]
+    print(render_report(audits))
+
+    if args.out is not None:
+        out: Path = args.out
+        if out.suffix != ".json":
+            out = out / "omnieda-audit.json"
+        out.parent.mkdir(parents=True, exist_ok=True)
+        payload = {
+            "sample_dir": str(sample_dir),
+            "gap_notes": GAP_NOTES,
+            "boards": [audit.to_dict() for audit in audits],
+        }
+        out.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+        print(f"wrote {out}")
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/tests/test_corpus_omnieda.py
+++ b/tests/test_corpus_omnieda.py
@@ -1,0 +1,290 @@
+"""Tests for the OmniEDA sample audit tool (issue #4830, slice 3).
+
+``scripts/corpus/omnieda_sample.py`` is offline by construction -- the OmniLayout /
+OmniRouting sample drops sit behind interactive Google Drive links and are
+downloaded by hand -- so, unlike the slice-1/2 fetching scripts, it is safe for
+the test suite to import. Everything below runs on synthetic records; no
+third-party payload is vendored or fetched.
+
+The properties worth pinning are the ones a future edit could quietly break:
+flavor sniffing (a placement drop must not be mistaken for a routing drop, since
+only the latter carries reference copper), and the gap census -- particularly
+that an Eagle layer-19 "Unrouted" airwire is **not** counted as routed copper.
+That single confusion would inflate any route-vs-human completion score.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[1]
+CORPUS_DIR = ROOT / "scripts" / "corpus"
+
+# The corpus tooling lives under scripts/, not in the installed package (same
+# convention as tests/test_corpus_manifest.py).
+sys.path.insert(0, str(CORPUS_DIR))
+
+from omnieda_sample import (  # noqa: E402  (sys.path manipulation above)
+    FLAVOR_LAYOUT,
+    FLAVOR_ROUTING,
+    FLAVOR_UNKNOWN,
+    GAP_AIRWIRE_AS_ROUTING,
+    GAP_BLIND_BURIED_VIA,
+    GAP_COPPER_POUR,
+    GAP_CURVED_COPPER,
+    GAP_INNER_LAYER,
+    GAP_MISSING_ROTATION,
+    GAP_NO_SCHEMATIC,
+    GAP_NOTES,
+    GAP_PLACEMENT_WITHOUT_GEOMETRY,
+    GAP_TH_PAD_NO_DIAMETER,
+    audit_record,
+    load_sample,
+    render_report,
+    sniff_flavor,
+)
+
+
+def _placement_record(**overrides: Any) -> dict[str, Any]:
+    """A minimal OmniLayout-shaped record with no gaps except the schematic one."""
+    record: dict[str, Any] = {
+        "netlist": [{"name": "GND", "contactref": [{"element": "R1", "pad": "1"}]}],
+        "board_boundary": {
+            "segment_details": [{"start": [0, 0], "end": [10, 0], "layer": "20", "curve": 0.0}],
+            "unit": "mm",
+            "closed": True,
+            "dxf_details": [],
+        },
+        "ic_library": [
+            {
+                "element_name": "R1",
+                "library_name": "lib",
+                "package_name": "0603",
+                "position": [1.0, 2.0],
+                "rotation": "R90",
+                "smd": [
+                    {
+                        "name": "1",
+                        "position": [0, 0],
+                        "width": 0.8,
+                        "length": 0.8,
+                        "rotation": "R0",
+                        "layer": "1",
+                    }
+                ],
+                "pads": [],
+                "holes": [],
+            }
+        ],
+        "ic_position": [{"element_name": "R1", "position": [1.0, 2.0], "rotation": "R90"}],
+        "ic_dimension": [],
+    }
+    record.update(overrides)
+    return record
+
+
+def _routing_record(**overrides: Any) -> dict[str, Any]:
+    record = _placement_record()
+    record.update(
+        {
+            "routing_wires": [
+                {
+                    "start": [0, 0],
+                    "end": [1, 0],
+                    "width": 0.2,
+                    "layer": "1",
+                    "curve": 0.0,
+                }
+            ],
+            "routing_vias": [{"pos": [1, 1], "drill": 0.3, "extent": "1-16"}],
+            "copper_pours": [],
+            "Clearance": {"unit": "mm", "rules": {"wire": 0.2, "restrict": 0.0}},
+            "board_semantics": {
+                "eagle_version": "9.6.2",
+                "designrules": {"name": "Some-DRU"},
+            },
+        }
+    )
+    record.update(overrides)
+    return record
+
+
+class TestSniffFlavor:
+    def test_placement_drop_is_not_mistaken_for_a_routing_drop(self) -> None:
+        assert sniff_flavor(_placement_record()) == FLAVOR_LAYOUT
+
+    def test_routing_keys_promote_the_flavor(self) -> None:
+        assert sniff_flavor(_routing_record()) == FLAVOR_ROUTING
+
+    def test_non_omnieda_payloads_are_unknown(self) -> None:
+        assert sniff_flavor({"version": 20221018, "footprints": []}) == FLAVOR_UNKNOWN
+        assert sniff_flavor([1, 2, 3]) == FLAVOR_UNKNOWN
+        assert sniff_flavor("(kicad_pcb ...)") == FLAVOR_UNKNOWN
+
+    def test_unknown_records_are_audited_but_empty(self) -> None:
+        audit = audit_record("stray.json", {"nope": True})
+        assert audit.flavor == FLAVOR_UNKNOWN
+        assert audit.components == 0
+        assert audit.gaps == {}
+
+
+class TestAuditCounts:
+    def test_clean_placement_record_reports_only_the_schematic_gap(self) -> None:
+        audit = audit_record("b.json", _placement_record())
+        assert audit.flavor == FLAVOR_LAYOUT
+        assert (audit.components, audit.placements) == (1, 1)
+        assert (audit.nets, audit.connections) == (1, 1)
+        assert (audit.smd_pads, audit.th_pads) == (1, 0)
+        assert audit.boundary_segments == 1
+        assert audit.boundary_closed is True
+        assert audit.gaps == {GAP_NO_SCHEMATIC: 1}
+
+    def test_routing_record_captures_copper_and_rules(self) -> None:
+        audit = audit_record("b.json", _routing_record())
+        assert audit.flavor == FLAVOR_ROUTING
+        assert audit.copper_wires == 1
+        assert audit.copper_layers == ["1"]
+        assert audit.vias == 1
+        assert audit.clearance_mm == 0.2
+        assert audit.eagle_version == "9.6.2"
+        assert audit.designrule_set == "Some-DRU"
+
+    def test_singleton_lists_collapsed_by_the_eagle_export_are_tolerated(self) -> None:
+        # Eagle-derived JSON writes a bare object where a one-element list was.
+        record = _placement_record()
+        record["netlist"] = {
+            "name": "GND",
+            "contactref": {"element": "R1", "pad": "1"},
+        }
+        record["ic_library"] = record["ic_library"][0]
+        record["ic_position"] = record["ic_position"][0]
+        audit = audit_record("b.json", record)
+        assert (audit.nets, audit.connections) == (1, 1)
+        assert (audit.components, audit.placements) == (1, 1)
+        assert audit.gaps == {GAP_NO_SCHEMATIC: 1}
+
+    def test_a_schematic_payload_clears_the_schematic_gap(self) -> None:
+        audit = audit_record("b.json", _placement_record(schematic={"sheets": []}))
+        assert GAP_NO_SCHEMATIC not in audit.gaps
+
+
+class TestGapCensus:
+    def test_placement_without_geometry_is_counted(self) -> None:
+        record = _placement_record()
+        record["ic_position"].append(
+            {"element_name": "GHOST", "position": [0, 0], "rotation": "R0"}
+        )
+        assert audit_record("b.json", record).gaps[GAP_PLACEMENT_WITHOUT_GEOMETRY] == 1
+
+    def test_missing_rotation_is_counted(self) -> None:
+        record = _placement_record()
+        del record["ic_library"][0]["rotation"]
+        assert audit_record("b.json", record).gaps[GAP_MISSING_ROTATION] == 1
+
+    def test_through_hole_pad_without_diameter_is_counted(self) -> None:
+        record = _placement_record()
+        record["ic_library"][0]["pads"] = [
+            {"name": "1", "position": [0, 0], "drill": 0.4},
+            {"name": "2", "position": [1, 0], "drill": 0.4, "diameter": 0.9},
+        ]
+        audit = audit_record("b.json", record)
+        assert audit.th_pads == 2
+        assert audit.gaps[GAP_TH_PAD_NO_DIAMETER] == 1
+
+    def test_layer_19_airwire_is_not_copper(self) -> None:
+        record = _routing_record()
+        record["routing_wires"].append(
+            {"start": [0, 0], "end": [5, 5], "width": 0.0, "layer": "19", "curve": 0.0}
+        )
+        audit = audit_record("b.json", record)
+        assert audit.copper_wires == 1  # the airwire is excluded
+        assert audit.gaps[GAP_AIRWIRE_AS_ROUTING] == 1
+
+    def test_curved_copper_is_counted_but_still_copper(self) -> None:
+        record = _routing_record()
+        record["routing_wires"].append(
+            {"start": [0, 0], "end": [5, 5], "width": 0.2, "layer": "16", "curve": 42.0}
+        )
+        audit = audit_record("b.json", record)
+        assert audit.copper_wires == 2
+        assert audit.gaps[GAP_CURVED_COPPER] == 1
+
+    def test_inner_layers_counted_once_per_layer(self) -> None:
+        record = _routing_record()
+        for layer in ("2", "2", "15", "16"):
+            record["routing_wires"].append(
+                {
+                    "start": [0, 0],
+                    "end": [1, 1],
+                    "width": 0.2,
+                    "layer": layer,
+                    "curve": 0.0,
+                }
+            )
+        audit = audit_record("b.json", record)
+        assert audit.copper_layers == ["1", "2", "15", "16"]
+        assert audit.gaps[GAP_INNER_LAYER] == 2
+
+    def test_blind_or_buried_via_is_counted(self) -> None:
+        record = _routing_record()
+        record["routing_vias"].append({"pos": [2, 2], "drill": 0.3, "extent": "1-2"})
+        audit = audit_record("b.json", record)
+        assert audit.vias == 2
+        assert audit.gaps[GAP_BLIND_BURIED_VIA] == 1
+
+    def test_copper_pours_are_counted(self) -> None:
+        record = _routing_record()
+        record["copper_pours"] = [{"signal": "GND", "layer": "16"}]
+        audit = audit_record("b.json", record)
+        assert audit.pours == 1
+        assert audit.gaps[GAP_COPPER_POUR] == 1
+
+    def test_every_gap_constant_has_a_note(self) -> None:
+        # A gap with no note is a number nobody can act on.
+        record = _routing_record()
+        record["ic_position"].append({"element_name": "GHOST", "position": [0, 0]})
+        del record["ic_library"][0]["rotation"]
+        record["ic_library"][0]["pads"] = [{"name": "1", "position": [0, 0], "drill": 0.4}]
+        record["routing_wires"].append(
+            {"start": [0, 0], "end": [1, 1], "width": 0.0, "layer": "19", "curve": 0.0}
+        )
+        record["routing_wires"].append(
+            {"start": [0, 0], "end": [1, 1], "width": 0.2, "layer": "2", "curve": 9.0}
+        )
+        record["routing_vias"].append({"pos": [2, 2], "drill": 0.3, "extent": "1-2"})
+        record["copper_pours"] = [{"signal": "GND", "layer": "16"}]
+        audit = audit_record("b.json", record)
+        assert set(audit.gaps) == set(GAP_NOTES)
+        assert all(GAP_NOTES[key] for key in audit.gaps)
+
+
+class TestSampleLoadingAndReport:
+    def test_load_sample_reads_nested_json_and_survives_garbage(self, tmp_path: Path) -> None:
+        (tmp_path / "nested").mkdir()
+        good = tmp_path / "nested" / "board.json"
+        good.write_text(json.dumps(_placement_record()), encoding="utf-8")
+        (tmp_path / "broken.json").write_text("{not json", encoding="utf-8")
+
+        records = dict(load_sample(tmp_path))
+        assert set(records) == {"broken.json", str(Path("nested") / "board.json")}
+        assert "__error__" in records["broken.json"]
+        assert sniff_flavor(records[str(Path("nested") / "board.json")]) == FLAVOR_LAYOUT
+
+    def test_report_lists_boards_and_pooled_gaps(self) -> None:
+        audits = [
+            audit_record("alpha.json", _placement_record()),
+            audit_record("beta.json", _routing_record()),
+        ]
+        text = render_report(audits)
+        assert "alpha.json" in text and "beta.json" in text
+        assert FLAVOR_ROUTING in text
+        assert f"{GAP_NO_SCHEMATIC:<38}" in text
+        assert "on 2/2 boards" in text
+
+    def test_report_is_explicit_when_nothing_was_recognized(self) -> None:
+        text = render_report([audit_record("x.json", {"nope": True})])
+        assert "unrecognized: 1" in text
+        assert "--sample" in text


### PR DESCRIPTION
Part of #4830 (slice 3 of 4: OmniLayout recon). Slices 1 (#4839) and 2 (#4858) merged; slice 4 (feasibility notes) remains, so this does **not** close the issue.

## Verdict: adapt the protocol, drop the data

I downloaded and characterized the OmniEDA benchmark — [OmniLayout](https://arxiv.org/abs/2607.03261) and its sibling [OmniRouting](https://arxiv.org/abs/2608.04434), which share the same 1,681-design collection — and recommend **declining the dataset** while **adapting its metric protocol**.

| Question | Answer |
|----------|--------|
| Adopt the dataset? | **No** — no data licence of any kind; the public drop is 5 boards behind Google Drive links |
| Adopt the tooling? | **No** — only a matplotlib renderer is released; the evaluation harness is not |
| Adapt anything? | **Yes** — the metric vocabulary, implementable against our own boards + the CC-BY-4.0 open-schematics manifest at zero licence risk |
| Build a JSON → `.kicad_pcb` converter? | **Not now** — feasible (gap list is short and bounded) but there is nothing licensed to convert |

### Key evidence

- **Licence: none granted.** No licence text on either site page, none in either archive (5 JSONs / 89 files), none in the released scripts. The only *stated* licence is **CC BY-NC-ND 4.0** on the two papers — non-commercial *and* no-derivatives. The redistribution also doesn't surface the upstream hardware licences it derives from (`adafruit/Adafruit-FunHouse-PCB`, `sparkfun/SparkFun_Ultrasonic_Distance_Sensor-Qwiic` are `NOASSERTION` custom hardware licences). Contrast slice 2's corpus: CC-BY-4.0, KiCad-native, HF-versioned, sha256-pinned.
- **Not KiCad.** Every record is a JSON transcription of an Eagle 9.6.2 `.brd` (Eagle layer numbers, `R90`/`MR270` rotations, `contactref` netlists, `curve` bulges, `mdWireVia` DRU params). No slice-1/2 tooling can be pointed at it — hence the substitute measurement in this PR.
- **Not the advertised scale.** 5 hand-picked boards, not 1,681; the site's arXiv/Code/Data/Hugging Face buttons are all `href="#"`; HF and GitHub searches return nothing.
- **Three traps a naive harness would hit**, each measured: 61 of one board's "routing wires" are on Eagle layer 19 (*Unrouted* ratsnest stubs, `width: 0.0`, with matching approved-error hashes) — counting them as copper would corrupt completion and length metrics; **no** record carries a schematic despite the "schematic-coupled" billing (so the LVS-breadth motivation gets nothing); and two boards declare an inner copper layer that carries neither trace nor pour.
- **The two drops differ.** OmniRouting is a strictly richer re-export of the same boards — e.g. FunHouse pad `U3/43_10` is `{drill: 0.4}` in the OmniLayout drop and `{drill: 0.4, diameter: 0.908, diameter_source: "drc_restring"}` in the routing one.

### What's worth keeping

OmniRouting's metric vocabulary is the sharpest external definition of "routed well" I found, and maps cleanly onto `BenchmarkResult`. Three gaps worth filing as their own issues (all generic library capability, none needing their data):

1. **DRC-attributed net completion (NRR)** — today a net counts as routed if its pads share a connected component; a net routed *through* a clearance violation still scores.
2. **Pad-pair routability (PRR)** — net-level completion hides partial progress on high-fanout nets.
3. **Violation split by cause** (clearance vs distance) and the open / physical-short / logical-short split — we have the underlying checks, we report a scalar.

## Changes

- `docs/research/omnilayout-recon.md` (new) — the deliverable: provenance table (URLs, SHA-256, sizes, reproduction commands), what the benchmark is, schema-vs-KiCad field mapping, the gap census, the licence finding, the metric-protocol mapping, and 5 numbered next steps + the re-evaluation trigger. Indexed from `docs/README.md`.
- `scripts/corpus/omnieda_sample.py` (new, **offline**) — the instrument that produced the numbers: per-board contents plus a census of fields with no `kicad_tools.schema.pcb` counterpart, each gap constant carrying the converter work it implies. Offline because the sample sits behind interactive Drive links, which is also why `tests/` may import it (the slice-1/2 network scripts still may not).
- `tests/test_corpus_omnieda.py` (new) — 20 tests on synthetic records; the load-bearing one pins that an Eagle layer-19 airwire is *not* counted as copper.
- `scripts/README.md`, `scripts/corpus/README.md` — invocation + an explicit "do not add OmniEDA data to `manifests/`" note.
- `CHANGELOG.md` — `[Unreleased]` entry citing #4830.

**No third-party bytes fetched, cached or committed.** Nothing new runs in CI; no new dependencies.

## Testing

```
uv run pytest tests -k corpus -q --no-cov     # 73 passed, 9 skipped
uv run ruff check / format --check            # clean on touched paths
MYPYPATH=scripts/corpus uv run mypy scripts/corpus/omnieda_sample.py --no-incremental   # Success
uv run python scripts/ci/check_mypy_baseline.py  # OK, 1464/1472, no new errors
uv run pytest tests/test_check_doc_drift.py tests/test_docs_source_citations.py  # 35 passed
```

Manual: both sample drops downloaded to scratch and audited end-to-end (commands and hashes recorded in the doc); `git status --porcelain` clean afterwards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
