### PR TITLE
fix(router): difference signed net potentials in the pairwise clearance table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1038,6 +1038,38 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`route --voltage-map` collapsed signed net potentials with `abs()`, so
+  +150 V vs −150 V differenced to 0 V** (#4867, blocker for #4507, epic #4431
+  Phase 2) — the router normalised its voltage map to *magnitudes* before
+  differencing (`build_pairwise_clearance_table`, and again in `route_cmd`'s
+  preload, which additionally read the sidecar through placement's
+  magnitude-only `load_voltage_map`). The creepage census reads the **same
+  file** signed, so on a bipolar map — the normal encoding for an HV bank
+  topology, and the one softstart rev-C declares in its own `_comment` — the
+  two disagreed by construction: the census requires 3.20 mm between a +150 V
+  and a −150 V net, the router required nothing at all. Such a pair was not
+  merely under-required but **absent from the matrix**, therefore invisible to
+  the search-time kernels *and* to the post-route audit, which can only report
+  on pairs its own table contains. On softstart rev-C's 84-net map that
+  under-constrained **339 of 1922 cross-pairs (17.6 %)**, 99 of them missing
+  entirely, while the run printed a reassuring `HV pairwise clearance: 84
+  mapped nets, 1823 cross-pairs` banner and exited 0 over ±300 V copper at the
+  DRU floor. Potentials are now differenced **as supplied**, via a new
+  `router.pairwise_clearance.load_signed_voltage_map` that shares the census'
+  parse contract (`_`-prefixed metadata keys skipped; a #4411 `{min,max}` range
+  collapses to its worst-case endpoint *with the sign*). The banner's
+  cross-pair count is now the signed count. All-non-negative maps are
+  unaffected — `abs()` was the identity there — and a signed span below
+  `--hv-threshold` (e.g. ±10 V) still stays out of the matrix, so there is no
+  over-correction. Python-only: the C++ grid has no concept of a net's voltage
+  and consumes the already-built dense mm matrix, so the corrected requirements
+  reach `Grid3D::set_pairwise_domains` with no recompile. Placement's
+  magnitude-only `load_voltage_map` is deliberately untouched (its cross-domain
+  model has no reference potential). Per the issue's own acceptance criteria,
+  softstart rev-C's leak set is expected to **grow** before it shrinks — 99
+  pairs re-enter the matrix — and #4507's T4 criterion must be re-scored on top
+  of this change.
+
 - **`kct build --quiet` exited 0 when a build step failed** (part of #4674) —
   the success/failure verdict was computed *inside* the `if not args.quiet:`
   summary block, so suppressing the summary also suppressed the non-zero exit

--- a/docs/hv-pairwise-softstart-proof.md
+++ b/docs/hv-pairwise-softstart-proof.md
@@ -2,6 +2,20 @@
 
 Point-in-time working document — it describes the tree as of its date.
 
+> **Update (#4867 fixed):** the root cause this run isolated — the `abs()`
+> collapse of signed potentials, described in
+> [The root cause](#the-root-cause-signed-potentials-are-collapsed-to-magnitudes)
+> — has since been fixed. Re-measuring the table over the **same**
+> `vmap.json` (md5 `cc72a701a6c4c3c335859bcc6029ab94`) now yields **1922
+> cross-pairs**, matching the census exactly: the 99 missing pairs are back,
+> the 240 under-required pairs carry their full requirement, and **no pair is
+> lost**. Everything below the update is the *pre-fix* measurement and is kept
+> as the record of the diagnosis. The routing arms have **not** been re-run, so
+> the 49/82 · 42-census-fail · 3-gate-hit numbers in the verdict table are
+> stale: per #4867's acceptance criteria the leak set is expected to **grow**
+> before it shrinks, because 99 pairs re-enter the matrix. **#4507's T4 must be
+> re-scored** on top of the fix.
+
 This is the record of the **T4 manual criterion** of issue
 [#4507](https://github.com/rjwalters/kicad-tools/issues/4507) (router Phase 2 of
 epic #4431, pairwise HV-isolation clearance):
@@ -265,6 +279,21 @@ This is a **safety-gate under-constraint**, not merely a missed optimisation: a
 `--voltage-map` run can print a reassuring banner, pass its own post-route audit,
 and still commit ±300 V copper at the DRU floor.
 
+**Resolved by #4867.** Potentials are now differenced as supplied, and the
+sidecar is read through `router.pairwise_clearance.load_signed_voltage_map`
+(the census' own parse contract) rather than placement's magnitude-only loader.
+Replaying the block above against the same `vmap.json` on the fixed tree:
+
+```
+cross-pairs, signed (post-fix)                : 1922   <- what the banner now prints
+cross-pairs, magnitude (pre-fix)              : 1823
+pairs that RE-ENTER the matrix                :   99
+pairs previously UNDER-required               :  240
+total previously under-constrained            :  339 / 1922  (17.6 %)
+pairs LOST by the fix                         :    0
+worst: AC_LINE <-> {BOOST_B,GATE_BUS,GATE_DRV,SRC,TRK}_NEG   3.20 mm (was 0.00)
+```
+
 ## Which engine actually ran — and what that means for #4507
 
 Worth stating plainly, because it bounds what this run does and does not prove
@@ -356,7 +385,7 @@ placement capacity wall, and a definitional mismatch between two gates.
 | T1 | Parity: C++ and Python validators agree | **MET** | `tests/router/test_pairwise_cpp_parity.py` |
 | T2 | Two-domain fixture converges | **MET** | `test_two_domain_board_converges_with_search_time_avoidance` |
 | T3 | Backward compat: no `--voltage-map` → unchanged routes | **MET** | `test_no_voltage_map_route_leaves_grid_dormant` + this run's control arm (dormant, no banner, 7/7 in 32 s) |
-| **T4** | **softstart rev-C: route completes, 0 board-level census fails** | **FAILS** | **49/82 nets; 42 board-level fails; 3 router-gate leaks — root-caused to the signed/magnitude collapse above** |
+| **T4** | **softstart rev-C: route completes, 0 board-level census fails** | **FAILS (must be re-scored)** | **49/82 nets; 42 board-level fails; 3 router-gate leaks — root-caused to the signed/magnitude collapse above. That collapse is fixed (#4867), which restores 99 missing pairs and corrects 240 more; the routing arms have not been re-run, so these three numbers are pre-fix and no longer describe the tool** |
 
 ## Reproducing
 

--- a/src/kicad_tools/cli/route_cmd.py
+++ b/src/kicad_tools/cli/route_cmd.py
@@ -11875,8 +11875,10 @@ def _main_impl(argv: list[str] | None = None) -> int:
         metavar="FILE",
         help=(
             "Path to a JSON per-net voltage map {net_name: volts} (reuses the "
-            "#4371 format; ranges {min,max} per #4411 collapse to worst-case "
-            "magnitude). Enables HV-isolation pairwise clearance (Issue #4431 "
+            "#4371 format; ranges {min,max} per #4411 collapse to the worst-case "
+            "endpoint). Potentials are read SIGNED, exactly as kct creepage "
+            "reads the same file (#4867): a +150 V net and a -150 V net are a "
+            "300 V pair, not 0 V. Enables HV-isolation pairwise clearance (Issue #4431 "
             "Phase 1): the router derives a net-pair required-clearance matrix "
             "max(dru, IEC creepage @ |ΔV|) using the SAME lookup as HV-aware "
             "placement (--voltage-map on optimize-placement) and the creepage "
@@ -13229,22 +13231,31 @@ def _main_impl(argv: list[str] | None = None) -> int:
     args._pairwise_required = None
     if getattr(args, "voltage_map", None) is not None:
         from kicad_tools.creepage.standards import StandardLookupError
-        from kicad_tools.placement.hv_domains import (
-            build_required_by_domain_pair,
-            load_voltage_map,
+        from kicad_tools.placement.hv_domains import build_required_by_domain_pair
+        from kicad_tools.router.pairwise_clearance import (
+            _norm_net_key,
+            load_signed_voltage_map,
         )
-        from kicad_tools.router.pairwise_clearance import _norm_net_key
 
         vm_path = Path(args.voltage_map).resolve()
         if not vm_path.exists():
             print(f"Error: voltage-map file not found: {vm_path}", file=sys.stderr)
             return 1
         try:
-            _raw_voltages = load_voltage_map(vm_path)
+            # Issue #4867: read the sidecar SIGNED.  Placement's
+            # ``load_voltage_map`` collapses each net to ``max(|lo|, |hi|)``
+            # (its cross-domain model is magnitude-only) and this site then
+            # took ``abs()`` again -- so a +150 V net and a -150 V net
+            # differenced to 0 V, fell below ``--hv-threshold``, and dropped
+            # out of the matrix entirely: neither the search-time kernels nor
+            # the post-route audit could see the 300 V pair.  The census
+            # (``kct creepage``) reads the same file signed, so the router now
+            # agrees with the gate it is scored against.
+            _raw_voltages = load_signed_voltage_map(vm_path)
         except (ValueError, OSError) as e:
             print(f"Error: invalid voltage-map: {e}", file=sys.stderr)
             return 1
-        _voltages = {_norm_net_key(n): abs(float(v)) for n, v in _raw_voltages.items()}
+        _voltages = {_norm_net_key(n): float(v) for n, v in _raw_voltages.items()}
         try:
             _required = build_required_by_domain_pair(
                 _voltages,

--- a/src/kicad_tools/router/pairwise_clearance.py
+++ b/src/kicad_tools/router/pairwise_clearance.py
@@ -17,10 +17,10 @@ fail-loud out-of-table contract are all reused verbatim from the already-merged
 placement derivation
 (:func:`kicad_tools.placement.hv_domains.build_required_by_domain_pair`, itself
 backed by :meth:`kicad_tools.creepage.standards.CreepageStandard.required_creepage`).
-Feeding that builder a per-net ``{net_name: |V|}`` map -- each net treated as its
-own "domain" -- yields the order-independent ``{(net_a, net_b): required_mm}``
-matrix the router resolves against, so the router, placement and the post-route
-creepage census all agree by construction.
+Feeding that builder a per-net ``{net_name: V}`` map of **signed** potentials
+(#4867) -- each net treated as its own "domain" -- yields the order-independent
+``{(net_a, net_b): required_mm}`` matrix the router resolves against, so the
+router, placement and the post-route creepage census all agree by construction.
 
 Explicitly OUT OF SCOPE here (deferred to follow-up architect phases):
 
@@ -39,8 +39,10 @@ byte-identically.
 
 from __future__ import annotations
 
+import json
 import math
 from dataclasses import dataclass
+from pathlib import Path
 from typing import TYPE_CHECKING, Callable, Iterable, Mapping, NamedTuple, Sequence
 
 from kicad_tools.core.geometry import segment_to_segment_distance
@@ -253,8 +255,11 @@ class PairwiseClearanceTable:
         dru: The scalar manufacturer/DRU clearance floor (mm).  Every resolved
             requirement is at least this value -- a pairwise widening never
             *tightens* below the fab's functional spacing.
-        net_voltages: ``{net_name: |V|}`` worst-case voltage magnitude per net,
-            keyed by the ``/``-stripped net name.  Retained for provenance /
+        net_voltages: ``{net_name: V}`` worst-case **signed** potential per net
+            (relative to the map's common reference), keyed by the
+            ``/``-stripped net name.  Signs are load-bearing (#4867): the pair
+            requirement is looked up at ``|Va - Vb|``, so a +150 V net and a
+            -150 V net are 300 V apart, not 0 V.  Retained for provenance /
             diagnostics; the resolver reads :attr:`required_by_pair`.
         required_by_pair: ``{(net_a, net_b): required_mm}`` with order-independent
             (sorted, ``/``-stripped) keys, as produced by
@@ -296,6 +301,46 @@ class PairwiseClearanceTable:
         return max(self.dru, max(self.required_by_pair.values()))
 
 
+def load_signed_voltage_map(path: str | Path) -> dict[str, float]:
+    """Load a ``--voltage-map`` sidecar preserving each net's **sign** (#4867).
+
+    Parses through :func:`kicad_tools.creepage.engine.voltage_map_from_dict` --
+    the same parse contract ``kct creepage`` uses -- so reserved ``_``-prefixed
+    metadata keys (``_comment``, ``_edge_voltage``) are skipped identically.
+
+    This is the router's counterpart to placement's
+    :func:`kicad_tools.placement.hv_domains.load_voltage_map`, which collapses
+    each net to ``max(|lo|, |hi|)`` because placement's cross-domain model is
+    magnitude-only.  The router must NOT do that: the pairwise table differences
+    potentials, and two nets at +150 V / -150 V are 300 V apart (3.20 mm of IEC
+    60664-1 creepage), not 0 V.  A bipolar map about a mid-point reference is
+    the normal encoding for an HV bank topology.
+
+    Range support (#4411): each net is parsed as a closed ``[lo, hi]`` interval
+    and collapsed to the endpoint of largest magnitude *with its sign* --
+    exactly the authored value for a scalar entry (the degenerate interval), and
+    the worst-case excursion for a swinging node.  The router's table is
+    scalar-per-net, so a genuinely swinging pair can still be differenced less
+    conservatively than the census' full
+    ``dv = max(|a.hi - b.lo|, |b.hi - a.lo|)``; consuming intervals end-to-end
+    is #4411 follow-up work, out of scope here.  For an all-non-negative map
+    this returns exactly what ``load_voltage_map`` does.
+
+    Raises:
+        ValueError: If the file is not a JSON object, or any net voltage
+            endpoint is not a finite real number.
+    """
+    from kicad_tools.creepage.engine import voltage_map_from_dict
+
+    raw = json.loads(Path(path).read_text())
+    if not isinstance(raw, dict):
+        # ``voltage_map_from_dict`` raises ``TypeError`` for a non-dict; keep the
+        # ``ValueError`` contract the CLI loaders already catch.
+        raise ValueError(f"voltage map must be a JSON object, got {type(raw).__name__}")
+    intervals = voltage_map_from_dict(raw)[0]
+    return {name: (iv.hi if abs(iv.hi) >= abs(iv.lo) else iv.lo) for name, iv in intervals.items()}
+
+
 def build_pairwise_clearance_table(
     net_voltages: Mapping[str, float],
     *,
@@ -317,10 +362,15 @@ def build_pairwise_clearance_table(
     silently extrapolating.
 
     Args:
-        net_voltages: ``{net_name: volts}`` -- signed or magnitude; magnitudes
-            are taken internally.  Reserved ``_``-prefixed metadata keys should
-            already be stripped by the loader
-            (:func:`kicad_tools.placement.hv_domains.load_voltage_map`).
+        net_voltages: ``{net_name: volts}`` -- **signed** potentials about the
+            map's common reference, differenced as supplied (#4867).  Signs are
+            load-bearing: ``{A: +150, B: -150}`` is a 300 V pair, exactly as the
+            creepage census (``kct creepage``) reads the same sidecar.  Passing
+            pre-``abs()``-ed magnitudes silently collapses every bipolar pair to
+            ``0 V`` and drops it out of the matrix, so use
+            :func:`load_signed_voltage_map` (not placement's magnitude-only
+            ``load_voltage_map``) to read a sidecar for this builder.  Reserved
+            ``_``-prefixed metadata keys are stripped by that loader.
         dru: Scalar clearance floor (mm), typically ``DesignRules.trace_clearance``.
         standard_id: Creepage standard id (``iec60664`` / ``iec62368``).
         pollution_degree: IEC pollution degree (1, 2 or 3).
@@ -339,7 +389,13 @@ def build_pairwise_clearance_table(
     # (placement.__init__ pulls router.rules), avoiding any import-order cycle.
     from kicad_tools.placement.hv_domains import build_required_by_domain_pair
 
-    normalised = {_norm_net_key(name): abs(float(v)) for name, v in net_voltages.items()}
+    # Issue #4867: difference the potentials AS SUPPLIED.  Taking ``abs()`` here
+    # (pre-#4867) collapsed every bipolar pair before ``build_required_by_domain_pair``
+    # could difference it -- +150 V vs -150 V became |150| - |150| = 0 V, fell
+    # below ``hv_threshold`` and vanished from the matrix entirely, invisible to
+    # both search-time avoidance and the post-route audit.  An all-non-negative
+    # map is unaffected (``abs`` was the identity on it).
+    normalised = {_norm_net_key(name): float(v) for name, v in net_voltages.items()}
     required = build_required_by_domain_pair(
         normalised,
         standard_id=standard_id,

--- a/tests/router/test_pairwise_clearance.py
+++ b/tests/router/test_pairwise_clearance.py
@@ -21,6 +21,7 @@ from types import SimpleNamespace
 
 import pytest
 
+from kicad_tools.creepage.engine import resolve_hv_nets
 from kicad_tools.creepage.standards import StandardLookupError
 from kicad_tools.router.layers import Layer
 from kicad_tools.router.pairwise_clearance import (
@@ -30,6 +31,7 @@ from kicad_tools.router.pairwise_clearance import (
     build_attach_zones,
     build_pairwise_clearance_table,
     find_pairwise_violations,
+    load_signed_voltage_map,
     path_pairwise_violation,
     route_pairwise_violation,
     segment_pair_violation,
@@ -149,6 +151,246 @@ def test_below_hv_threshold_pair_absent_from_matrix() -> None:
     table = _table({"/V12": 12.0, "/GND": 0.0})
     assert ("GND", "V12") not in table.required_by_pair
     assert table.required_clearance("/V12", "/GND") == pytest.approx(DRU)
+
+
+# ---------------------------------------------------------------------------
+# Signed potentials (#4867)
+# ---------------------------------------------------------------------------
+#
+# ``build_pairwise_clearance_table`` used to normalise its input with
+# ``abs(float(v))`` BEFORE differencing, so a +150 V net and a -150 V net
+# differenced to ``|150| - |150| = 0 V``, fell below ``hv_threshold`` and
+# dropped out of the matrix entirely -- invisible to search-time avoidance AND
+# to the post-route audit, which can only report on pairs its own table holds.
+# The census (``creepage/engine.py``) reads the same sidecar signed, so router
+# and gate disagreed by construction on every bipolar (bank) topology.
+
+
+def test_bipolar_pair_differences_to_the_full_span() -> None:
+    """+150 V vs -150 V is a 300 V pair (3.20 mm), not 0 V (absent)."""
+    table = _table({"/BANK_POS": 150.0, "/BANK_NEG": -150.0})
+    assert ("BANK_NEG", "BANK_POS") in table.required_by_pair
+    assert table.required_by_pair[("BANK_NEG", "BANK_POS")] == pytest.approx(3.2)
+    assert table.required_clearance("/BANK_POS", "/BANK_NEG") == pytest.approx(3.2)
+
+
+def test_bipolar_pair_is_wider_than_either_net_against_ground() -> None:
+    """The bank span binds harder than either leg's own potential."""
+    table = _table({"/BANK_POS": 150.0, "/BANK_NEG": -150.0, "/GND": 0.0})
+    span = table.required_clearance("/BANK_POS", "/BANK_NEG")
+    to_gnd = table.required_clearance("/BANK_POS", "/GND")
+    assert span > to_gnd
+    assert to_gnd == pytest.approx(IEC_150V_PD2_IIIA_MM)
+    # The magnitude reading collapsed POS<->NEG to nothing; the signed reading
+    # makes it the *widest* pair on the board.
+    assert table.max_required_clearance() == pytest.approx(span)
+
+
+def test_asymmetric_bipolar_pair_uses_the_signed_difference() -> None:
+    """-90 V vs +150 V is 240 V (2.50 mm), not the 60 V of the magnitudes."""
+    table = _table({"/SCAP_NEG": -90.0, "/SRC_POS": 150.0})
+    # 240 V under IEC 60664-1 / PD2 / IIIa.
+    assert table.required_by_pair[("SCAP_NEG", "SRC_POS")] == pytest.approx(2.5)
+    # The magnitude reading would have differenced |150| - |90| = 60 V, which is
+    # a strictly smaller (and therefore unsafe) requirement.
+    magnitude_only = _table({"/SCAP_NEG": 90.0, "/SRC_POS": 150.0})
+    assert magnitude_only.required_by_pair[("SCAP_NEG", "SRC_POS")] < 2.5
+
+
+def test_signed_pair_below_hv_threshold_stays_out_of_the_matrix() -> None:
+    """No over-correction: a signed span under the threshold is still absent.
+
+    +10 V vs -10 V is a genuine 20 V span -- signed differencing must see it as
+    20 V (not 0 V), but 20 V is below the 30 V default threshold, so the pair
+    keeps only the DRU floor exactly as an all-positive 20 V span would.
+    """
+    table = _table({"/AUX_POS": 10.0, "/AUX_NEG": -10.0})
+    assert table.required_by_pair == {}
+    assert table.required_clearance("/AUX_POS", "/AUX_NEG") == pytest.approx(DRU)
+
+
+def test_all_positive_map_is_unchanged_by_signed_differencing() -> None:
+    """Regression guard: the common non-bipolar case must not move (#4867 AC).
+
+    ``abs()`` was the identity on a non-negative map, so dropping it has to be
+    a strict no-op there -- asserted against the explicitly magnitude-normalised
+    input the pre-#4867 code built internally.
+    """
+    voltages = {"/AC_LINE": 150.0, "/GND": 0.0, "/V12": 12.0, "/HVDC": 400.0}
+    signed = build_pairwise_clearance_table(voltages, dru=DRU)
+    magnitudes = build_pairwise_clearance_table({k: abs(v) for k, v in voltages.items()}, dru=DRU)
+    assert dict(signed.required_by_pair) == dict(magnitudes.required_by_pair)
+    assert dict(signed.net_voltages) == dict(magnitudes.net_voltages)
+
+
+def test_all_negative_map_matches_its_mirror_image() -> None:
+    """A uniformly negative map differences identically to its positive mirror."""
+    negative = build_pairwise_clearance_table({"/A": -150.0, "/B": -0.0}, dru=DRU)
+    positive = build_pairwise_clearance_table({"/A": 150.0, "/B": 0.0}, dru=DRU)
+    assert dict(negative.required_by_pair) == dict(positive.required_by_pair)
+
+
+def test_signed_potentials_are_retained_for_provenance() -> None:
+    """``net_voltages`` keeps the sign so diagnostics can explain the span."""
+    table = _table({"/BANK_POS": 150.0, "/BANK_NEG": -150.0})
+    assert dict(table.net_voltages) == {"BANK_POS": 150.0, "BANK_NEG": -150.0}
+
+
+# ---------------------------------------------------------------------------
+# The router's signed sidecar loader (#4867)
+# ---------------------------------------------------------------------------
+
+
+def _write_map(tmp_path, payload) -> str:
+    import json
+
+    p = tmp_path / "vmap.json"
+    p.write_text(json.dumps(payload))
+    return str(p)
+
+
+def test_load_signed_voltage_map_preserves_sign(tmp_path) -> None:
+    """The router's loader must NOT collapse to a magnitude (placement's does)."""
+    from kicad_tools.placement.hv_domains import load_voltage_map
+
+    path = _write_map(tmp_path, {"/BANK_POS": 150, "/BANK_NEG": -150, "/GND": 0})
+    assert load_signed_voltage_map(path) == {
+        "/BANK_POS": 150.0,
+        "/BANK_NEG": -150.0,
+        "/GND": 0.0,
+    }
+    # Placement's magnitude-only loader is the thing that used to be reused here.
+    assert load_voltage_map(path)["/BANK_NEG"] == 150.0
+
+
+def test_load_signed_voltage_map_skips_reserved_metadata_keys(tmp_path) -> None:
+    """Same parse contract as ``kct creepage``: ``_``-prefixed keys are not nets."""
+    path = _write_map(
+        tmp_path,
+        {"_comment": "signed volts about GND", "_edge_voltage": 0, "/HV": -150},
+    )
+    assert load_signed_voltage_map(path) == {"/HV": -150.0}
+
+
+def test_load_signed_voltage_map_collapses_a_range_to_its_signed_extreme(
+    tmp_path,
+) -> None:
+    """A swinging node (#4411) keeps the SIGN of its worst-case endpoint."""
+    path = _write_map(tmp_path, {"/SW": {"min": -170, "max": 90}, "/GND": 0})
+    assert load_signed_voltage_map(path) == {"/SW": -170.0, "/GND": 0.0}
+
+
+def test_load_signed_voltage_map_matches_placement_on_a_positive_map(
+    tmp_path,
+) -> None:
+    """All-non-negative maps read identically through either loader (#4867 AC)."""
+    from kicad_tools.placement.hv_domains import load_voltage_map
+
+    path = _write_map(tmp_path, {"/AC_LINE": 150, "/GND": 0, "/V12": 12})
+    assert load_signed_voltage_map(path) == load_voltage_map(path)
+
+
+def test_load_signed_voltage_map_rejects_a_non_object(tmp_path) -> None:
+    """The CLI catches ``ValueError``; a JSON array must not escape as TypeError."""
+    path = _write_map(tmp_path, [1, 2, 3])
+    with pytest.raises(ValueError):
+        load_signed_voltage_map(path)
+
+
+# ---------------------------------------------------------------------------
+# Parity with the creepage census over a bipolar map (#4867 AC)
+# ---------------------------------------------------------------------------
+
+
+def _bipolar_board_source() -> str:
+    """Three single-pad footprints: +150 V, -150 V and 0 V, well separated."""
+    pads = [("BANK_POS", 1, 105.0), ("BANK_NEG", 2, 115.0), ("GND", 3, 125.0)]
+    fps = "".join(
+        f"""  (footprint "test:pad" (layer "F.Cu") (at {x} 110)
+    (pad "1" smd rect (at 0 0) (size 2 2) (layers "F.Cu")
+      (net {num} "{name}"))
+  )
+"""
+        for name, num, x in pads
+    )
+    return f"""(kicad_pcb
+  (version 20240108)
+  (generator "test_4867")
+  (general (thickness 1.6))
+  (paper "A4")
+  (layers
+    (0 "F.Cu" signal)
+    (31 "B.Cu" signal)
+    (44 "Edge.Cuts" user)
+  )
+  (setup (pad_to_mask_clearance 0))
+  (net 0 "")
+  (net 1 "BANK_POS")
+  (net 2 "BANK_NEG")
+  (net 3 "GND")
+  (gr_line (start 100 100) (end 130 100) (layer "Edge.Cuts") (width 0.1))
+  (gr_line (start 130 100) (end 130 120) (layer "Edge.Cuts") (width 0.1))
+  (gr_line (start 130 120) (end 100 120) (layer "Edge.Cuts") (width 0.1))
+  (gr_line (start 100 120) (end 100 100) (layer "Edge.Cuts") (width 0.1))
+{fps})
+"""
+
+
+def test_router_table_matches_the_creepage_census_on_a_bipolar_map(tmp_path) -> None:
+    """The router and ``kct creepage`` must require the SAME mm on every pair.
+
+    This is the #4867 acceptance criterion asserted as parity over a bipolar
+    fixture rather than a spot check: the census differences the sidecar's
+    signed endpoints, so any magnitude collapse on the router side shows up
+    here as a missing pair (POS<->NEG) or a smaller requirement.
+    """
+    from kicad_tools._shapely import has_shapely
+
+    if not has_shapely():
+        pytest.skip("creepage census requires shapely")
+
+    from kicad_tools.creepage.engine import (
+        compute_creepage_census,
+        voltage_map_from_dict,
+    )
+    from kicad_tools.creepage.standards import get_standard
+    from kicad_tools.schema.pcb import PCB
+
+    payload = {"BANK_POS": 150, "BANK_NEG": -150, "GND": 0}
+    board = tmp_path / "bipolar.kicad_pcb"
+    board.write_text(_bipolar_board_source())
+    pcb = PCB.load(board)
+
+    intervals = voltage_map_from_dict(payload)[0]
+    hv_nets = resolve_hv_nets(pcb, "HV", None, voltage_map=intervals, census_threshold=30.0)
+    report = compute_creepage_census(
+        pcb,
+        hv_nets,
+        voltage_map=intervals,
+        standard_obj=get_standard("iec60664"),
+        pollution_degree=2,
+        material_group="IIIa",
+    )
+    census_required = {
+        tuple(sorted((p.net_a, p.net_b))): p.required_creepage_mm
+        for p in report.pairs
+        if p.kind == "conductor"
+    }
+    assert census_required, "census produced no conductor pairs"
+
+    router_map = load_signed_voltage_map(_write_map(tmp_path, payload))
+    table = build_pairwise_clearance_table(router_map, dru=DRU)
+
+    for pair, census_mm in census_required.items():
+        assert census_mm is not None
+        if census_mm <= DRU:
+            continue  # below the DRU floor -- the router keeps the scalar path
+        assert table.required_by_pair.get(pair) == pytest.approx(census_mm), (
+            f"router/census disagree on {pair}: {table.required_by_pair.get(pair)} vs {census_mm}"
+        )
+    # And specifically the pair the magnitude collapse used to erase.
+    assert ("BANK_NEG", "BANK_POS") in census_required
+    assert ("BANK_NEG", "BANK_POS") in table.required_by_pair
 
 
 # ---------------------------------------------------------------------------

--- a/tests/router/test_pairwise_cpp_parity.py
+++ b/tests/router/test_pairwise_cpp_parity.py
@@ -445,6 +445,29 @@ def test_build_cpp_domain_matrix_normalises_leading_slash() -> None:
     assert matrix[net_to_domain[1]][net_to_domain[2]] == pytest.approx(IEC_150V_PD2_IIIA_MM)
 
 
+def test_build_cpp_domain_matrix_carries_a_bipolar_span() -> None:
+    """Issue #4867: a signed (+/-) map projects the FULL span into the matrix.
+
+    The C++ grid has no concept of a net's voltage -- it only reads the dense
+    mm matrix built here.  So the magnitude collapse in
+    ``build_pairwise_clearance_table`` (+150 V vs -150 V -> 0 V -> pair absent)
+    reached the C++ validator as a *dormant* payload: no domains, no widening,
+    no rejection.  This pins the projection end of the fix.
+    """
+    table = build_pairwise_clearance_table({"/BANK_POS": 150.0, "/BANK_NEG": -150.0}, dru=DRU)
+    domains = build_cpp_domain_matrix(table, {"/BANK_POS": 1, "/BANK_NEG": 2})
+    assert domains is not None, "bipolar pair must not project to a dormant payload"
+    net_to_domain, matrix = domains
+    pos, neg = net_to_domain[1], net_to_domain[2]
+    # 300 V under IEC 60664-1 / PD2 / IIIa.
+    assert matrix[pos][neg] == pytest.approx(3.2)
+    assert matrix[neg][pos] == pytest.approx(3.2)
+    # And the dense matrix still reproduces the Python resolver exactly.
+    assert max(table.dru, matrix[pos][neg]) == pytest.approx(
+        table.required_clearance("/BANK_POS", "/BANK_NEG")
+    )
+
+
 def test_build_cpp_domain_matrix_dormant_without_widening_pairs() -> None:
     assert build_cpp_domain_matrix(None, NET_NAMES) is None
     # All nets at the same potential -> no pair needs widening.
@@ -695,6 +718,43 @@ def test_backend_validate_route_rejects_hv_trace_beside_lv_pad() -> None:
     backend.set_attach_zones((AttachZone(0.0, -1.0, 5.0, 1.0, frozenset({"AC_LINE", "GND"})),))
     cpp_grid._impl.set_pairwise_domains([], [])  # force a fresh install
     assert backend._validate_route_clearance(route, start, end, 1) is None
+
+
+@requires_cpp
+def test_backend_validate_route_rejects_a_bipolar_neighbour() -> None:
+    """Issue #4867: the C++ validator sees the +/-150 V span end to end.
+
+    Same geometry as the HV-vs-LV-pad case above, but the neighbouring pad is
+    at -150 V instead of 0 V -- a *wider* 300 V pair.  Pre-#4867 the magnitude
+    collapse differenced it to 0 V, ``build_cpp_domain_matrix`` returned the
+    dormant ``None``, and the C++ grid validated this route clean.  Confirms
+    the Python-only fix reaches the C++ consumer without a recompile.
+    """
+    py_grid, rules = _backend_grid_and_rules()
+    bank_names = {"/BANK_POS": HV_NET, "/BANK_NEG": LV_NET}
+    rules.pairwise_clearance = build_pairwise_clearance_table(
+        {"/BANK_POS": 150.0, "/BANK_NEG": -150.0}, dru=DRU
+    )
+    cpp_grid = CppGrid.from_routing_grid(py_grid)
+    backend = CppPathfinder(cpp_grid, rules, diagonal_routing=True)
+    backend.set_net_name_to_id(bank_names)
+
+    # -150 V pad 0.4 mm off the +150 V candidate's centreline -> 0.2 mm gap,
+    # DRU-legal but far inside the 3.2 mm creepage requirement.
+    cpp_grid._impl.add_pad(2.5, 0.4, 0.2, 0.2, LV_NET, 0, 0, DRU, False)
+
+    route = Route(
+        net=HV_NET,
+        net_name="/BANK_POS",
+        segments=[
+            Segment(0.0, 0.0, 5.0, 0.0, TRACE_WIDTH, Layer.F_CU, net=HV_NET, net_name="/BANK_POS")
+        ],
+    )
+    start = Pad(0.0, 0.0, 0.2, 0.2, HV_NET, "/BANK_POS")
+    end = Pad(5.0, 0.0, 0.2, 0.2, HV_NET, "/BANK_POS")
+
+    assert backend._validate_route_clearance(route, start, end, 1) is not None
+    assert cpp_grid._impl.pairwise_required_clearance(HV_NET, LV_NET) == pytest.approx(3.2)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_route_signed_voltage_map_4867.py
+++ b/tests/test_route_signed_voltage_map_4867.py
@@ -1,0 +1,216 @@
+"""CLI-level tests for signed ``--voltage-map`` potentials (issue #4867).
+
+``kct route --voltage-map`` read its sidecar through placement's
+magnitude-only loader and then took ``abs()`` again, so on a **signed** map --
+the normal encoding for a bipolar HV bank, and the encoding ``kct creepage``
+itself reads -- a ``+150 V`` net and a ``-150 V`` net differenced to ``0 V``.
+Below the 30 V threshold, such a pair was not merely under-required: it was
+**absent from the matrix entirely**, therefore invisible to search-time
+avoidance *and* to the post-route audit, which can only report on pairs its own
+table holds.  The run printed a reassuring ``HV pairwise clearance: N mapped
+nets, M cross-pairs`` banner (with ``M`` silently short by every bank pair) and
+exited 0 over +/-300 V copper at the DRU floor.
+
+These tests pin the CLI end of the fix:
+
+1. a bipolar map on a board with preserved +/-150 V copper 0.4 mm apart is a
+   hard FAIL, not a silent SUCCESS;
+2. the banner's cross-pair count is the signed count;
+3. a signed span *below* ``--hv-threshold`` still yields no pairs (no
+   over-correction); and
+4. an all-positive map behaves exactly as before.
+
+The board is a fully synthetic S-expression string (same approach as
+``test_route_pairwise_gate_4588.py``) -- the softstart rev-C board from the
+original report is local-only and must never be a CI dependency.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from kicad_tools.cli.route_cmd import main as route_main
+
+# +/-150 V about the map's reference: a 300 V span requiring 3.2 mm of creepage
+# under IEC 60664-1 / PD2 / material group IIIa.  Either leg alone against 0 V
+# needs only 1.6 mm -- so the span is the binding requirement, and it is exactly
+# the one the magnitude collapse erased.
+BANK_VOLTS = 150.0
+
+
+def _pad(number: str, x: float, y: float, net: int, net_name: str) -> str:
+    return (
+        f'(pad "{number}" smd rect (at {x} {y}) (size 0.4 0.4) '
+        f'(layers "F.Cu" "F.Paste" "F.Mask") (net {net} "{net_name}"))'
+    )
+
+
+def _fp(ref: str, uid: int, x: float, y: float, pads: str) -> str:
+    return f"""  (footprint "Resistor_SMD:R_0603_1608Metric"
+    (layer "F.Cu")
+    (uuid "00000000-0000-0000-0000-0000000000{uid:02d}")
+    (at {x} {y})
+    (property "Reference" "{ref}" (at 0 -1.5 0) (layer "F.SilkS"))
+    (property "Value" "10k" (at 0 1.5 0) (layer "F.Fab"))
+    {pads}
+  )
+"""
+
+
+def _bipolar_preserved_board() -> str:
+    """Preserved +/-150 V copper 0.6 mm apart (0.4 mm edge-to-edge).
+
+    ``/BANK_POS`` and ``/BANK_NEG`` carry hand-placed ``(segment ...)`` copper
+    and have no pads at all, so the router never re-routes them: with
+    ``--preserve-existing`` that copper is re-emitted verbatim and the
+    post-route audit (#4699) scans it.  Fixing the geometry at author time
+    keeps this test independent of any search outcome.  ``/SIG_A`` is an
+    ordinary two-pad link in the far corner that gives the run something to do.
+    """
+    parts = [
+        _fp("R1", 10, 103.0, 120.0, _pad("1", 0, 0, 3, "/SIG_A")),
+        _fp("R2", 11, 127.0, 120.0, _pad("1", 0, 0, 3, "/SIG_A")),
+    ]
+    return f"""(kicad_pcb
+  (version 20240108)
+  (generator "test")
+  (generator_version "8.0")
+  (general
+    (thickness 1.6)
+  )
+  (layers
+    (0 "F.Cu" signal)
+    (31 "B.Cu" signal)
+    (44 "Edge.Cuts" user)
+  )
+  (setup
+    (pad_to_mask_clearance 0)
+  )
+  (net 0 "")
+  (net 1 "/BANK_POS")
+  (net 2 "/BANK_NEG")
+  (net 3 "/SIG_A")
+  (gr_rect (start 100 100) (end 130 124)
+    (stroke (width 0.1) (type default))
+    (fill none)
+    (layer "Edge.Cuts")
+  )
+  (segment (start 105 105) (end 125 105) (width 0.2) (layer "F.Cu") (net 1))
+  (segment (start 105 105.6) (end 125 105.6) (width 0.2) (layer "F.Cu") (net 2))
+{"".join(parts)})
+"""
+
+
+def _write_map(tmp_path: Path, payload: dict, name: str = "vmap.json") -> Path:
+    vmap = tmp_path / name
+    vmap.write_text(json.dumps(payload))
+    return vmap
+
+
+def _route_args(pcb: Path, out: Path, vmap: Path | None) -> list[str]:
+    args = [
+        str(pcb),
+        "-o",
+        str(out),
+        "--route-engine",
+        "lattice",
+        "--strategy",
+        "basic",
+        "--skip-drc",
+        "--preserve-existing",
+    ]
+    if vmap is not None:
+        args += [
+            "--voltage-map",
+            str(vmap),
+            "--creepage-standard",
+            "iec60664",
+            "--pollution-degree",
+            "2",
+            "--material-group",
+            "IIIa",
+        ]
+    return args
+
+
+@pytest.fixture
+def bipolar_board(tmp_path: Path) -> Path:
+    pcb = tmp_path / "bipolar.kicad_pcb"
+    pcb.write_text(_bipolar_preserved_board())
+    return pcb
+
+
+def test_signed_map_no_longer_false_passes_bipolar_copper(
+    bipolar_board: Path, tmp_path: Path, capsys
+) -> None:
+    """The headline regression: +/-150 V at 0.4 mm must FAIL the run."""
+    vmap = _write_map(tmp_path, {"/BANK_POS": BANK_VOLTS, "/BANK_NEG": -BANK_VOLTS})
+    out = tmp_path / "bipolar_routed.kicad_pcb"
+
+    rc = route_main(_route_args(bipolar_board, out, vmap))
+    captured = capsys.readouterr().out
+
+    assert rc != 0, f"expected a non-zero exit, got {rc}\n{captured}"
+    assert "SUCCESS:" not in captured
+    assert "pairwise HV clearance violations" in captured
+    assert "/BANK_POS vs /BANK_NEG" in captured or "/BANK_NEG vs /BANK_POS" in captured
+
+
+def test_banner_reports_the_signed_cross_pair_count(
+    bipolar_board: Path, tmp_path: Path, capsys
+) -> None:
+    """``M cross-pairs`` must count the pair, not silently omit it."""
+    vmap = _write_map(tmp_path, {"/BANK_POS": BANK_VOLTS, "/BANK_NEG": -BANK_VOLTS})
+    out = tmp_path / "banner.kicad_pcb"
+
+    route_main(_route_args(bipolar_board, out, vmap))
+    captured = capsys.readouterr().out
+
+    assert "HV pairwise clearance: 2 mapped nets, 1 cross-pairs" in captured
+
+
+def test_signed_span_below_the_threshold_stays_dormant(
+    bipolar_board: Path, tmp_path: Path, capsys
+) -> None:
+    """No over-correction: +/-10 V is a real 20 V span, still under 30 V."""
+    vmap = _write_map(tmp_path, {"/BANK_POS": 10.0, "/BANK_NEG": -10.0})
+    out = tmp_path / "lowv.kicad_pcb"
+
+    rc = route_main(_route_args(bipolar_board, out, vmap))
+    captured = capsys.readouterr().out
+
+    assert rc == 0, captured
+    assert "HV pairwise clearance: 2 mapped nets, 0 cross-pairs" in captured
+    assert "pairwise HV clearance violations" not in captured
+
+
+def test_all_positive_map_is_unchanged(bipolar_board: Path, tmp_path: Path, capsys) -> None:
+    """The common non-bipolar case must behave exactly as before (#4867 AC).
+
+    150 V vs 0 V needs 1.6 mm; the planted copper is 0.4 mm apart, so this map
+    failed pre-#4867 and must still fail -- with the same single cross-pair.
+    """
+    vmap = _write_map(tmp_path, {"/BANK_POS": BANK_VOLTS, "/BANK_NEG": 0.0})
+    out = tmp_path / "positive.kicad_pcb"
+
+    rc = route_main(_route_args(bipolar_board, out, vmap))
+    captured = capsys.readouterr().out
+
+    assert rc != 0, captured
+    assert "HV pairwise clearance: 2 mapped nets, 1 cross-pairs" in captured
+    assert "pairwise HV clearance violations" in captured
+
+
+def test_no_voltage_map_is_still_a_strict_noop(bipolar_board: Path, tmp_path: Path, capsys) -> None:
+    """Dormancy: without ``--voltage-map`` nothing about this board changes."""
+    out = tmp_path / "noflag.kicad_pcb"
+
+    rc = route_main(_route_args(bipolar_board, out, None))
+    captured = capsys.readouterr().out
+
+    assert rc == 0, captured
+    assert "SUCCESS:" in captured
+    assert "HV pairwise clearance:" not in captured


### PR DESCRIPTION
Closes #4867

## Problem

`route --voltage-map` normalised its voltage map to **magnitudes** before differencing — in **two** places, not the one the issue named:

1. `build_pairwise_clearance_table()` (`src/kicad_tools/router/pairwise_clearance.py`) took `abs(float(v))` on the way in; and
2. `route_cmd`'s `--voltage-map` preload read the sidecar through placement's magnitude-only `load_voltage_map` (which itself collapses each net to `max(|lo|, |hi|)`) and then took `abs()` **again**.

Fixing only (1) would have left the CLI path unchanged, because the CLI never calls `build_pairwise_clearance_table` — it calls `build_required_by_domain_pair` directly on an already-collapsed map.

The creepage census reads the **same file** signed (`creepage/engine.py`, `dv = max(|a.hi − b.lo|, |b.hi − a.lo|)`), so on a bipolar map the two disagreed by construction: `+150 V` vs `−150 V` is 300 V (3.20 mm) to the census and **0 V** to the router. Below the 30 V `--hv-threshold` such a pair was not merely under-required but **absent from the matrix**, therefore invisible to the search-time kernels *and* to the post-route audit, which can only report on pairs its own table contains. The run printed a reassuring `HV pairwise clearance: N mapped nets, M cross-pairs` banner and exited 0 over ±300 V copper at the DRU floor.

## Change

- Difference potentials **as supplied** in `build_pairwise_clearance_table` (drop the `abs()`), and correct the docstring's now-false "signed or magnitude; magnitudes are taken internally" claim.
- New `router.pairwise_clearance.load_signed_voltage_map(path)` — the router's counterpart to placement's loader, parsing through `creepage.engine.voltage_map_from_dict` so it honours the census' exact parse contract (`_`-prefixed metadata keys skipped, `_edge_voltage` recognised). A #4411 `{min,max}` range collapses to its worst-case endpoint **with its sign**; for an all-non-negative map it returns exactly what `load_voltage_map` does.
- `route_cmd` uses that loader and stops re-`abs()`-ing, so the banner's cross-pair count is now the signed count. `--voltage-map` help text says so.
- Placement's `load_voltage_map` and `build_required_by_domain_pair` are **deliberately untouched** — the latter's `dv = abs(a - b)` already matched census semantics; the sign was destroyed upstream of it. Placement's magnitude-only model has no reference potential, so collapsing there is correct for that consumer.

**Python-only, confirmed.** The C++ grid has no concept of a net's voltage (`grep -n voltage` over `router/cpp/{src,include}` finds only comments) — it consumes the already-built dense mm matrix via `build_cpp_domain_matrix` → `Grid3D::set_pairwise_domains`. The corrected requirements reach it with no recompile; a new bipolar case in the C++ parity suite pins that in practice rather than by code-reading.

## Re-measurement on the real fixture

Replayed the #4866 measurement over softstart rev-C's own 84-net `vmap.json` (md5 `cc72a701a6c4c3c335859bcc6029ab94`, exact match to the proof doc) on the fixed tree:

```
cross-pairs, signed (post-fix)      : 1922   <- what the banner now prints
cross-pairs, magnitude (pre-fix)    : 1823
pairs that RE-ENTER the matrix      :   99
pairs previously UNDER-required     :  240
total previously under-constrained  :  339 / 1922  (17.6 %)
pairs LOST by the fix               :    0
worst: AC_LINE <-> {BOOST_B,GATE_BUS,GATE_DRV,SRC,TRK}_NEG   3.20 mm (was 0.00)
```

Reproduces the issue's numbers exactly. `docs/hv-pairwise-softstart-proof.md` carries an update banner: the routing arms were **not** re-run, so its 49/82 · 42-census-fail · 3-gate-hit figures are pre-fix and stale, and **#4507's T4 must be re-scored** — per that issue's own AC the leak set is expected to *grow* first, since 99 pairs re-enter the matrix.

## Acceptance criteria

| AC | Where |
|---|---|
| Signed map yields the same per-pair requirements as `kct creepage`, as a parity test over a bipolar fixture | `test_router_table_matches_the_creepage_census_on_a_bipolar_map` — runs the real `compute_creepage_census` over a 3-net (+150 / −150 / 0) synthetic board and compares every conductor pair |
| `{A: +150, B: -150}` → 300 V, both at table level and end-to-end through `route --voltage-map` | `test_bipolar_pair_differences_to_the_full_span`, `test_signed_map_no_longer_false_passes_bipolar_copper` |
| A pair below `hv_threshold` on signed values stays out of the matrix (no over-correction) | `test_signed_pair_below_hv_threshold_stays_out_of_the_matrix`, `test_signed_span_below_the_threshold_stays_dormant` (±10 V = a real 20 V span, still under 30 V) |
| Banner reports the signed cross-pair count | `test_banner_reports_the_signed_cross_pair_count` |
| An all-positive map is byte-identical to today | `test_all_positive_map_is_unchanged_by_signed_differencing` (asserted against the explicitly magnitude-normalised input the old code built internally), `test_all_negative_map_matches_its_mirror_image`, `test_all_positive_map_is_unchanged` (e2e) |
| Re-measure softstart rev-C | above, plus the doc update |

## Tests

New: 15 cases across `tests/router/test_pairwise_clearance.py` (signed differencing + the loader + census parity), `tests/router/test_pairwise_cpp_parity.py` (dense-matrix projection + a C++ `validate_route` rejection of a bipolar neighbour), and a new `tests/test_route_signed_voltage_map_4867.py` (CLI end-to-end over preserved ±150 V copper 0.4 mm apart, so the assertion does not depend on any search outcome).

**Vacuity-checked**: with the two `abs()` calls temporarily restored, **9** of the new tests fail and every all-positive/parity test still passes — the suite is measuring the fix, not the geometry.

Green locally:
- `tests/router` + `tests/creepage` + `tests/test_route_pairwise_gate_4588.py` + `tests/test_placement_hv_domains.py` + `tests/test_optimize_placement_cmd.py` + `tests/test_route_exit_codes.py` + the new file — **1815 passed, 5 skipped**
- `tests/test_pipeline_cmd.py`, `test_build_cmd_errors.py`, `test_pipeline_cli_args.py`, `test_format_json_sweep_drivers.py`, `test_lattice_keepout_areas.py`, `test_router_cache.py`, `test_audit_hv_isolation.py` — **582 passed**
- `ruff check` / `ruff format --check` clean on touched files; `scripts/ci/check_mypy_baseline.py` → 1464 errors, within the 1472 baseline (no new type errors, baseline untouched)
- C++ backend built in the worktree (`kct build-native`), so the parity suite ran against the real extension

## Out of scope

- Consuming `VoltageInterval` end-to-end in the router (the table stays scalar-per-net) — that is #4411 follow-up, flagged in the new loader's docstring.
- `creepage/export_rules.py` and `optimize_placement_cmd.py` also magnitude-normalise; both are different commands with their own semantics and are untouched here.
- Any #4507 Phase-2 feature work. This is the blocker only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014jM7psrLav9YQ8fqzzsa23