### PR TITLE
feat(router): opt-in go/no-go gate on the crossing-tail census prediction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (`LoadedCensusReport`, `build_advisory`, `emit_advisory`, `board_net_names`);
   documented in `docs/reference/crosstail-census-report.md`.
 
+- **Opt-in go/no-go on the crossing-tail census prediction** (part of #4799) —
+  `kct route --census-advisory-gate` promotes the advisory above from a printed
+  prediction to a decision: when the replayed census is applicable, trusted and
+  predicts an **inert** crossover lattice, the route aborts with the new
+  **exit code 9** *before any router or component loading* — the one route exit
+  code that means "nothing was spent". The `[crosstail-gate] NO-GO` block names
+  the worst nets by inert count and points at the layer that can act on it
+  (placement / escape planning, not the router), plus how to proceed anyway.
+  `--census-advisory-gate-pct PCT` (0–100, argparse-validated; implies the
+  gate) overrides the threshold, which otherwise defaults to the same
+  `SATURATED_PCT_ADVISORY_THRESHOLD` (90) the printed verdict uses, so verdict
+  and gate cannot silently disagree. The gate keys on **inertness**
+  (saturated + single-`v1`-site legal sets), not saturation alone, and reports
+  which of the two fired. Everything that would make the prediction
+  untrustworthy is a **GO** with an explicit reason token — `no-report`,
+  `not-applicable` (0 crossovers scanned is not a 0%-saturated pass *or* a
+  failure), `stale` (a cross-check the advisory already suppressed can never
+  gate), `census-disabled`, `schema-mismatch`, `no-board-crossovers`,
+  `below-threshold` — as is any exception inside the predictor. **Defaults are
+  unchanged**: without the flag the preflight still returns 0 unconditionally
+  and the advisory block still ends in `ADVISORY ONLY`. New API:
+  `evaluate_gate` / `emit_gate_decision` / `CensusGateDecision` /
+  `GATE_EXIT_CODE` in `kicad_tools.router.crosstail_advisory`; the threshold
+  remains uncalibrated beyond the board-06 precedent (#4799 follow-up), along
+  with a genuine pre-A\* predictor and coverage beyond diff-pair crossing
+  tails.
+
 - **Structured crossing-tail census report** (part of #4799) — the #4580
   diff-pair crossover legality census now also captures what it prints as
   data. Each censused crossover produces a `CrossingTailCensusRecord`

--- a/boards/06-diffpair-test/README.md
+++ b/boards/06-diffpair-test/README.md
@@ -381,8 +381,13 @@ That report is a post-mortem, but it does not have to be read as one: feeding
 it back in with `kct route --census-advisory <report.json>` (or
 `KCT_CROSSTAIL_CENSUS_ADVISORY=<path>`) prints this board's saturation figure
 **before** the next route's first A\* expansion, cross-checked against the
-board's current nets and suppressed when the report is stale.  Advisory only —
-it cannot change or fail a route.
+board's current nets and suppressed when the report is stale.  Advisory by
+default — it cannot change or fail a route.  Adding `--census-advisory-gate`
+(opt-in) turns that prediction into a go/no-go: on this board's own report it
+exits **9** before any router work rather than spending the 28 minutes again,
+naming the worst nets and pointing at placement / escape planning as the fix
+layer.  A prediction that cannot be trusted (stale, `not-applicable`,
+census-disabled) never gates.
 
 **State-neutral is not the same as budget-neutral ([#4635]).** PR [#4611]'s
 prose claimed the census "cannot" change the route because it is

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -1362,7 +1362,7 @@ expanded by the `# Exit codes:` comment block — both live in `_main_impl`
 | 4 | Partial routing **and** clearance violations remain — segment-segment (issue #1666) or HV pairwise (issue #4588) |
 | 5 | Interrupted by SIGINT with partial results saved (file on disk is valid) |
 | 8 | `--complete`: one or more previously-unconnected links remain unroutable (issue #4477) |
-| 9 | `--census-advisory-gate`: the replayed crossing-tail census (`--census-advisory <report.json>`) predicts an inert crossover lattice for this board, so routing was **not started** (issue #4799). The only route code that means "nothing was spent"; the fix layer is placement / escape planning. Opt-in — never returned without the flag. See [crosstail-census-report](crosstail-census-report.md#turning-the-prediction-into-a-gono-go-census-advisory-gate). |
+| 9 | `--census-advisory-gate`: the replayed crossing-tail census (`--census-advisory <report.json>`) predicts an inert crossover lattice for this board, so routing was **not started** (issue #4799). The only route code that means "nothing was spent"; the fix layer is placement / escape planning. Opt-in — never returned without the flag. See [crosstail-census-report](crosstail-census-report.md#turning-the-prediction-into-a-gate). |
 
 > **Consumer note (issues #4588 / #4607).** `kct build` and `kct pipeline`
 > forward `--voltage-map` (plus `--creepage-standard`, `--pollution-degree`,

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -1362,6 +1362,7 @@ expanded by the `# Exit codes:` comment block — both live in `_main_impl`
 | 4 | Partial routing **and** clearance violations remain — segment-segment (issue #1666) or HV pairwise (issue #4588) |
 | 5 | Interrupted by SIGINT with partial results saved (file on disk is valid) |
 | 8 | `--complete`: one or more previously-unconnected links remain unroutable (issue #4477) |
+| 9 | `--census-advisory-gate`: the replayed crossing-tail census (`--census-advisory <report.json>`) predicts an inert crossover lattice for this board, so routing was **not started** (issue #4799). The only route code that means "nothing was spent"; the fix layer is placement / escape planning. Opt-in — never returned without the flag. See [crosstail-census-report](crosstail-census-report.md#turning-the-prediction-into-a-gono-go-census-advisory-gate). |
 
 > **Consumer note (issues #4588 / #4607).** `kct build` and `kct pipeline`
 > forward `--voltage-map` (plus `--creepage-standard`, `--pollution-degree`,

--- a/docs/reference/crosstail-census-report.md
+++ b/docs/reference/crosstail-census-report.md
@@ -1,9 +1,12 @@
 # Crossing-tail census report (`KCT_CROSSTAIL_CENSUS_REPORT`)
 
-A **report-only**, machine-readable aggregate of the diff-pair crossing-tail
-legality census. It answers one question about a board — *how much of the
-crossover via-site lattice is legal at all?* — as data rather than as scraped
-stdout.
+A machine-readable aggregate of the diff-pair crossing-tail legality census. It
+answers one question about a board — *how much of the crossover via-site
+lattice is legal at all?* — as data rather than as scraped stdout.
+
+Writing the report is **report-only**. Replaying it before the next route is
+advisory by default (`kct route --census-advisory`), and can be promoted to a
+go/no-go on request (`--census-advisory-gate`, exit 9).
 
 Issue [#4799]. The measurement itself is older ([#4580], budget-corrected in
 [#4635]); this document covers the structured capture layered on top of it.
@@ -162,14 +165,18 @@ The default threshold is **90%** (`SATURATED_PCT_ADVISORY_THRESHOLD`), taken
 from the board-06 precedent: its measured saturation sits in the 90–95% band,
 while an open synthetic lattice measures near 0%.
 
-**This is documentation, not a gate.** No code branches on `verdict`, no exit
-code reflects it, and nothing about routing changes when it flips. Wiring
-saturation into an actual go/no-go or steering decision is deliberate follow-up
-work, as is a genuine *pre*-routing predictor (the census's legality checks
-consult order-dependent state — drills already placed by earlier crossovers,
-the escape-channel registry keyed on which nets are still unrouted, and the
-pair's own guide route — so it cannot simply be hoisted ahead of the first A*
-expansion).
+**Documentation by default; a gate only if you ask.** Nothing in the *report*
+branches on `verdict` — writing it changes no route and no exit code. The
+replay side adds one opt-in exception: `kct route --census-advisory-gate` turns
+the same verdict into a go/no-go that can abort a run with exit 9 (see
+[the gate](#turning-the-prediction-into-a-gono-go-census-advisory-gate) below).
+It is off by default, so an un-flagged route is byte-identical to the
+advisory-only behaviour. What remains follow-up work is a genuine *pre*-routing
+predictor (the census's legality checks consult order-dependent state — drills
+already placed by earlier crossovers, the escape-channel registry keyed on
+which nets are still unrouted, and the pair's own guide route — so it cannot
+simply be hoisted ahead of the first A* expansion) and calibrating the
+threshold against a corpus of real designs.
 
 ## Replaying it before the next route (`--census-advisory`)
 
@@ -226,8 +233,8 @@ The prediction is suppressed the same way for a report that scanned nothing
 
 `--census-advisory` **cannot fail a route.** A missing, unreadable, malformed
 or foreign file prints one `[crosstail-advisory] no prediction: …` line and the
-route proceeds; the preflight returns 0 unconditionally, unlike the
-`_offboard_preflight` gate it is modelled on. Anomalies that are *not* fatal —
+route proceeds; the preflight returns 0 unless `--census-advisory-gate` is also
+set (below). Anomalies that are *not* fatal —
 a schema version this build does not know, a report written with the census
 disabled, a stored summary that disagrees with its own records (the advisory
 re-aggregates from the records and says so) — surface as `WARNING:` lines.
@@ -246,8 +253,78 @@ tooling; `kct route` prints only the text):
 | `nets_in_report` / `nets_on_board` / `coverage_pct` | The cross-check |
 | `predicted_crossovers` / `predicted_saturated` / `_pct` | Restricted to nets still on the board |
 | `prior_summary` | The re-aggregated summary block, identical in shape to the report's own |
+| `predicted_inert` / `_pct` | Saturated **plus** single-site-legal, restricted to nets still on the board — what the gate keys on |
 | `nets[]` | Per-net roll-up (`crossovers`, `saturated`, `saturated_pct`, `no_ordering_lever`, `inert`, `present_on_board`), worst first |
 | `warnings[]` | The `WARNING:` lines, verbatim |
+
+## Turning the prediction into a go/no-go (`--census-advisory-gate`)
+
+The advisory tells an operator that the next 28 minutes are unlikely to be
+productive. `--census-advisory-gate` lets CI act on that instead of reading it:
+
+```bash
+uv run kct route board.kicad_pcb \
+  --census-advisory census.json --census-advisory-gate
+# ... exits 9, having loaded neither the router nor the components
+```
+
+```
+[crosstail-advisory]   GATE ARMED (--census-advisory-gate) -- see the [crosstail-gate] verdict below (#4799)
+[crosstail-gate] NO-GO (saturated) -- refusing to route a lattice this board already measured inert
+[crosstail-gate]   predicted 150/166 saturated (90.4%), inert 94.6% >= threshold 90.0%
+[crosstail-gate]   worst nets: PCIE_TX- inert 86/88, MIPI_CLK- inert 22/24, …
+[crosstail-gate]   the diff-pair shadow phase would spend its whole budget with no ordering lever to pull: …
+[crosstail-gate]   FIX LAYER: placement / escape planning, not the router -- …
+[crosstail-gate]   aborted before any router work (exit 9); drop --census-advisory-gate to route anyway, or raise --census-advisory-gate-pct (#4799)
+```
+
+| Flag | Effect |
+|------|--------|
+| `--census-advisory-gate` | Arms the gate. **Off by default** — without it the preflight still returns 0 unconditionally, and the advisory block still ends in `ADVISORY ONLY`. |
+| `--census-advisory-gate-pct PCT` | Inert-percentage threshold (0–100, argparse-validated). Defaults to the threshold the printed verdict used (`SATURATED_PCT_ADVISORY_THRESHOLD`, 90), so the gate and the verdict cannot silently disagree. Passing it implies `--census-advisory-gate`. |
+
+The gate runs in the same preflight as the advisory — after the hard off-board
+gate, **before** any router or component loading — so a NO-GO board spends
+nothing beyond parsing the report and the board's net list (~0.15 s, measured
+below). Exit code **9** is unique on the [route ladder](cli.md#kct-route-ladder):
+every other non-zero code means "we routed and the result was unsatisfactory",
+while 9 means "we declined to start".
+
+### What can and cannot gate
+
+NO-GO requires **all** of: a report was read; the prior run actually measured
+something; the board cross-check accepted it; the census was enabled when it was
+written; the schema is one this build reads; at least one predicted crossover
+survives the cross-check; and `predicted_inert_pct >= threshold`.
+
+Everything else is a **GO** with an explicit reason token, printed as
+`[crosstail-gate] GO (<reason>)`:
+
+| `reason` | Why it cannot gate |
+|----------|--------------------|
+| `no-report` | Nothing was given to predict from (armed-with-no-report still prints a line — a silent pass would read as a clean prediction) |
+| `not-applicable` | The prior run scanned 0 crossovers. **Not a 0%-saturated result**, so it is neither a pass nor a failure — the same distinction the report draws (boards 05 / 07) |
+| `stale` | The advisory already suppressed the prediction as describing another design; a suppressed prediction must never fail a route |
+| `census-disabled` | The report was written without `KCT_CROSSTAIL_CENSUS=1`, so its figures are not measurements |
+| `schema-mismatch` | The document declares a schema this build does not read; fields may be missing |
+| `no-board-crossovers` | None of the measured crossovers belong to a net still on this board |
+| `below-threshold` | `predicted_inert_pct` is under the bound — ordering levers remain |
+
+A gate that raises is also a GO: an exception inside a predictor is not
+evidence about the board, so `_census_advisory_preflight` returns 0 on any
+error, exactly as it did when it was advisory-only.
+
+The gate keys on **inert**, not saturation alone: a lattice whose every legal
+set offers a single via site is just as unmovable by an ordering key as one
+that offers nothing, and `reason` distinguishes the two (`saturated` vs
+`inert`) so the message sends the reader to the right mechanism.
+
+Machine form: `CensusGateDecision.to_dict()` (`gated`, `reason`, `detail`,
+`exit_code`, `threshold_pct`, the four predicted counts, `worst_nets[]`).
+
+**The threshold is not calibrated.** 90% comes from the board-06 precedent, one
+board — treat `--census-advisory-gate-pct` as required tuning for any other
+design, and see #4799 for the open work of calibrating it against a corpus.
 
 ## Not applicable ≠ zero
 
@@ -323,6 +400,8 @@ from kicad_tools.router.crosstail_advisory import (
     board_net_names,  # nets of the board about to be routed (None = unknown)
     build_advisory,  # report + board nets -> prediction
     emit_advisory,  # the two above + print; never raises
+    evaluate_gate,  # prediction -> opt-in go/no-go
+    emit_gate_decision,  # evaluate_gate + print; never raises
 )
 
 advisory = build_advisory(
@@ -330,7 +409,13 @@ advisory = build_advisory(
     board_net_names("board.kicad_pcb"),
 )
 print(advisory.applicable, advisory.predicted_saturated, advisory.summary.verdict)
+
+decision = evaluate_gate(advisory)  # threshold_pct=... to override
+print(decision.gated, decision.reason, decision.exit_code)
 ```
+
+`evaluate_gate(None)` is a valid call and returns a GO (`reason="no-report"`),
+so a caller never has to special-case "the report could not be read".
 
 `LoadedCensusReport.from_path` raises `CensusReportError` for anything that is
 not a readable census report — `emit_advisory` (and therefore `kct route`)

--- a/docs/reference/crosstail-census-report.md
+++ b/docs/reference/crosstail-census-report.md
@@ -152,7 +152,7 @@ unchanged.
 | `verdict` | See below |
 | `saturated_threshold_pct` | The threshold the verdict used (default 90.0) |
 
-## Interpreting it (advisory, non-blocking)
+## Interpreting it (advisory by default)
 
 | Verdict | Condition | Reading |
 |---------|-----------|---------|
@@ -169,7 +169,7 @@ while an open synthetic lattice measures near 0%.
 branches on `verdict` — writing it changes no route and no exit code. The
 replay side adds one opt-in exception: `kct route --census-advisory-gate` turns
 the same verdict into a go/no-go that can abort a run with exit 9 (see
-[the gate](#turning-the-prediction-into-a-gono-go-census-advisory-gate) below).
+[the gate](#turning-the-prediction-into-a-gate) below).
 It is off by default, so an un-flagged route is byte-identical to the
 advisory-only behaviour. What remains follow-up work is a genuine *pre*-routing
 predictor (the census's legality checks consult order-dependent state — drills
@@ -257,7 +257,7 @@ tooling; `kct route` prints only the text):
 | `nets[]` | Per-net roll-up (`crossovers`, `saturated`, `saturated_pct`, `no_ordering_lever`, `inert`, `present_on_board`), worst first |
 | `warnings[]` | The `WARNING:` lines, verbatim |
 
-## Turning the prediction into a go/no-go (`--census-advisory-gate`)
+## Turning the prediction into a gate
 
 The advisory tells an operator that the next 28 minutes are unlikely to be
 productive. `--census-advisory-gate` lets CI act on that instead of reading it:
@@ -313,6 +313,12 @@ Everything else is a **GO** with an explicit reason token, printed as
 A gate that raises is also a GO: an exception inside a predictor is not
 evidence about the board, so `_census_advisory_preflight` returns 0 on any
 error, exactly as it did when it was advisory-only.
+
+Unlike the report and the advisory, the gate has **no environment surface**:
+`KCT_CROSSTAIL_CENSUS_ADVISORY` can supply the report to *read*, but only the
+explicit flag can make a route fail on it. An exported variable must never be
+able to turn someone else's green pipeline red — and `kct build` / `kct
+pipeline` do not forward the flag, so exit 9 cannot reach them at all.
 
 The gate keys on **inert**, not saturation alone: a lattice whose every legal
 set offers a single via site is just as unmovable by an ordering key as one

--- a/src/kicad_tools/cli/commands/routing.py
+++ b/src/kicad_tools/cli/commands/routing.py
@@ -746,6 +746,13 @@ def run_route_command(args) -> int:
     # flag-off path stays byte-identical.
     if getattr(args, "census_advisory", None):
         sub_argv.extend(["--census-advisory", str(args.census_advisory)])
+    # Issue #4799: forward the opt-in go/no-go gate and its threshold.  Both
+    # default off/None; forwarded only when set so the flag-off path stays
+    # byte-identical to the advisory-only behaviour.
+    if getattr(args, "census_advisory_gate", False):
+        sub_argv.append("--census-advisory-gate")
+    if getattr(args, "census_advisory_gate_pct", None) is not None:
+        sub_argv.extend(["--census-advisory-gate-pct", str(args.census_advisory_gate_pct)])
     if getattr(args, "auto_fix", False):
         sub_argv.append("--auto-fix")
     if getattr(args, "auto_fix_passes", None) is not None:

--- a/src/kicad_tools/cli/parser.py
+++ b/src/kicad_tools/cli/parser.py
@@ -3388,6 +3388,19 @@ def _add_stitch_parser(subparsers) -> None:
     add_format_flag(stitch_parser)
 
 
+def _census_gate_pct(value: str) -> float:
+    """argparse ``type=`` for ``--census-advisory-gate-pct`` (issue #4799).
+
+    Mirror of ``route_cmd._census_gate_pct``; both delegate to the single
+    router-side validator so the inner and outer parsers cannot disagree about
+    what a legal threshold is.  The import is deferred to keep the router
+    package off the CLI's import path until the flag is actually used.
+    """
+    from kicad_tools.router.crosstail_advisory import parse_gate_threshold_pct
+
+    return parse_gate_threshold_pct(value)
+
+
 def _add_route_parser(subparsers) -> None:
     """Add route subcommand parser."""
     route_parser = subparsers.add_parser(
@@ -4090,8 +4103,32 @@ def _add_route_parser(subparsers) -> None:
             "KCT_CROSSTAIL_CENSUS_REPORT) to replay as a pre-route prediction: "
             "how saturated this board's diff-pair crossover lattice measured "
             "last time, printed before routing starts. Advisory only -- never "
-            "changes routing or the exit code. Defaults to "
-            "$KCT_CROSSTAIL_CENSUS_ADVISORY when unset."
+            "changes routing or the exit code unless --census-advisory-gate is "
+            "also set. Defaults to $KCT_CROSSTAIL_CENSUS_ADVISORY when unset."
+        ),
+    )
+    route_parser.add_argument(
+        "--census-advisory-gate",
+        action="store_true",
+        default=False,
+        help=(
+            "Turn the --census-advisory prediction into a go/no-go: abort "
+            "(exit 9) before any router work when the replayed census predicts "
+            "an inert crossover lattice (inert%% >= the threshold, default 90). "
+            "Off by default. A prediction that cannot be trusted -- no report, "
+            "nothing measured ('not-applicable'), a stale board cross-check, a "
+            "census-disabled or unknown-schema report -- never gates."
+        ),
+    )
+    route_parser.add_argument(
+        "--census-advisory-gate-pct",
+        metavar="PCT",
+        type=_census_gate_pct,
+        default=None,
+        help=(
+            "Inert-percentage threshold for --census-advisory-gate (0-100; "
+            "default 90, the SATURATED_PCT_ADVISORY_THRESHOLD the printed "
+            "verdict uses). Passing this implies --census-advisory-gate."
         ),
     )
     # Issue #4178: hard-gate on native (kicad-cli) DRC actually running.

--- a/src/kicad_tools/cli/route_cmd.py
+++ b/src/kicad_tools/cli/route_cmd.py
@@ -10216,6 +10216,24 @@ def _offboard_preflight(pcb_path: Path) -> int:
     return 2
 
 
+#: Exit code for the opt-in crossing-tail census gate (#4799).  Mirrored from
+#: ``crosstail_advisory.GATE_EXIT_CODE`` as a literal so building the parser
+#: (help text) does not import the router package.
+_CENSUS_GATE_EXIT_CODE = 9
+
+
+def _census_gate_pct(value: str) -> float:
+    """argparse ``type=`` for ``--census-advisory-gate-pct`` (#4799).
+
+    Delegates to the router-side validator so the inner and outer parsers
+    cannot disagree about what a legal threshold is.  Raises ``ValueError``,
+    which argparse renders as its standard "invalid value" error (exit 2).
+    """
+    from kicad_tools.router.crosstail_advisory import parse_gate_threshold_pct
+
+    return parse_gate_threshold_pct(value)
+
+
 def _census_advisory_preflight(pcb_path: Path, args) -> int:
     """Replay a prior crossing-tail census as a pre-route prediction (#4799).
 
@@ -10226,25 +10244,52 @@ def _census_advisory_preflight(pcb_path: Path, args) -> int:
     previous run's report here turns that post-mortem into a leading indicator:
     same measurement, taken earlier.
 
-    **Always returns 0.**  Unlike ``_offboard_preflight`` this is advisory, not
-    a gate: a missing or stale report degrades to a printed diagnostic, never
-    to a refusal to route.  Wiring the prediction into an actual go/no-go
-    decision is deliberate follow-up work on #4799.
+    **Returns 0 unless ``--census-advisory-gate`` is set.**  Without the gate
+    flag this is advisory exactly as it was in #4862: a missing or stale report
+    degrades to a printed diagnostic, never to a refusal to route.  With the
+    flag, a prediction that is applicable, trusted and inert at/above the
+    threshold aborts the run with
+    :data:`~kicad_tools.router.crosstail_advisory.GATE_EXIT_CODE` (9) before any
+    router or component loading — the point of a *pre*-route gate is to spend
+    nothing.  Every path where the prediction cannot be trusted (no report,
+    nothing measured, stale cross-check, census disabled, unknown schema) still
+    returns 0.
     """
+    gate = bool(getattr(args, "census_advisory_gate", False)) or (
+        getattr(args, "census_advisory_gate_pct", None) is not None
+    )
     try:
         from kicad_tools.router.crosstail_advisory import (
             advisory_path_from_env,
             emit_advisory,
+            emit_gate_decision,
         )
 
         report_path = getattr(args, "census_advisory", None) or advisory_path_from_env()
         if report_path is None:
+            if gate:
+                # Armed but with nothing to read: say so rather than passing
+                # silently, or the operator reads a green run as "predicted OK".
+                print(
+                    "[crosstail-gate] GO (no-report) -- --census-advisory-gate is "
+                    "set but no census report was given (--census-advisory / "
+                    "$KCT_CROSSTAIL_CENSUS_ADVISORY); nothing to gate on",
+                    file=sys.stderr,
+                )
             return 0
-        emit_advisory(report_path, pcb_path)
+        advisory = emit_advisory(report_path, pcb_path, gating=gate)
+        if not gate:
+            return 0
+        decision = emit_gate_decision(
+            advisory,
+            threshold_pct=getattr(args, "census_advisory_gate_pct", None),
+        )
+        return decision.exit_code
     except Exception:
-        # An advisory that cannot run must never block routing (#4156 precedent).
-        pass
-    return 0
+        # An advisory that cannot run must never block routing (#4156
+        # precedent) — and neither may the gate: a crashed predictor is not
+        # evidence about the board.
+        return 0
 
 
 def _apply_complete_mode_defaults(args, parser, argv: list[str] | None = None) -> None:
@@ -11232,6 +11277,9 @@ def _main_impl(argv: list[str] | None = None) -> int:
                  clearance violations (issues #1666, #4588)
               5  interrupted by SIGINT with partial results saved
               8  --complete: one or more unroutable links remain (issue #4477)
+              9  --census-advisory-gate: the replayed crossing-tail census
+                 predicts an inert crossover lattice; aborted before any
+                 router work (issue #4799)
         """),
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
@@ -12147,8 +12195,33 @@ def _main_impl(argv: list[str] | None = None) -> int:
             "KCT_CROSSTAIL_CENSUS_REPORT) to replay as a pre-route prediction: "
             "how saturated this board's diff-pair crossover lattice measured "
             "last time, printed before routing starts. Advisory only -- never "
-            "changes routing or the exit code. Defaults to "
-            "$KCT_CROSSTAIL_CENSUS_ADVISORY when unset."
+            "changes routing or the exit code unless --census-advisory-gate is "
+            "also set. Defaults to $KCT_CROSSTAIL_CENSUS_ADVISORY when unset."
+        ),
+    )
+    parser.add_argument(
+        "--census-advisory-gate",
+        action="store_true",
+        default=False,
+        help=(
+            "Turn the --census-advisory prediction into a go/no-go: abort "
+            f"(exit {_CENSUS_GATE_EXIT_CODE}) before any router work when the "
+            "replayed census predicts an inert crossover lattice (inert%% >= "
+            "the threshold, default 90). Off by default. A prediction that "
+            "cannot be trusted -- no report, nothing measured "
+            "('not-applicable'), a stale board cross-check, a census-disabled "
+            "or unknown-schema report -- never gates."
+        ),
+    )
+    parser.add_argument(
+        "--census-advisory-gate-pct",
+        metavar="PCT",
+        type=_census_gate_pct,
+        default=None,
+        help=(
+            "Inert-percentage threshold for --census-advisory-gate (0-100; "
+            "default 90, the SATURATED_PCT_ADVISORY_THRESHOLD the printed "
+            "verdict uses). Passing this implies --census-advisory-gate."
         ),
     )
     parser.add_argument(
@@ -13052,11 +13125,15 @@ def _main_impl(argv: list[str] | None = None) -> int:
         if rc != 0:
             return rc
 
-    # Issue #4799: advisory crossing-tail census replay.  Runs after the hard
-    # gates (there is no point predicting congestion for a board that is not
-    # going to route at all) and before any router/component loading, so the
-    # prediction is on screen ahead of the first A* expansion.
-    _census_advisory_preflight(pcb_path, args)
+    # Issue #4799: crossing-tail census replay.  Runs after the hard gates
+    # (there is no point predicting congestion for a board that is not going to
+    # route at all) and before any router/component loading, so the prediction
+    # is on screen ahead of the first A* expansion.  Advisory (returns 0) unless
+    # --census-advisory-gate armed it, in which case an inert prediction aborts
+    # here with exit 9 — before anything has been spent.
+    rc = _census_advisory_preflight(pcb_path, args)
+    if rc != 0:
+        return rc
 
     # Issue #2996: Validate and load the optional --net-class-map sidecar
     # early -- before dispatching to any of the route_with_* sub-flows --
@@ -15750,6 +15827,12 @@ def _main_impl(argv: list[str] | None = None) -> int:
     #     was specifically asked to close never closed".  See the per-link
     #     report printed above (and optionally written via
     #     --complete-report) for WHY and what copper is blocking.
+    # 9 = ``--census-advisory-gate`` refused to start: a previous run's
+    #     crossing-tail census (replayed via --census-advisory) predicts an
+    #     inert crossover lattice for this board (issue #4799).  Returned by
+    #     _census_advisory_preflight BEFORE any router or component loading,
+    #     so it is the one route exit code that means "nothing was spent";
+    #     the fix layer is placement / escape planning, not the router.
     #
     # The --min-completion flag (default 0.95) controls the success threshold.
     # With --min-completion 0.80, routing 85% of nets returns exit code 0.

--- a/src/kicad_tools/router/crosstail_advisory.py
+++ b/src/kicad_tools/router/crosstail_advisory.py
@@ -28,11 +28,20 @@ carries an explicit board cross-check (how many of the report's nets still
 exist on the board being routed) and refuses to look confident when the
 overlap is poor.
 
-**Advisory only.**  Nothing here changes routing, and nothing here can fail a
-run: :func:`emit_advisory` swallows every error into a stderr diagnostic, on
-the ``_offboard_preflight`` precedent that report-only surfaces must never
-block a route.  Wiring saturation into an actual go/no-go or steering decision
-remains deliberate follow-up work on #4799.
+**Advisory by default.**  Reading a report changes nothing: :func:`emit_advisory`
+swallows every error into a stderr diagnostic, on the ``_offboard_preflight``
+precedent that report-only surfaces must never block a route.
+
+**Opt-in go/no-go.**  :func:`evaluate_gate` turns that same prediction into a
+decision for callers that ask for one (``kct route --census-advisory-gate``):
+when the replayed prediction is applicable, trusted, and inert at or above the
+threshold, the route aborts with :data:`GATE_EXIT_CODE` *before the first A\\*
+expansion*, naming the worst nets and pointing at the layer that can actually
+fix them (placement / escape planning).  The gate is deliberately hard to
+trigger by accident -- every condition that makes the prediction less than
+trustworthy (no report, nothing measured, a stale/suppressed cross-check, a
+census that was never enabled, an unknown schema) resolves to **GO**, because
+"we could not predict" must never read as "we predict failure".
 """
 
 from __future__ import annotations
@@ -55,8 +64,19 @@ from kicad_tools.router.crosstail_census import (
 
 __all__ = [
     "ADVISORY_ENV_VAR",
+    "GATE_EXIT_CODE",
+    "GATE_REASON_BELOW_THRESHOLD",
+    "GATE_REASON_CENSUS_DISABLED",
+    "GATE_REASON_INERT",
+    "GATE_REASON_NOT_APPLICABLE",
+    "GATE_REASON_NO_BOARD_CROSSOVERS",
+    "GATE_REASON_NO_REPORT",
+    "GATE_REASON_SATURATED",
+    "GATE_REASON_SCHEMA_MISMATCH",
+    "GATE_REASON_STALE",
     "STALE_COVERAGE_PCT_THRESHOLD",
     "WORST_NETS_SHOWN",
+    "CensusGateDecision",
     "CensusReportError",
     "CrossingTailAdvisory",
     "LoadedCensusReport",
@@ -65,6 +85,9 @@ __all__ = [
     "board_net_names",
     "build_advisory",
     "emit_advisory",
+    "emit_gate_decision",
+    "evaluate_gate",
+    "parse_gate_threshold_pct",
 ]
 
 #: Fallback surface for callers that do not go through ``kct route`` -- board
@@ -82,6 +105,27 @@ STALE_COVERAGE_PCT_THRESHOLD = 50.0
 
 #: How many worst-offender nets the human block names before eliding.
 WORST_NETS_SHOWN = 5
+
+#: Exit code ``kct route`` returns when the opt-in census gate says NO-GO.
+#: Distinct from every code already on the route ladder (0-8; see the
+#: ``exit codes:`` epilog in ``cli/route_cmd.py``) so CI can tell "refused to
+#: start -- the lattice was measured inert" apart from "started and failed",
+#: which is the whole point of a pre-route gate.
+GATE_EXIT_CODE = 9
+
+#: Why the gate decided what it decided.  The first six are all **GO**: they
+#: describe a prediction that does not exist or cannot be trusted, and the gate
+#: refuses to convert any of them into a failure.
+GATE_REASON_NO_REPORT = "no-report"
+GATE_REASON_NOT_APPLICABLE = "not-applicable"
+GATE_REASON_STALE = "stale"
+GATE_REASON_CENSUS_DISABLED = "census-disabled"
+GATE_REASON_SCHEMA_MISMATCH = "schema-mismatch"
+GATE_REASON_NO_BOARD_CROSSOVERS = "no-board-crossovers"
+GATE_REASON_BELOW_THRESHOLD = "below-threshold"
+#: NO-GO reasons.
+GATE_REASON_SATURATED = "saturated"
+GATE_REASON_INERT = "inert"
 
 
 class CensusReportError(ValueError):
@@ -259,6 +303,10 @@ class CrossingTailAdvisory:
     predicted_saturated: int
     stale: bool
     warnings: tuple[str, ...] = ()
+    #: Schema version the *report* declared.  Kept as a field (rather than
+    #: re-derived from the warning text) because the gate has to branch on it:
+    #: a document this build only half-understands must not fail a route.
+    report_schema_version: int = SCHEMA_VERSION
 
     @property
     def applicable(self) -> bool:
@@ -277,6 +325,32 @@ class CrossingTailAdvisory:
             return 0.0
         return round(100.0 * self.predicted_saturated / self.predicted_crossovers, 1)
 
+    @property
+    def contributing_nets(self) -> tuple[NetPrediction, ...]:
+        """Report nets that still exist on the board (worst first).
+
+        ``present_on_board is None`` (cross-check skipped) counts as present --
+        the same rule :func:`build_advisory` used to compute the predicted
+        counts, kept in one place so the block and the gate cannot disagree.
+        """
+        return tuple(n for n in self.nets if n.present_on_board is not False)
+
+    @property
+    def predicted_inert(self) -> int:
+        """Predicted crossovers where no ordering key could change the outcome.
+
+        The union of saturated and single-site-legal, restricted to nets still
+        on the board -- the gate's real subject.  ``predicted_saturated`` alone
+        would call a lattice healthy when its every legal set offered one site.
+        """
+        return sum(n.inert for n in self.contributing_nets)
+
+    @property
+    def predicted_inert_pct(self) -> float:
+        if self.predicted_crossovers <= 0:
+            return 0.0
+        return round(100.0 * self.predicted_inert / self.predicted_crossovers, 1)
+
     def to_dict(self) -> dict[str, Any]:
         return {
             "advisory": "crosstail-census",
@@ -294,13 +368,20 @@ class CrossingTailAdvisory:
             "predicted_crossovers": self.predicted_crossovers,
             "predicted_saturated": self.predicted_saturated,
             "predicted_saturated_pct": self.predicted_saturated_pct,
+            "predicted_inert": self.predicted_inert,
+            "predicted_inert_pct": self.predicted_inert_pct,
             "prior_summary": self.summary.to_dict(),
             "nets": [n.to_dict() for n in self.nets],
             "warnings": list(self.warnings),
         }
 
-    def format_human(self) -> str:
-        """Greppable ``[crosstail-advisory]`` block, printed before routing."""
+    def format_human(self, *, gating: bool = False) -> str:
+        """Greppable ``[crosstail-advisory]`` block, printed before routing.
+
+        *gating* only changes the trailer: a block that says "ADVISORY ONLY --
+        this route is unchanged" and is then followed by an abort would be a
+        lie, so an armed :func:`evaluate_gate` gets its own last line.
+        """
         tag = "[crosstail-advisory]"
         age = ""
         if self.age_seconds is not None:
@@ -365,7 +446,13 @@ class CrossingTailAdvisory:
                 f"diff-pair shadow phase will spend its budget without a lever "
                 f"to pull; the constraint is upstream in placement / escape planning"
             )
-        lines.append(f"{tag}   ADVISORY ONLY -- this route is unchanged by the above (#4799)")
+        if gating:
+            lines.append(
+                f"{tag}   GATE ARMED (--census-advisory-gate) -- see the "
+                f"[crosstail-gate] verdict below (#4799)"
+            )
+        else:
+            lines.append(f"{tag}   ADVISORY ONLY -- this route is unchanged by the above (#4799)")
         return "\n".join(lines)
 
 
@@ -479,6 +566,241 @@ def build_advisory(
         predicted_saturated=predicted_saturated,
         stale=stale,
         warnings=tuple(warnings),
+        report_schema_version=report.schema_version,
+    )
+
+
+@dataclass(frozen=True)
+class CensusGateDecision:
+    """The opt-in go/no-go verdict derived from a :class:`CrossingTailAdvisory`.
+
+    ``gated`` is the decision; ``reason`` is the machine-readable *why* (one of
+    the ``GATE_REASON_*`` tokens) so a caller never has to parse the prose.
+    Every "cannot trust the prediction" path is a **GO** with its own reason --
+    the distinction that keeps this gate from failing routes on the strength of
+    a file that describes some other board.
+    """
+
+    gated: bool
+    reason: str
+    detail: str
+    threshold_pct: float
+    predicted_crossovers: int
+    predicted_saturated: int
+    predicted_saturated_pct: float
+    predicted_inert: int
+    predicted_inert_pct: float
+    worst_nets: tuple[str, ...] = ()
+    source: str | None = None
+
+    @property
+    def exit_code(self) -> int:
+        """:data:`GATE_EXIT_CODE` on NO-GO, 0 on GO."""
+        return GATE_EXIT_CODE if self.gated else 0
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "gate": "crosstail-census",
+            "schema_version": SCHEMA_VERSION,
+            "source": self.source,
+            "gated": self.gated,
+            "reason": self.reason,
+            "detail": self.detail,
+            "exit_code": self.exit_code,
+            "threshold_pct": self.threshold_pct,
+            "predicted_crossovers": self.predicted_crossovers,
+            "predicted_saturated": self.predicted_saturated,
+            "predicted_saturated_pct": self.predicted_saturated_pct,
+            "predicted_inert": self.predicted_inert,
+            "predicted_inert_pct": self.predicted_inert_pct,
+            "worst_nets": list(self.worst_nets),
+        }
+
+    def format_human(self) -> str:
+        """Greppable ``[crosstail-gate]`` block, printed under the advisory."""
+        tag = "[crosstail-gate]"
+        if not self.gated:
+            return "\n".join(
+                [
+                    f"{tag} GO ({self.reason})",
+                    f"{tag}   {self.detail}",
+                ]
+            )
+        lines = [
+            f"{tag} NO-GO ({self.reason}) -- refusing to route a lattice this board "
+            f"already measured inert",
+            f"{tag}   predicted {self.predicted_saturated}/{self.predicted_crossovers} "
+            f"saturated ({self.predicted_saturated_pct}%), inert "
+            f"{self.predicted_inert_pct}% >= threshold {self.threshold_pct}%",
+        ]
+        if self.worst_nets:
+            lines.append(f"{tag}   worst nets: {', '.join(self.worst_nets)}")
+        lines.extend(
+            [
+                f"{tag}   the diff-pair shadow phase would spend its whole budget "
+                f"with no ordering lever to pull: no via-site sort key can create "
+                f"legality that the lattice does not have",
+                f"{tag}   FIX LAYER: placement / escape planning, not the router -- "
+                f"give the nets above more room (re-place their sources/sinks, widen "
+                f"the escape channels, or add a layer), then re-measure with "
+                f"KCT_CROSSTAIL_CENSUS=1 KCT_CROSSTAIL_CENSUS_REPORT=<path>",
+                f"{tag}   aborted before any router work (exit {self.exit_code}); "
+                f"drop --census-advisory-gate to route anyway, or raise "
+                f"--census-advisory-gate-pct (#4799)",
+            ]
+        )
+        return "\n".join(lines)
+
+
+def parse_gate_threshold_pct(value: str) -> float:
+    """argparse ``type=`` for ``--census-advisory-gate-pct``.
+
+    Rejects non-numeric and out-of-range values at parse time (argparse exit 2)
+    rather than letting a typo like ``-90`` silently gate every board.
+    """
+    try:
+        parsed = float(value)
+    except (TypeError, ValueError):
+        raise ValueError(f"invalid percentage: {value!r}") from None
+    if not (0.0 <= parsed <= 100.0):
+        raise ValueError(f"percentage must be between 0 and 100, got {parsed}")
+    return parsed
+
+
+def evaluate_gate(
+    advisory: CrossingTailAdvisory | None,
+    *,
+    threshold_pct: float | None = None,
+) -> CensusGateDecision:
+    """Turn a replayed prediction into an opt-in go/no-go (#4799).
+
+    NO-GO requires **all** of:
+
+    * a prediction exists (a report was read),
+    * the prior run actually measured something (``applicable``; "not
+      applicable" is 0 crossovers scanned, which is emphatically not 0%
+      saturated and must never be read as either a pass or a failure),
+    * the board cross-check accepted it (``not stale``) -- a suppressed
+      prediction can never gate, per this module's staleness contract,
+    * the report was written with the census enabled and at a schema this
+      build reads (otherwise the numbers are not the numbers),
+    * at least one predicted crossover survives the board cross-check, and
+    * ``predicted_inert_pct >= threshold_pct``.
+
+    *threshold_pct* defaults to the threshold the advisory's own verdict used
+    (:data:`SATURATED_PCT_ADVISORY_THRESHOLD`, 90%), so the gate and the
+    printed verdict cannot drift apart unless the caller asks them to.
+    """
+    if advisory is None:
+        return CensusGateDecision(
+            gated=False,
+            reason=GATE_REASON_NO_REPORT,
+            detail=(
+                "no census report could be read, so there is no prediction to "
+                "gate on; routing proceeds unchanged"
+            ),
+            threshold_pct=(
+                SATURATED_PCT_ADVISORY_THRESHOLD if threshold_pct is None else threshold_pct
+            ),
+            predicted_crossovers=0,
+            predicted_saturated=0,
+            predicted_saturated_pct=0.0,
+            predicted_inert=0,
+            predicted_inert_pct=0.0,
+        )
+
+    threshold = advisory.summary.saturated_threshold_pct if threshold_pct is None else threshold_pct
+
+    def _decide(gated: bool, reason: str, detail: str) -> CensusGateDecision:
+        # Worst offenders by inert count -- the gate's subject is inertness, not
+        # saturation alone, so a net whose every legal set has a single site
+        # must be nameable here even though it saturates nowhere.
+        offenders = sorted(
+            (n for n in advisory.contributing_nets if n.inert > 0),
+            key=lambda n: (-n.inert, -n.crossovers, n.net_name),
+        )
+        worst = tuple(
+            f"{n.net_name} inert {n.inert}/{n.crossovers}" for n in offenders[:WORST_NETS_SHOWN]
+        )
+        return CensusGateDecision(
+            gated=gated,
+            reason=reason,
+            detail=detail,
+            threshold_pct=threshold,
+            predicted_crossovers=advisory.predicted_crossovers,
+            predicted_saturated=advisory.predicted_saturated,
+            predicted_saturated_pct=advisory.predicted_saturated_pct,
+            predicted_inert=advisory.predicted_inert,
+            predicted_inert_pct=advisory.predicted_inert_pct,
+            worst_nets=worst if gated else (),
+            source=advisory.source,
+        )
+
+    if not advisory.summary.applicable:
+        return _decide(
+            False,
+            GATE_REASON_NOT_APPLICABLE,
+            "the prior run scanned 0 crossover(s) (verdict=not-applicable): "
+            "nothing was measured, which is not a 0%-saturated result and not a "
+            "failing one either -- never gating on it",
+        )
+    if advisory.stale:
+        return _decide(
+            False,
+            GATE_REASON_STALE,
+            f"the prediction was suppressed as stale ({advisory.coverage_pct}% of "
+            f"the report's nets are on this board); a measurement of a different "
+            f"design must never fail this route",
+        )
+    if not advisory.census_enabled:
+        return _decide(
+            False,
+            GATE_REASON_CENSUS_DISABLED,
+            "the report was written with the census disabled "
+            "(KCT_CROSSTAIL_CENSUS unset), so its lattice figures are not "
+            "measurements -- not gating",
+        )
+    if advisory.summary.crossovers_scanned and advisory.nets_in_report == 0:
+        # Defensive: records with no net names at all.
+        return _decide(
+            False,
+            GATE_REASON_NO_BOARD_CROSSOVERS,
+            "the report names no nets, so nothing can be matched to this board",
+        )
+    if advisory.predicted_crossovers <= 0:
+        return _decide(
+            False,
+            GATE_REASON_NO_BOARD_CROSSOVERS,
+            "none of the report's measured crossovers belong to a net that is "
+            "still on this board -- nothing to predict",
+        )
+    if advisory.report_schema_version != SCHEMA_VERSION:
+        return _decide(
+            False,
+            GATE_REASON_SCHEMA_MISMATCH,
+            f"the report declares schema v{advisory.report_schema_version} and "
+            f"this build reads v{SCHEMA_VERSION}; fields may be missing, so its "
+            "numbers are not trusted to fail a route",
+        )
+
+    if advisory.predicted_inert_pct < threshold:
+        return _decide(
+            False,
+            GATE_REASON_BELOW_THRESHOLD,
+            f"predicted inert {advisory.predicted_inert_pct}% < threshold "
+            f"{threshold}% ({advisory.predicted_saturated}/"
+            f"{advisory.predicted_crossovers} saturated); ordering levers remain, "
+            "routing proceeds",
+        )
+    reason = (
+        GATE_REASON_SATURATED
+        if advisory.predicted_saturated_pct >= threshold
+        else GATE_REASON_INERT
+    )
+    return _decide(
+        True,
+        reason,
+        f"predicted inert {advisory.predicted_inert_pct}% >= threshold {threshold}%",
     )
 
 
@@ -520,6 +842,7 @@ def emit_advisory(
     *,
     stream: Any = None,
     saturated_threshold_pct: float = SATURATED_PCT_ADVISORY_THRESHOLD,
+    gating: bool = False,
 ) -> CrossingTailAdvisory | None:
     """Print the pre-route advisory for *report_path*.  Never raises.
 
@@ -527,6 +850,10 @@ def emit_advisory(
     one-line diagnostic goes to *stream*).  A missing or malformed report is a
     missing diagnostic, not a reason to refuse to route -- the
     ``_offboard_preflight`` precedent.
+
+    *gating* only affects the block's trailer (see
+    :meth:`CrossingTailAdvisory.format_human`); the decision itself is
+    :func:`evaluate_gate`'s, so printing and deciding stay separable.
     """
     import sys
 
@@ -548,5 +875,41 @@ def emit_advisory(
         board_nets,
         saturated_threshold_pct=saturated_threshold_pct,
     )
-    print(advisory.format_human(), file=out)
+    print(advisory.format_human(gating=gating), file=out)
     return advisory
+
+
+def emit_gate_decision(
+    advisory: CrossingTailAdvisory | None,
+    *,
+    threshold_pct: float | None = None,
+    stream: Any = None,
+) -> CensusGateDecision:
+    """Print and return the go/no-go for *advisory*.  Never raises.
+
+    A decision that cannot be computed is a **GO**: the caller gets an
+    unconditional :class:`CensusGateDecision` and routing proceeds, because an
+    exception in a predictor is not evidence about the board.
+    """
+    import sys
+
+    out = stream if stream is not None else sys.stderr
+    try:
+        decision = evaluate_gate(advisory, threshold_pct=threshold_pct)
+    except Exception as exc:  # pragma: no cover - defensive, see docstring
+        print(f"[crosstail-gate] GO (error) -- gate could not run: {exc}", file=out)
+        return CensusGateDecision(
+            gated=False,
+            reason="error",
+            detail=f"gate could not run: {exc}",
+            threshold_pct=(
+                SATURATED_PCT_ADVISORY_THRESHOLD if threshold_pct is None else threshold_pct
+            ),
+            predicted_crossovers=0,
+            predicted_saturated=0,
+            predicted_saturated_pct=0.0,
+            predicted_inert=0,
+            predicted_inert_pct=0.0,
+        )
+    print(decision.format_human(), file=out)
+    return decision

--- a/tests/router/test_crosstail_advisory_4799.py
+++ b/tests/router/test_crosstail_advisory_4799.py
@@ -14,8 +14,14 @@ indicator rather than a post-mortem:
    a different design's measurement.
 4. "Not applicable" (nothing was ever scanned) stays distinct from "0%
    saturated" -- the same distinction slice 1 drew, carried through the replay.
-5. Advisory ONLY: the preflight returns 0 for a missing, malformed, empty and
-   valid report alike, and never raises.
+5. Advisory by default: without ``--census-advisory-gate`` the preflight
+   returns 0 for a missing, malformed, empty and valid report alike, and never
+   raises.
+6. The opt-in go/no-go gate (sections 8-9): it fails a route only for a
+   prediction that is applicable, trusted, and inert at/above the threshold --
+   and every "cannot trust this" path (no report, not-applicable, stale,
+   census-disabled, unknown schema, crash) is pinned as a GO, because those are
+   the cases where a gate would fail builds for the wrong reason.
 
 No board fixture and no routing: every test drives fabricated records, so this
 file runs in milliseconds -- which is also the point of the feature (a leading
@@ -32,6 +38,16 @@ import pytest
 
 from kicad_tools.router.crosstail_advisory import (
     ADVISORY_ENV_VAR,
+    GATE_EXIT_CODE,
+    GATE_REASON_BELOW_THRESHOLD,
+    GATE_REASON_CENSUS_DISABLED,
+    GATE_REASON_INERT,
+    GATE_REASON_NO_BOARD_CROSSOVERS,
+    GATE_REASON_NO_REPORT,
+    GATE_REASON_NOT_APPLICABLE,
+    GATE_REASON_SATURATED,
+    GATE_REASON_SCHEMA_MISMATCH,
+    GATE_REASON_STALE,
     STALE_COVERAGE_PCT_THRESHOLD,
     WORST_NETS_SHOWN,
     CensusReportError,
@@ -42,6 +58,9 @@ from kicad_tools.router.crosstail_advisory import (
     board_net_names,
     build_advisory,
     emit_advisory,
+    emit_gate_decision,
+    evaluate_gate,
+    parse_gate_threshold_pct,
 )
 from kicad_tools.router.crosstail_census import (
     SCHEMA_VERSION,
@@ -429,6 +448,10 @@ def test_to_dict_exposes_a_stable_field_set():
         "predicted_crossovers",
         "predicted_saturated",
         "predicted_saturated_pct",
+        # #4799 gate slice: inertness (saturated + single-site-legal) is what
+        # the go/no-go keys on, so it is part of the machine form too.
+        "predicted_inert",
+        "predicted_inert_pct",
         "prior_summary",
         "nets",
         "warnings",
@@ -614,3 +637,394 @@ def test_outer_kct_parser_accepts_and_forwards_the_flag():
     assert "--census-advisory" in with_flag
     assert with_flag[with_flag.index("--census-advisory") + 1] == "census.json"
     assert "--census-advisory" not in without_flag
+
+
+# --------------------------------------------------------------------------
+# 8. the opt-in go/no-go gate (--census-advisory-gate)
+# --------------------------------------------------------------------------
+#
+# The gate is the enforcement half of the advisory: same prediction, now
+# allowed to refuse a route.  Its whole design surface is "when may this fail
+# a build?", so most of what follows pins the cases where it must NOT.
+
+
+def _saturated_advisory(*, board_nets=None, count: int = 10, saturated: int = 10):
+    records = [_record("PCIE_TX-", legal=0) for _ in range(saturated)]
+    records += [_record("PCIE_TX-", legal=7, distinct_v1=4) for _ in range(count - saturated)]
+    return build_advisory(_report_from(records), board_nets)
+
+
+def test_gate_says_no_go_on_a_saturated_prediction():
+    decision = evaluate_gate(_saturated_advisory())
+
+    assert decision.gated is True
+    assert decision.reason == GATE_REASON_SATURATED
+    assert decision.exit_code == GATE_EXIT_CODE == 9
+    assert decision.predicted_inert_pct == 100.0
+    assert decision.threshold_pct == 90.0
+
+
+def test_no_go_message_names_the_worst_nets_and_the_fix_layer():
+    records = [_record("PCIE_TX-", legal=0) for _ in range(8)]
+    records += [_record("USB2_D+", legal=0) for _ in range(2)]
+    decision = evaluate_gate(build_advisory(_report_from(records)))
+    text = decision.format_human()
+
+    assert "NO-GO" in text
+    assert "PCIE_TX- inert 8/8" in text
+    assert "USB2_D+ inert 2/2" in text
+    # The actionable half: which layer can fix this, and how to proceed anyway.
+    assert "placement / escape planning" in text
+    assert "not the router" in text
+    assert "exit 9" in text
+    assert "--census-advisory-gate" in text
+    assert "KCT_CROSSTAIL_CENSUS_REPORT" in text
+
+
+def test_gate_keys_on_inert_not_saturation_alone():
+    """Every legal set having a single site is just as inert as legal=0."""
+    records = [_record("A", legal=5, distinct_v1=1) for _ in range(10)]
+    advisory = build_advisory(_report_from(records))
+
+    assert advisory.predicted_saturated == 0
+    assert advisory.predicted_inert == 10
+
+    decision = evaluate_gate(advisory)
+    assert decision.gated is True
+    # Distinct token: nothing was saturated, so calling it "saturated" would
+    # send the reader looking for a legality wall that is not there.
+    assert decision.reason == GATE_REASON_INERT
+
+
+def test_gate_never_fires_without_a_report():
+    decision = evaluate_gate(None)
+    assert decision.gated is False
+    assert decision.reason == GATE_REASON_NO_REPORT
+    assert decision.exit_code == 0
+    assert "GO (no-report)" in decision.format_human()
+
+
+def test_gate_never_fires_on_a_not_applicable_report():
+    """0 crossovers scanned is not 0% saturated -- and not a failure either."""
+    decision = evaluate_gate(build_advisory(_report_from([])))
+
+    assert decision.gated is False
+    assert decision.reason == GATE_REASON_NOT_APPLICABLE
+    assert decision.exit_code == 0
+    assert "not a 0%-saturated result" in decision.detail
+
+
+def test_gate_never_fires_on_a_suppressed_stale_prediction():
+    """A measurement of some other design must not fail this board's route."""
+    records = [_record(f"OLD{i}", legal=0) for i in range(4)]
+    advisory = build_advisory(_report_from(records), {"OLD0", "SOMETHING_ELSE"})
+    assert advisory.stale is True
+    assert advisory.summary.verdict == VERDICT_SATURATED  # would gate if trusted
+
+    decision = evaluate_gate(advisory)
+    assert decision.gated is False
+    assert decision.reason == GATE_REASON_STALE
+    assert "different design" in decision.detail or "stale" in decision.detail
+
+
+def test_gate_never_fires_on_a_census_disabled_report():
+    records = [_record("A", legal=0) for _ in range(4)]
+    advisory = build_advisory(_report_from(records, census_enabled=False))
+
+    decision = evaluate_gate(advisory)
+    assert decision.gated is False
+    assert decision.reason == GATE_REASON_CENSUS_DISABLED
+
+
+def test_gate_never_fires_on_an_unknown_schema_version():
+    payload = _report_from([_record("A", legal=0) for _ in range(4)])
+    future = LoadedCensusReport(
+        path=None,
+        schema_version=SCHEMA_VERSION + 7,
+        generated_at=payload.generated_at,
+        census_enabled=True,
+        records=payload.records,
+        stored_summary=payload.stored_summary,
+    )
+    decision = evaluate_gate(build_advisory(future))
+
+    assert decision.gated is False
+    assert decision.reason == GATE_REASON_SCHEMA_MISMATCH
+    assert str(SCHEMA_VERSION + 7) in decision.detail
+
+
+def test_gate_never_fires_when_no_predicted_crossover_survives_the_cross_check():
+    """Defensive: an applicable report that contributes nothing to this board."""
+    empty_prediction = CrossingTailAdvisory(
+        source="<payload>",
+        generated_at=None,
+        age_seconds=None,
+        census_enabled=True,
+        summary=build_advisory(_report_from([_record("A", legal=0)])).summary,
+        nets=(),
+        board_nets_known=True,
+        nets_in_report=1,
+        nets_on_board=1,
+        coverage_pct=100.0,
+        predicted_crossovers=0,
+        predicted_saturated=0,
+        stale=False,
+    )
+    decision = evaluate_gate(empty_prediction)
+    assert decision.gated is False
+    assert decision.reason == GATE_REASON_NO_BOARD_CROSSOVERS
+
+
+def test_gate_does_not_fire_below_the_threshold():
+    decision = evaluate_gate(_saturated_advisory(count=10, saturated=5))
+
+    assert decision.gated is False
+    assert decision.reason == GATE_REASON_BELOW_THRESHOLD
+    assert decision.predicted_inert_pct == 50.0
+    assert "50.0% < threshold 90.0%" in decision.detail
+    assert decision.format_human().startswith("[crosstail-gate] GO (below-threshold)")
+
+
+def test_gate_threshold_is_tunable_in_both_directions():
+    advisory = _saturated_advisory(count=10, saturated=5)
+    assert evaluate_gate(advisory, threshold_pct=50.0).gated is True
+    assert evaluate_gate(advisory, threshold_pct=50.1).gated is False
+    # Exactly at the bound gates: the same >= convention the verdict uses.
+    assert evaluate_gate(advisory, threshold_pct=50.0).threshold_pct == 50.0
+
+
+def test_gate_defaults_to_the_threshold_the_printed_verdict_used():
+    """Verdict and gate must not be able to disagree by construction."""
+    advisory = build_advisory(
+        _report_from([_record("A", legal=0), _record("B", legal=9, distinct_v1=5)]),
+        saturated_threshold_pct=40.0,
+    )
+    assert advisory.summary.verdict == VERDICT_SATURATED
+    assert evaluate_gate(advisory).threshold_pct == 40.0
+    assert evaluate_gate(advisory).gated is True
+
+
+def test_gate_decision_to_dict_is_machine_readable():
+    payload = evaluate_gate(_saturated_advisory()).to_dict()
+
+    assert payload["gate"] == "crosstail-census"
+    assert payload["gated"] is True
+    assert payload["reason"] == GATE_REASON_SATURATED
+    assert payload["exit_code"] == GATE_EXIT_CODE
+    assert payload["predicted_inert_pct"] == 100.0
+    assert payload["worst_nets"] == ["PCIE_TX- inert 10/10"]
+
+
+def test_go_decisions_do_not_name_worst_nets():
+    """A GO block listing 'worst nets' reads like a failure that was ignored."""
+    decision = evaluate_gate(_saturated_advisory(count=10, saturated=1))
+    assert decision.worst_nets == ()
+    assert "worst nets" not in decision.format_human()
+
+
+def test_emit_gate_decision_prints_and_never_raises(capsys):
+    decision = emit_gate_decision(_saturated_advisory())
+    assert decision.gated is True
+    assert "[crosstail-gate] NO-GO" in capsys.readouterr().err
+
+
+def test_advisory_trailer_is_honest_about_an_armed_gate():
+    advisory = _saturated_advisory()
+    assert "ADVISORY ONLY" in advisory.format_human()
+    armed = advisory.format_human(gating=True)
+    assert "ADVISORY ONLY" not in armed
+    assert "GATE ARMED" in armed
+
+
+def test_gate_threshold_parser_rejects_nonsense():
+    assert parse_gate_threshold_pct("90") == 90.0
+    assert parse_gate_threshold_pct("0") == 0.0
+    for bad in ("abc", "-1", "101", ""):
+        with pytest.raises(ValueError):
+            parse_gate_threshold_pct(bad)
+
+
+# --------------------------------------------------------------------------
+# 9. the gate on the CLI surface
+# --------------------------------------------------------------------------
+
+
+def _saturated_report(tmp_path, net: str = "MIPI_CLK-", n: int = 10):
+    collector = CrossingTailCensusCollector()
+    for _ in range(n):
+        collector.add(_record(net, legal=0))
+    return write_report(tmp_path / "census.json", collector, census_enabled=True)
+
+
+def test_route_preflight_gates_only_when_asked(tmp_path, capsys, monkeypatch):
+    from kicad_tools.cli import route_cmd
+
+    monkeypatch.delenv(ADVISORY_ENV_VAR, raising=False)
+    pcb = tmp_path / "b.kicad_pcb"
+    pcb.write_text(_MINIMAL_PCB)
+    target = _saturated_report(tmp_path)
+
+    # Default (flag absent): byte-identical to the #4862 advisory -- 0.
+    advisory_only = SimpleNamespace(census_advisory=str(target))
+    assert route_cmd._census_advisory_preflight(pcb, advisory_only) == 0
+    assert "ADVISORY ONLY" in capsys.readouterr().err
+
+    # Armed on the same report: NO-GO.
+    gated = SimpleNamespace(census_advisory=str(target), census_advisory_gate=True)
+    assert route_cmd._census_advisory_preflight(pcb, gated) == GATE_EXIT_CODE
+    err = capsys.readouterr().err
+    assert "[crosstail-gate] NO-GO" in err
+    assert "GATE ARMED" in err
+
+
+def test_route_preflight_gate_pct_implies_the_gate(tmp_path, capsys, monkeypatch):
+    from kicad_tools.cli import route_cmd
+
+    monkeypatch.delenv(ADVISORY_ENV_VAR, raising=False)
+    pcb = tmp_path / "b.kicad_pcb"
+    pcb.write_text(_MINIMAL_PCB)
+    target = _saturated_report(tmp_path)
+
+    args = SimpleNamespace(census_advisory=str(target), census_advisory_gate_pct=99.9)
+    assert route_cmd._census_advisory_preflight(pcb, args) == GATE_EXIT_CODE
+
+    # ...and a threshold above the measurement lets it through.
+    loose = SimpleNamespace(census_advisory=str(target), census_advisory_gate_pct=100.1)
+    assert route_cmd._census_advisory_preflight(pcb, loose) == 0
+    assert "GO (below-threshold)" in capsys.readouterr().err
+
+
+def test_route_preflight_gate_is_loud_when_armed_with_no_report(tmp_path, capsys, monkeypatch):
+    from kicad_tools.cli import route_cmd
+
+    monkeypatch.delenv(ADVISORY_ENV_VAR, raising=False)
+    pcb = tmp_path / "b.kicad_pcb"
+    pcb.write_text(_MINIMAL_PCB)
+
+    args = SimpleNamespace(census_advisory_gate=True)
+    assert route_cmd._census_advisory_preflight(pcb, args) == 0
+    err = capsys.readouterr().err
+    assert "GO (no-report)" in err
+    # Armed-but-inert must not look like a passed prediction.
+    assert "nothing to gate on" in err
+
+
+def test_route_preflight_gate_never_blocks_on_a_broken_report(tmp_path, monkeypatch):
+    from kicad_tools.cli import route_cmd
+
+    monkeypatch.delenv(ADVISORY_ENV_VAR, raising=False)
+    pcb = tmp_path / "b.kicad_pcb"
+    pcb.write_text(_MINIMAL_PCB)
+
+    broken = tmp_path / "broken.json"
+    broken.write_text("{")
+    args = SimpleNamespace(census_advisory=str(broken), census_advisory_gate=True)
+    assert route_cmd._census_advisory_preflight(pcb, args) == 0
+
+    missing = SimpleNamespace(
+        census_advisory=str(tmp_path / "absent.json"), census_advisory_gate=True
+    )
+    assert route_cmd._census_advisory_preflight(pcb, missing) == 0
+
+
+def test_route_preflight_gate_never_blocks_when_it_crashes(tmp_path, monkeypatch):
+    """A predictor that raises is not evidence about the board."""
+    from kicad_tools.cli import route_cmd
+    from kicad_tools.router import crosstail_advisory as mod
+
+    monkeypatch.delenv(ADVISORY_ENV_VAR, raising=False)
+
+    def _boom(*_a, **_k):
+        raise RuntimeError("kaboom")
+
+    monkeypatch.setattr(mod, "emit_advisory", _boom)
+    pcb = tmp_path / "b.kicad_pcb"
+    pcb.write_text(_MINIMAL_PCB)
+    args = SimpleNamespace(
+        census_advisory=str(_saturated_report(tmp_path)), census_advisory_gate=True
+    )
+    assert route_cmd._census_advisory_preflight(pcb, args) == 0
+
+
+def test_route_main_aborts_with_exit_nine_before_any_router_work(tmp_path, capsys, monkeypatch):
+    """End-to-end: the gate's return value actually reaches the exit code.
+
+    Also the point of a *pre*-route gate -- no output board is produced,
+    because nothing downstream of the preflight ever ran.
+    """
+    from kicad_tools.cli import route_cmd
+
+    monkeypatch.delenv(ADVISORY_ENV_VAR, raising=False)
+    pcb = tmp_path / "b.kicad_pcb"
+    pcb.write_text(_MINIMAL_PCB)
+    target = _saturated_report(tmp_path)
+
+    rc = route_cmd.main([str(pcb), "--census-advisory", str(target), "--census-advisory-gate"])
+
+    assert rc == GATE_EXIT_CODE
+    assert "[crosstail-gate] NO-GO" in capsys.readouterr().err
+    assert not (tmp_path / "b_routed.kicad_pcb").exists()
+
+
+def test_route_help_documents_the_gate_and_its_exit_code(capsys):
+    from kicad_tools.cli import route_cmd
+
+    with pytest.raises(SystemExit):
+        route_cmd.main(["--help"])
+    out = capsys.readouterr().out
+    assert "--census-advisory-gate" in out
+    assert "--census-advisory-gate-pct" in out
+    assert "9  --census-advisory-gate" in out
+
+
+def test_outer_kct_parser_accepts_and_forwards_the_gate_flags():
+    from kicad_tools.cli import route_cmd
+    from kicad_tools.cli.commands import routing
+    from kicad_tools.cli.parser import create_parser
+
+    captured: list[list[str]] = []
+
+    def _fake_route_main(argv):
+        captured.append(list(argv))
+        return 0
+
+    original = route_cmd.main
+    route_cmd.main = _fake_route_main
+    try:
+        args = create_parser().parse_args(
+            [
+                "route",
+                "board.kicad_pcb",
+                "--census-advisory",
+                "census.json",
+                "--census-advisory-gate",
+                "--census-advisory-gate-pct",
+                "75",
+            ]
+        )
+        assert args.census_advisory_gate is True
+        assert args.census_advisory_gate_pct == 75.0
+        assert routing.run_route_command(args) == 0
+
+        plain = create_parser().parse_args(["route", "board.kicad_pcb"])
+        assert plain.census_advisory_gate is False
+        assert plain.census_advisory_gate_pct is None
+        assert routing.run_route_command(plain) == 0
+    finally:
+        route_cmd.main = original
+
+    with_flags, without_flags = captured
+    assert "--census-advisory-gate" in with_flags
+    assert with_flags[with_flags.index("--census-advisory-gate-pct") + 1] == "75.0"
+    # Flag-off path stays byte-identical to the advisory-only behaviour.
+    assert "--census-advisory-gate" not in without_flags
+    assert "--census-advisory-gate-pct" not in without_flags
+
+
+def test_outer_parser_rejects_an_out_of_range_threshold():
+    from kicad_tools.cli.parser import create_parser
+
+    with pytest.raises(SystemExit):
+        create_parser().parse_args(
+            ["route", "board.kicad_pcb", "--census-advisory-gate-pct", "150"]
+        )


### PR DESCRIPTION
## Part of #4799 — slice 3: the opt-in go/no-go

Slices 1 (#4852, structured report) and 2 (#4862, `--census-advisory` replay)
made the crossing-tail census a *leading indicator* that still returned 0
unconditionally. This slice wires it into a decision, opt-in.

### Flag design

| Flag | Effect |
|------|--------|
| `--census-advisory-gate` | Arms the gate. Off by default. |
| `--census-advisory-gate-pct PCT` | Inert-% threshold (0–100, argparse-validated via a shared validator so the inner and outer parsers cannot disagree). Defaults to the same `SATURATED_PCT_ADVISORY_THRESHOLD` (90) the printed verdict uses. Implies the gate. |

Both are on **both** parsers (`route_cmd.py` and `cli/parser.py`) and forwarded
from `commands/routing.py` only when set — the #4862 lesson. `tests/test_cli_parser_drift.py`
passes with no allowlist edit.

**Exit code 9**, new and unique on the route ladder (0–8 taken): every other
non-zero route code means "we routed and the result was unsatisfactory"; 9 means
"we declined to start". Documented in the `exit codes:` epilog, the `# Exit
codes:` comment block, and `docs/reference/cli.md`'s ladder table. The gate runs
in the existing preflight — after the hard off-board gate, before any router or
component loading — so a NO-GO board spends ~0.15 s total.

### What can gate, and (mostly) what cannot

NO-GO requires all of: a report was read; the prior run measured something; the
board cross-check accepted it; the census was enabled; the schema is one this
build reads; at least one predicted crossover survives the cross-check; and
`predicted_inert_pct >= threshold`.

Everything else is a **GO** with an explicit `GATE_REASON_*` token —
`no-report`, `not-applicable`, `stale`, `census-disabled`, `schema-mismatch`,
`no-board-crossovers`, `below-threshold` — as is any exception inside the
predictor. This respects the two constraints called out in the issue's design
notes: a suppressed/stale prediction can never gate, and `not-applicable` (0
crossovers scanned) is neither a 0%-saturated pass nor a failure.

The gate keys on **inertness** (saturated ∪ single-`v1`-site legal sets), not
saturation alone, and reports which of the two fired (`saturated` vs `inert`) so
the message sends the reader to the right mechanism. The NO-GO block names the
worst nets by inert count and points at the fix layer — placement / escape
planning, not the router — plus how to proceed anyway.

The gate is deliberately **flag-only**: `KCT_CROSSTAIL_CENSUS_ADVISORY` can
supply the report to read, but no environment variable can turn someone else's
green pipeline red, and `kct build` / `kct pipeline` do not forward the flag, so
exit 9 cannot reach them.

### Defaults unchanged

Without the flag the preflight still returns 0 unconditionally and the advisory
block still ends in `ADVISORY ONLY` (with the gate armed that trailer becomes
`GATE ARMED`, since "this route is unchanged by the above" followed by an abort
would be a lie). Pinned by
`test_route_preflight_gates_only_when_asked` and the outer-parser forwarding test.

### Verification

- `uv run pytest tests/router -k "census or crosstail" tests/test_cli_parser_drift.py -q --no-cov` → **65 passed**
- `uv run pytest tests/test_cli_parser_drift.py -q --no-cov` (unfiltered) → **29 passed**
- `tests/test_docs_source_citations.py`, `test_check_doc_drift.py`, `test_route_offboard_gate.py`, `test_report_offboard_and_census.py` → green
- `ruff check .` / `ruff format --check .` → clean
- mypy baseline (`scripts/ci/check_mypy_baseline.py`, no `--update`) → 1464 errors, all within the 1472 baseline

New tests are 25 cases across two sections; the bulk pin the *refuse-to-gate*
paths, since those are where a gate fails builds for the wrong reason. One
end-to-end `route_cmd.main` test asserts exit 9 actually reaches the caller and
that no output board is produced.

### Still open on #4799

1. A genuine pre-any-A\*-expansion predictor (research-grade; order dependency).
2. Generalizing beyond diff-pair crossing tails (#3438's pad-array bundles).
3. Calibrating the threshold against #4830's corpus — 90% is one board's
   precedent, and the docs say so where the flag is described.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
