### PR TITLE
feat(scripts): census which corpus boards can actually serve as benchmarks

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -50,6 +50,7 @@ Point-in-time working documents — dated entries describe the tree as of their 
 | [HV Pairwise Proof: softstart rev-C (2026-08)](hv-pairwise-softstart-proof.md) | #4507 T4 manual proof run on the local-only mains HV fixture |
 | [Placement Pad-Anchoring Audit (2026-08)](placement-pad-anchoring-audit.md) | Centre- vs pad-anchored placement objective terms (#4831) |
 | [OmniLayout / OmniRouting Recon (2026-08)](research/omnilayout-recon.md) | External LLM layout/routing benchmark (#4830); verdict: adapt the metric protocol, drop the data (no licence) |
+| [Corpus Benchmark Feasibility (2026-08)](research/corpus-benchmark-feasibility.md) | #4830 slice 4: which open-schematics boards can serve as capacity-predictor labels (#4799) or route-vs-human cases, plus three pilot routes |
 | [Board Fleet Parity Audit (2026-06)](board-fleet-parity-audit-2026-06.md) | Fleet-wide board status snapshot |
 | [Install Pilot: chorus](install-pilot-chorus.md) | Consumer-repo install pilot for Epic #4054 acceptance |
 | [Atopile Build System Research](research-atopile-build-system.md) | Survey of Atopile's build DAG and targets |

--- a/docs/research/corpus-benchmark-feasibility.md
+++ b/docs/research/corpus-benchmark-feasibility.md
@@ -21,7 +21,7 @@ input at all?**
 | Question | Answer |
 |----------|--------|
 | Is the corpus usable for capacity-predictor calibration? | **Yes, but the sample must be ~3× larger than the naive estimate.** Only **36%** of pinned PCBs (8/22) yield a feature vector *and* a positive label; the rest are blocked, mostly by one fixable parser gap. |
-| Is a route-vs-human harness feasible? | **Yes — demonstrated end-to-end**, but not as a one-liner. Of 3 pilot boards, 1 routed out of the box, 1 crashed the router, 1 was refused by the grid-safety gate. The harness needs a per-board preflight, not just `strip_traces` + `kct route`. |
+| Is a route-vs-human harness feasible? | **Yes — demonstrated end-to-end**, but not as a one-liner. Of 3 pilot boards, 1 routed out of the box, 1 crashed the router, and 1 was refused by the grid-safety gate until its grid was set by hand (then reached 20% against the human's 100%). The harness needs a per-board preflight, not just `strip_traces` + `kct route`. |
 | Should either be built next? | **Build the harness first, on a handful of boards; defer predictor calibration.** The harness surfaced three generic library defects in three boards. Calibration needs hundreds of labeled boards, which is gated on the same parser gap. |
 | Biggest single lever | **Legacy `(module …)` support.** It alone blocks 41% of the sampled corpus (9/22 boards), *all* of which carry copper. |
 
@@ -121,13 +121,13 @@ right.
 
 The harness recipe is short — `PCB.load` → `strip_traces()` → `kct route` →
 compare — and every piece already exists. Running it on three candidates
-produced one comparison and two library defects:
+produced two comparisons and two library defects:
 
 | Board | Size | Human reference | `kct route` result |
 |-------|------|-----------------|--------------------|
 | `os-0007182-pcb0` | 20 pads, 6 nets, 5.2 cm², 2 layers | 22 seg, 0 vias, **26.9 mm** | **83% (5/6 nets)**, 36 seg, 1 via, **42.5 mm** (1.58× the human wirelength); `/GND` left 4/5 pads connected |
 | `os-0003340-pcb0` | 73 pads, 15 nets, 8.4 cm² | 143 seg, 45 vias, 305.9 mm | **crash** — off-board preflight false-positives 25/47 footprints, then `ValueError: A linearring requires at least 4 coordinates` |
-| `os-0009947-pcb1` | 110 pads, 19 nets, 9.6 cm², 11.4 pads/cm² | 183 seg, 45 vias, 295.5 mm | **refused** — auto-grid safety gate: 0.127 mm grid > clearance/2 (0.075 mm) under the default manufacturer profile |
+| `os-0009947-pcb1` | 110 pads, 19 nets, 9.6 cm², 11.4 pads/cm² | 183 seg, 45 vias, 295.5 mm | **refused by default** (auto-grid safety gate: 0.127 mm grid > clearance/2 = 0.075 mm under our default manufacturer profile); with an explicit `--grid 0.05` it routes and reaches **20% (3/15 nets)** in ~5 min, 48 seg, 9 vias, 54.5 mm |
 
 Each failure is informative, and none is fatal to the idea:
 
@@ -140,17 +140,23 @@ Each failure is informative, and none is fatal to the idea:
   it is a `schema.pcb` gap, not a corpus artifact, and it will hit any user
   with a rounded-corner board. The census now predicts it
   (`outline-not-polygonal`) instead of discovering it at crash time.
-- **`os-0009947-pcb1` — imported rules vs. our profile.** The human routed to
-  that board's *own* design rules; we applied the default manufacturer profile
-  and the grid-safety rule (correctly) refused rather than emit shorts. Raising
-  `--max-cells` to 4 M does not change the verdict. A harness must adopt each
-  board's `(setup …)` clearance/track-width — comparing our router at
-  JLCPCB-tier rules against a human at their own rules is not a comparison.
+- **`os-0009947-pcb1` — imported rules vs. our profile, then a real gap.** The
+  human routed to that board's *own* design rules; we applied the default
+  manufacturer profile and the grid-safety rule (correctly) refused rather than
+  emit shorts. Raising `--max-cells` to 4 M does not change that verdict —
+  only an explicit `--grid 0.05` does. Forced past the gate, the router
+  completes **3 of 15 nets (20%)** in ~5 minutes where the human completed all
+  of them on 2 layers with 45 vias. Two lessons: a harness must adopt each
+  board's `(setup …)` clearance/track-width (our router at JLCPCB-tier rules
+  vs. a human at their own rules is not a comparison), and once that is fixed
+  there is a genuine capability gap to measure — this board is 11.4 pads/cm²,
+  4.5× the median density of anything in `boards/`.
 
-**What the one successful pilot already tells us**: on a trivially small board
-our router completes 5/6 nets and spends 1.58× the human's copper length. That
-is the first time this repo has measured itself against human-authored copper
-at all, and it took ~4 minutes of compute.
+**What the two comparisons already tell us**: on a trivially small board our
+router completes 5/6 nets and spends 1.58× the human's copper length; on a
+dense one it reaches 20% where the human reached 100%. That is the first time
+this repo has measured itself against human-authored copper at all, and it cost
+minutes of compute per board.
 
 ## 4. Recommendation
 

--- a/docs/research/corpus-benchmark-feasibility.md
+++ b/docs/research/corpus-benchmark-feasibility.md
@@ -46,7 +46,7 @@ engineering action:
 | `legacy-module-schema` | the diagnosable cause of most of the above: pre-KiCad-6 `(module …)` | parser |
 | `no-net-binding` | pads exist, but no net has ≥ 2 pads | the design (not fixable) |
 | `no-outline` | no Edge.Cuts bounding box with positive area | the design |
-| `outline-not-polygonal` | bounding box fine, but `get_board_outline()` returns < 3 points | `schema.pcb` arc chaining |
+| `outline-not-polygonal` | bounding box fine, but `get_board_outline()` returns < 3 points | parser — `GraphicArc.from_sexp`, the pre-KiCad-6 `(gr_arc … angle …)` form |
 | `no-reference-copper` | no copper at all — an unrouted *input*, never a reference | the design |
 | `partial-reference-routing` | < 95% of multi-pad nets carry copper — too incomplete to score against | the design |
 
@@ -78,6 +78,15 @@ blockers                          boards
   no-outline                           1
   outline-not-polygonal                1
 ```
+
+The blocker column does **not** sum to 22, by design: a board carries every
+code that applies to it, one per distinct engineering action, so the counts
+overlap. All 9 `legacy-module-schema` boards *are* the same 9 `no-pad-graph`
+boards — the second code names the fixable cause of the first. The
+featurizability blockers (`no-pad-graph`, `no-net-binding`, `no-outline`,
+`outline-not-polygonal`) fall on 12 distinct boards, leaving the 10
+featurizable ones; `no-reference-copper` then disqualifies 2 of those 10 as
+*references* while leaving them usable as predictor inputs.
 
 ### 2.1 The dominant blocker is one parser gap
 
@@ -131,14 +140,36 @@ produced two comparisons and two library defects:
 
 Each failure is informative, and none is fatal to the idea:
 
-- **`os-0003340-pcb0` — arc outlines.** Its Edge.Cuts is a rounded rectangle:
-  4 `gr_line` + 4 `gr_arc`. `get_board_outline()` chains only the straight
-  segments and returns **2 points**, which makes the off-board preflight
-  reject two-thirds of the board and then kills the run inside shapely. This
-  reproduces on a hand-written 8-primitive board (see
-  `tests/test_corpus_readiness.py::…::test_rounded_outline_has_area_but_no_usable_polygon`) —
-  it is a `schema.pcb` gap, not a corpus artifact, and it will hit any user
-  with a rounded-corner board. The census now predicts it
+- **`os-0003340-pcb0` — legacy arcs, the same gap as §2.1.** Its Edge.Cuts is a
+  rounded rectangle: 4 `gr_line` + 4 `gr_arc`, and `get_board_outline()`
+  returns **2 points**, which makes the off-board preflight reject two-thirds
+  of the board and then kills the run inside shapely. The chainer is not at
+  fault — it already emits `start→mid` and `mid→end` per arc
+  (`src/kicad_tools/schema/pcb.py:3482-3485`), and a well-formed KiCad-6
+  rounded rectangle chains to 13 points. The defect is one level down, in the
+  **parser**: the board declares `version 20210623` and writes its arcs in the
+  pre-KiCad-6 centre+angle form, with no `mid` token at all —
+
+  ```
+  (gr_arc (start 100.999997 93) (end 101 92) (angle -90) (layer "Edge.Cuts") …)
+  ```
+
+  `GraphicArc.from_sexp` (`src/kicad_tools/schema/pcb.py:1596-1623`) reads
+  `start`/`mid`/`end` literally, so `mid` silently defaults to `(0, 0)`. Every
+  arc then injects a segment to the origin and poisons the chain. Measured
+  side by side on hand-written 8-primitive boards (both pinned in
+  `tests/test_corpus_readiness.py`):
+
+  ```
+  v6-wellformed      outline_points = 13
+  legacy-centre-arc  outline_points =  2
+  ```
+
+  So this is **not** a generic "rounded corners break" defect — KiCad 6+ files
+  are fine. It hits boards written by pre-KiCad-6 (or 5.99-era) tools, which
+  makes it the *second instance of finding #1's root cause*: a legacy schema
+  that is neither read nor refused, just silently half-understood. It is a
+  library gap, not a corpus artifact. The census now predicts it
   (`outline-not-polygonal`) instead of discovering it at crash time.
 - **`os-0009947-pcb1` — imported rules vs. our profile, then a real gap.** The
   human routed to that board's *own* design rules; we applied the default
@@ -163,8 +194,8 @@ minutes of compute per board.
 Build **Capability B first, scoped small**; defer **Capability A**.
 
 **Why B first.** The harness pays for itself immediately: three pilot boards
-produced three generic findings (arc outlines, rule import, a real wirelength
-ratio). It needs no labels, no statistics, and no bigger corpus — a
+produced three generic findings (legacy arc parsing, rule import, a real
+wirelength ratio). It needs no labels, no statistics, and no bigger corpus — a
 `kct bench route-vs-human <board>` over 5–10 pinned boards is a complete,
 useful increment. And its per-board preflight is what makes A trustworthy
 later.
@@ -177,12 +208,20 @@ sequencing with numbers.
 
 Concrete follow-up issues to file (all generic library capability):
 
+Items 1 and 2 are the same defect shape — a pre-KiCad-6 construct the parser
+accepts without understanding — and are worth filing as a pair:
+
 1. **`(module …)` boards: read or refuse.** Unblocks 41% of the sampled corpus.
    Include a `kct check`-visible signal so a user is never silently handed an
    empty component graph.
-2. **Chain arcs into `get_board_outline()`.** Rounded-rectangle outlines are
-   ordinary; today they yield a 2-point polygon, a false off-board preflight
-   failure, and a shapely crash inside `kct route`.
+2. **Parse pre-KiCad-6 `(gr_arc … (angle …))` into `start`/`mid`/`end`.** The
+   legacy centre+angle form carries no `mid` token, so `GraphicArc.from_sexp`
+   defaults it to `(0, 0)`; the resulting segment-to-origin poisons
+   `get_board_outline()` down to a 2-point polygon, a false off-board preflight
+   failure, and a shapely crash inside `kct route`. Derive `mid` from
+   centre + start-point + swept angle (and refuse, loudly, if the form is
+   unrecognisable) — the arc *chainer* already handles `start/mid/end`
+   correctly and needs no change.
 3. **Import a board's own design rules when routing an imported board** (or a
    `kct route --rules-from-board` flag). Prerequisite for any fair comparison
    against third-party copper.

--- a/docs/research/corpus-benchmark-feasibility.md
+++ b/docs/research/corpus-benchmark-feasibility.md
@@ -1,0 +1,201 @@
+# Corpus benchmark feasibility: capacity calibration and route-vs-human
+
+*Point-in-time working document — issue [#4830](https://github.com/rjwalters/kicad-tools/issues/4830),
+slice 4 of 4. Measured on 2026-08-16 against the 22 PCB entries of
+`scripts/corpus/manifests/open-schematics-sample.json` (revision-pinned
+`bshada/open-schematics` payloads) plus this repo's own 8 routed boards.*
+
+Slices 1–3 answered *"can our parsers read real-world KiCad files?"* (yes:
+30/30 manifest entries parse). This slice answers the question the two proposed
+follow-on capabilities actually depend on: **is the corpus usable as benchmark
+input at all?**
+
+- **Capability A — capacity-predictor calibration** (feeds
+  [#4799](https://github.com/rjwalters/kicad-tools/issues/4799)): needs, per
+  board, a feature vector *and* a routability label.
+- **Capability B — route-vs-human benchmark harness**: needs all of that plus
+  reference copper to diff our router's output against.
+
+## Verdicts
+
+| Question | Answer |
+|----------|--------|
+| Is the corpus usable for capacity-predictor calibration? | **Yes, but the sample must be ~3× larger than the naive estimate.** Only **36%** of pinned PCBs (8/22) yield a feature vector *and* a positive label; the rest are blocked, mostly by one fixable parser gap. |
+| Is a route-vs-human harness feasible? | **Yes — demonstrated end-to-end**, but not as a one-liner. Of 3 pilot boards, 1 routed out of the box, 1 crashed the router, 1 was refused by the grid-safety gate. The harness needs a per-board preflight, not just `strip_traces` + `kct route`. |
+| Should either be built next? | **Build the harness first, on a handful of boards; defer predictor calibration.** The harness surfaced three generic library defects in three boards. Calibration needs hundreds of labeled boards, which is gated on the same parser gap. |
+| Biggest single lever | **Legacy `(module …)` support.** It alone blocks 41% of the sampled corpus (9/22 boards), *all* of which carry copper. |
+
+Reproduce every number below with:
+
+```bash
+uv run python scripts/corpus/check_manifest.py        # populate the payload cache once
+uv run python scripts/corpus/benchmark_readiness.py   # the census, ~40 s, offline
+```
+
+---
+
+## 1. What the census measures
+
+`scripts/corpus/benchmark_readiness.py` scores each board against the
+preconditions the two capabilities need, one blocker code per distinct
+engineering action:
+
+| Blocker | Meaning | Fix lives in |
+|---------|---------|--------------|
+| `no-pad-graph` | parsed, but zero footprints/pads came out | parser |
+| `legacy-module-schema` | the diagnosable cause of most of the above: pre-KiCad-6 `(module …)` | parser |
+| `no-net-binding` | pads exist, but no net has ≥ 2 pads | the design (not fixable) |
+| `no-outline` | no Edge.Cuts bounding box with positive area | the design |
+| `outline-not-polygonal` | bounding box fine, but `get_board_outline()` returns < 3 points | `schema.pcb` arc chaining |
+| `no-reference-copper` | no copper at all — an unrouted *input*, never a reference | the design |
+| `partial-reference-routing` | < 95% of multi-pad nets carry copper — too incomplete to score against | the design |
+
+Two definitional choices matter more than the thresholds:
+
+1. **A pour counts as copper.** A ground net served entirely by a filled zone
+   has zero segments. Measured on this repo's own 8 routed boards, a
+   trace-only definition scores 7 of them "partially routed" (`simple_led` at
+   0.33!) and only 1 complete — versus 7/8 complete once pours count. Any
+   harness that forgets this will mis-grade every board with a plane.
+2. **Completion is measured at net granularity, and is optimistic.** A net
+   counts as routed if it carries *any* copper, not if all its pads are
+   connected. That makes the census a *screen*: a board it rejects is certainly
+   unusable, a board it accepts still needs the harness to confirm.
+
+## 2. Measured: the corpus (22 pinned PCBs)
+
+```
+featurizable (#4799)   : 10 (45.5%)
+labeled examples       :  8 (36.4%)
+route-vs-human cases   :  8 (36.4%)
+  of which pour-served :  1
+
+blockers                          boards
+  legacy-module-schema                 9
+  no-pad-graph                         9
+  no-net-binding                       2
+  no-reference-copper                  2
+  no-outline                           1
+  outline-not-polygonal                1
+```
+
+### 2.1 The dominant blocker is one parser gap
+
+Nine of the 22 boards (41%) parse cleanly and yield **zero footprints and zero
+pads**. Every one of them declares a pre-KiCad-6 file version (`3`, `4`,
+`20160815`, `20170901`, `20171130` ×5) and uses the legacy `(module …)` token
+where KiCad 6+ writes `(footprint …)`. Their nets, segments, vias and zones all
+parse fine — 8 of the 9 carry copper (up to 5,024 segments) — so what is lost is
+exactly the component graph both capabilities need.
+
+This repo has **no version-reject path**: such a file is neither read nor
+refused, it is silently half-understood. Two possible fixes, in increasing
+order of value:
+
+1. **Refuse** — raise on `(module …)` boards, so a caller learns the truth.
+2. **Read them** — map `(module …)` onto `Footprint`. The corpus is heavy with
+   KiCad-4/5 designs; supporting them roughly doubles the usable sample
+   (8 labeled → an estimated 16, since 8 of the 9 have reference copper).
+
+Either is generic library capability and neither is corpus-specific. This is
+the highest-leverage follow-up this slice found.
+
+### 2.2 The remaining blockers are properties of the designs
+
+`no-net-binding` (2 boards) is real: one is a 15-footprint panel with no nets,
+one is a 7-footprint mechanical board. `no-reference-copper` (2 boards) are
+genuinely unrouted layouts — *useful as predictor inputs*, useless as
+references. `no-outline` (1) has no Edge.Cuts at all. None of these are defects
+on our side; a bigger sample simply has to expect ~20% attrition from them.
+
+### 2.3 The usable slice is more diverse than the in-repo fleet
+
+The 8 route-vs-human candidates span 20–825 pads, 6–209 routable nets, 2–4
+copper layers, 5–223 cm², and 1.1–48.9 pads/cm². The densest (`os-0050425-pcb0`,
+391 pads on 8 cm², 275 vias) is far outside anything in `boards/`, where the
+median is 86 pads at 2.5 pads/cm². That density span is the point of using the
+corpus at all — it is exactly the region where a capacity predictor has to be
+right.
+
+## 3. Measured: three route-vs-human pilots
+
+The harness recipe is short — `PCB.load` → `strip_traces()` → `kct route` →
+compare — and every piece already exists. Running it on three candidates
+produced one comparison and two library defects:
+
+| Board | Size | Human reference | `kct route` result |
+|-------|------|-----------------|--------------------|
+| `os-0007182-pcb0` | 20 pads, 6 nets, 5.2 cm², 2 layers | 22 seg, 0 vias, **26.9 mm** | **83% (5/6 nets)**, 36 seg, 1 via, **42.5 mm** (1.58× the human wirelength); `/GND` left 4/5 pads connected |
+| `os-0003340-pcb0` | 73 pads, 15 nets, 8.4 cm² | 143 seg, 45 vias, 305.9 mm | **crash** — off-board preflight false-positives 25/47 footprints, then `ValueError: A linearring requires at least 4 coordinates` |
+| `os-0009947-pcb1` | 110 pads, 19 nets, 9.6 cm², 11.4 pads/cm² | 183 seg, 45 vias, 295.5 mm | **refused** — auto-grid safety gate: 0.127 mm grid > clearance/2 (0.075 mm) under the default manufacturer profile |
+
+Each failure is informative, and none is fatal to the idea:
+
+- **`os-0003340-pcb0` — arc outlines.** Its Edge.Cuts is a rounded rectangle:
+  4 `gr_line` + 4 `gr_arc`. `get_board_outline()` chains only the straight
+  segments and returns **2 points**, which makes the off-board preflight
+  reject two-thirds of the board and then kills the run inside shapely. This
+  reproduces on a hand-written 8-primitive board (see
+  `tests/test_corpus_readiness.py::…::test_rounded_outline_has_area_but_no_usable_polygon`) —
+  it is a `schema.pcb` gap, not a corpus artifact, and it will hit any user
+  with a rounded-corner board. The census now predicts it
+  (`outline-not-polygonal`) instead of discovering it at crash time.
+- **`os-0009947-pcb1` — imported rules vs. our profile.** The human routed to
+  that board's *own* design rules; we applied the default manufacturer profile
+  and the grid-safety rule (correctly) refused rather than emit shorts. Raising
+  `--max-cells` to 4 M does not change the verdict. A harness must adopt each
+  board's `(setup …)` clearance/track-width — comparing our router at
+  JLCPCB-tier rules against a human at their own rules is not a comparison.
+
+**What the one successful pilot already tells us**: on a trivially small board
+our router completes 5/6 nets and spends 1.58× the human's copper length. That
+is the first time this repo has measured itself against human-authored copper
+at all, and it took ~4 minutes of compute.
+
+## 4. Recommendation
+
+Build **Capability B first, scoped small**; defer **Capability A**.
+
+**Why B first.** The harness pays for itself immediately: three pilot boards
+produced three generic findings (arc outlines, rule import, a real wirelength
+ratio). It needs no labels, no statistics, and no bigger corpus — a
+`kct bench route-vs-human <board>` over 5–10 pinned boards is a complete,
+useful increment. And its per-board preflight is what makes A trustworthy
+later.
+
+**Why A is not ready.** A predictor calibrated on 8 boards is a curve fit, not
+a calibration; and the path to hundreds of boards runs straight through the
+legacy-`(module …)` gap plus a much larger manifest. #4799's own scope note
+already defers corpus calibration to "future work" — this slice confirms the
+sequencing with numbers.
+
+Concrete follow-up issues to file (all generic library capability):
+
+1. **`(module …)` boards: read or refuse.** Unblocks 41% of the sampled corpus.
+   Include a `kct check`-visible signal so a user is never silently handed an
+   empty component graph.
+2. **Chain arcs into `get_board_outline()`.** Rounded-rectangle outlines are
+   ordinary; today they yield a 2-point polygon, a false off-board preflight
+   failure, and a shapely crash inside `kct route`.
+3. **Import a board's own design rules when routing an imported board** (or a
+   `kct route --rules-from-board` flag). Prerequisite for any fair comparison
+   against third-party copper.
+4. **`route-vs-human` benchmark command** — strip, route, and report the
+   OmniRouting-style metric set (completion, DRC-attributed completion,
+   wirelength ratio, via ratio, runtime), reusing the metric vocabulary adopted
+   in [`omnilayout-recon.md`](omnilayout-recon.md) §5.
+5. *(Later, gated on 1)* **Grow the manifest to 100+ labeled boards** and
+   revisit predictor calibration for #4799.
+
+## 5. Scope and constraints honored
+
+- No corpus payload is committed. The census reads the gitignored
+  `scripts/corpus/.cache/`, which `check_manifest.py` fills from pinned URLs +
+  `sha256`; pilots wrote stripped boards to a scratch dir outside the repo.
+- The census is offline and does no network I/O; it is not referenced from any
+  workflow (asserted in `tests/test_corpus_readiness.py`).
+- Attribution: contains data from the *Open Schematics* dataset by bshada
+  (<https://huggingface.co/datasets/bshada/open-schematics>), used under
+  [CC BY 4.0](https://creativecommons.org/licenses/by/4.0/). Individual boards
+  carry their upstream projects' own licences; nothing from the corpus is
+  redistributed here.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -72,9 +72,24 @@ measured numbers, and the adopt/adapt/drop verdict live in
 uv run python scripts/corpus/omnieda_sample.py --sample /path/to/extracted --out /tmp/omni
 ```
 
+`benchmark_readiness.py` — **offline**; score the cached corpus boards (and any
+local `.kicad_pcb`) for whether they can serve as capacity-predictor
+calibration examples (#4799) or route-vs-human benchmark cases, with one
+blocker code per distinct cause. Measured verdicts and the three pilot routes
+are in
+[`docs/research/corpus-benchmark-feasibility.md`](../docs/research/corpus-benchmark-feasibility.md):
+
+```bash
+uv run python scripts/corpus/check_manifest.py        # populate the cache once
+uv run python scripts/corpus/benchmark_readiness.py   # census, ~40 s, offline
+uv run python scripts/corpus/benchmark_readiness.py --no-manifest \
+  --board boards/03-usb-joystick/output/usb_joystick_routed.kicad_pcb
+```
+
 The pure helpers `corpus/parse_taxonomy.py` and `corpus/corpus_manifest.py` (no
 network, no CLI) are unit-tested by `tests/test_corpus_manifest.py`;
-`corpus/omnieda_sample.py` (offline) by `tests/test_corpus_omnieda.py`.
+`corpus/omnieda_sample.py` (offline) by `tests/test_corpus_omnieda.py`;
+`corpus/benchmark_readiness.py` (offline) by `tests/test_corpus_readiness.py`.
 
 ### `research/`
 

--- a/scripts/corpus/README.md
+++ b/scripts/corpus/README.md
@@ -14,6 +14,7 @@ in CI — the network scripts are run by hand and are never imported from `tests
 | `parse_taxonomy.py` | library, **pure** | Outcome buckets, format sniffing, exception classification |
 | `corpus_manifest.py` | library, **pure** | Manifest schema/validation, cache integrity, scoring, rendering |
 | `omnieda_sample.py` | CLI + library, **offline** | Characterize an OmniLayout/OmniRouting sample and census its KiCad-mappability gaps (slice 3) |
+| `benchmark_readiness.py` | CLI + library, **offline** | Score cached boards for capacity-predictor calibration / route-vs-human benchmarking (slice 4) |
 
 These scripts import each other by plain module name (the script's own directory
 is `sys.path[0]` when you run `python scripts/corpus/<script>.py`). Type-check
@@ -28,7 +29,9 @@ they do no network I/O and have no CLI, which is why importing them from the tes
 suite does not violate the "no network in pytest" rule that keeps the network
 scripts out of `tests/`. `omnieda_sample.py` is tested for the same reason
 (`tests/test_corpus_omnieda.py`): it has a CLI but no network — its input is a
-sample you downloaded by hand.
+sample you downloaded by hand. So is `benchmark_readiness.py`
+(`tests/test_corpus_readiness.py`): its input is the payload cache
+`check_manifest.py` already filled.
 
 ## `probe_open_schematics.py`
 
@@ -211,6 +214,46 @@ Before redistributing (or vendoring) an *individual* board, verify that specific
 project's license — the dataset license covers the collection, not necessarily
 every constituent design. Per issue #4830 the corpus is referenced by URL +
 revision sha, never mirrored into this repo.
+
+## `benchmark_readiness.py` — is a board usable as a benchmark? (slice 4)
+
+The manifest scorecard says a board *parses*. That is a long way from "we can
+benchmark against it". This script scores each cached board against the
+preconditions the two proposed follow-on capabilities need — a feature vector
+plus a routability label for the #4799 capacity predictor, and reference copper
+for a route-vs-human harness — and names the blocking cause when it cannot:
+
+```bash
+uv run python scripts/corpus/check_manifest.py        # populate the cache once
+uv run python scripts/corpus/benchmark_readiness.py   # ~40 s, offline
+
+# compare the corpus distribution against this repo's own boards
+uv run python scripts/corpus/benchmark_readiness.py --no-manifest \
+  --board boards/05-bldc-motor-controller/output/bldc_controller_routed.kicad_pcb
+```
+
+Reports (JSON + text) land in the gitignored `.cache/`, same as everything else
+here. Blocker codes are one-per-engineering-action:
+
+| Blocker | Meaning |
+|---------|---------|
+| `no-pad-graph` | parsed, but zero footprints/pads came out |
+| `legacy-module-schema` | the cause of most of the above: pre-KiCad-6 `(module …)` |
+| `no-net-binding` | pads exist, but no net has ≥ 2 pads |
+| `no-outline` | no Edge.Cuts bounding box with positive area |
+| `outline-not-polygonal` | bounding box fine, outline polygon < 3 points (arc corners) |
+| `no-reference-copper` | unrouted: a predictor *input*, never a reference |
+| `partial-reference-routing` | < 95% of multi-pad nets carry copper |
+
+Two definitions to know before reading a report: **pours count as copper** (a
+plane-served ground net has no segments; ignoring pours scores 7 of this repo's
+8 routed boards as unfinished), and **completion is net-level and optimistic**
+(any copper on the net counts), so the census is a screen — it rejects
+confidently and accepts provisionally.
+
+The measured verdicts, the three pilot route-vs-human runs, and the follow-up
+recommendations are in
+[`docs/research/corpus-benchmark-feasibility.md`](../../docs/research/corpus-benchmark-feasibility.md).
 
 ## `omnieda_sample.py` — OmniLayout / OmniRouting recon (slice 3)
 

--- a/scripts/corpus/benchmark_readiness.py
+++ b/scripts/corpus/benchmark_readiness.py
@@ -1,0 +1,692 @@
+#!/usr/bin/env python3
+"""Benchmark-readiness census for corpus boards (issue #4830, slice 4).
+
+Slices 1-3 answered *"can this repo's parsers read real-world KiCad files?"*.
+This slice answers the next question, which is the one the two proposed
+follow-on capabilities actually depend on:
+
+1. **Capacity-predictor calibration** (feeds #4799) needs, per board, a feature
+   vector (area, layers, pad/net density, ...) **and a routability label**
+   ("a human finished this board").
+2. **A route-vs-human benchmark harness** needs, per board, everything above
+   *plus* usable reference copper to diff our router's output against.
+
+"It parsed" is nowhere near sufficient for either. A board can load cleanly and
+still expose **zero footprints and zero pads** (the corpus is full of KiCad-5-era
+``(module ...)`` boards, which this repo's parser accepts without reading a
+single component), or carry no net bindings, or have no outline, or ship
+half-routed. Each of those makes the board useless as a benchmark input in a
+*different* way, so this module scores each precondition separately and reports
+which one is the dominant blocker.
+
+The module is **offline and importable**: it reads payloads that
+``check_manifest.py`` already cached (or any local ``.kicad_pcb`` you point it
+at), does no network I/O, and writes only to a caller-supplied output directory.
+That is what lets ``tests/`` import it, in line with the "no network in pytest"
+rule that keeps the fetching scripts out of the suite.
+
+Usage::
+
+    # census the cached corpus sample (run check_manifest.py once first)
+    uv run python scripts/corpus/benchmark_readiness.py
+
+    # add local boards for comparison against the in-repo fleet
+    uv run python scripts/corpus/benchmark_readiness.py \\
+        --board boards/03-esp32-devkit/*.kicad_pcb
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from collections import Counter
+from dataclasses import asdict, dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from corpus_manifest import (
+    DEFAULT_CACHE_DIR,
+    DEFAULT_MANIFEST,
+    ManifestError,
+    cache_path_for,
+    load_manifest,
+)
+from parse_taxonomy import declared_version as sniff_declared_version
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_OUT_DIR = REPO_ROOT / "scripts" / "corpus" / ".cache"
+
+# --------------------------------------------------------------------------
+# Thresholds. Deliberately few, deliberately named, deliberately documented:
+# a readiness verdict that depends on unexplained magic numbers is not a
+# measurement, it is an opinion.
+# --------------------------------------------------------------------------
+
+#: A net needs >= 2 pads to be routable at all; a board needs a few such nets
+#: before "our router vs. the human" means anything. Two is the floor at which
+#: a comparison is arithmetically possible, not the floor at which it is
+#: interesting -- the census reports net counts so a harness can raise it.
+MIN_MULTI_PAD_NETS = 2
+
+#: Fraction of multi-pad nets that must carry copper before the board counts as
+#: a *completed* human reference. Not 1.0: real boards legitimately leave a
+#: mounting-hole or test-point net bare, and net-level copper presence is a
+#: coarse proxy for connectivity (see ``routed_net_fraction``).
+COMPLETE_REFERENCE_FRACTION = 0.95
+
+# --------------------------------------------------------------------------
+# Blocker codes -- one per *distinct engineering action*, same discipline as
+# the parse taxonomy. Do not add a code that would be fixed the same way as an
+# existing one.
+# --------------------------------------------------------------------------
+
+#: Parsed, but no footprints/pads came out: no component graph to featurize.
+BLOCK_NO_PAD_GRAPH = "no-pad-graph"
+#: The specific, fixable cause of most ``no-pad-graph`` boards: the file uses
+#: the pre-KiCad-6 ``(module ...)`` token, which this repo's parser silently
+#: ignores (it reads ``(footprint ...)`` only). Actionable as parser work.
+BLOCK_LEGACY_MODULE_SCHEMA = "legacy-module-schema"
+#: Pads exist but none carry a net, or no net has >= 2 pads: nothing to route.
+BLOCK_NO_NET_BINDING = "no-net-binding"
+#: No Edge.Cuts outline with positive area: no area, hence no density feature
+#: and no routing region.
+BLOCK_NO_OUTLINE = "no-outline"
+#: The outline has area (its bounding box is fine) but cannot be reconstructed
+#: as a polygon -- measured, not theoretical: a rounded-rectangle outline of
+#: 4 ``gr_line`` + 4 ``gr_arc`` yields 2 points, which makes ``kct route``
+#: false-positive its off-board preflight and then die inside shapely with
+#: "A linearring requires at least 4 coordinates". Distinct from
+#: ``no-outline`` because the fix is arc handling, not a missing Edge.Cuts.
+BLOCK_OUTLINE_NOT_POLYGONAL = "outline-not-polygonal"
+#: No copper at all: usable as an unrouted *input*, never as a human reference.
+BLOCK_NO_REFERENCE_COPPER = "no-reference-copper"
+#: Copper exists but a meaningful share of multi-pad nets is still bare --
+#: scoring "we completed 80%" against a reference that is itself 60% routed
+#: measures nothing.
+BLOCK_PARTIAL_REFERENCE_ROUTING = "partial-reference-routing"
+
+BLOCKER_CODES = (
+    BLOCK_NO_PAD_GRAPH,
+    BLOCK_LEGACY_MODULE_SCHEMA,
+    BLOCK_NO_NET_BINDING,
+    BLOCK_NO_OUTLINE,
+    BLOCK_OUTLINE_NOT_POLYGONAL,
+    BLOCK_NO_REFERENCE_COPPER,
+    BLOCK_PARTIAL_REFERENCE_ROUTING,
+)
+
+#: Minimum reconstructed outline vertices for the routing region to be usable
+#: (shapely needs 4 ring coordinates, i.e. 3 distinct points plus closure).
+MIN_OUTLINE_POINTS = 3
+
+#: Routing-completeness label attached to a board once its features are usable.
+LABEL_COMPLETE = "human-routed"  # a positive routability label
+LABEL_PARTIAL = "partially-routed"
+LABEL_UNROUTED = "unrouted-input"  # features only, no label
+LABEL_NONE = "unusable"  # features not extractable
+
+_MODULE_TOKEN_RE = re.compile(r"\(\s*module\s", re.MULTILINE)
+
+
+# --------------------------------------------------------------------------
+# Features
+# --------------------------------------------------------------------------
+@dataclass
+class BoardFeatures:
+    """What a corpus board offers a benchmark, measured rather than assumed."""
+
+    board_id: str
+    group: str = "corpus"  # "corpus" | "local"
+    source: str = ""
+    declared_version: str | None = None
+    size_bytes: int = 0
+
+    # component / connectivity graph
+    footprints: int = 0
+    pads: int = 0
+    netted_pads: int = 0
+    nets_declared: int = 0
+    multi_pad_nets: int = 0
+    max_net_degree: int = 0
+
+    # geometry
+    copper_layers: int = 0
+    board_mm: list[float] = field(default_factory=list)
+    area_cm2: float = 0.0
+    outline_points: int = 0
+
+    # existing copper (the would-be human reference)
+    segments: int = 0
+    vias: int = 0
+    zones: int = 0
+    pour_zones_with_net: int = 0
+    trace_length_mm: float = 0.0
+    nets_with_copper: int = 0
+    multi_pad_nets_with_copper: int = 0
+    multi_pad_nets_with_trace_copper: int = 0
+
+    # schema signal
+    legacy_module_tokens: int = 0
+
+    @property
+    def pad_density_per_cm2(self) -> float:
+        return round(self.pads / self.area_cm2, 3) if self.area_cm2 else 0.0
+
+    @property
+    def net_density_per_cm2(self) -> float:
+        return round(self.multi_pad_nets / self.area_cm2, 3) if self.area_cm2 else 0.0
+
+    @property
+    def avg_pads_per_net(self) -> float:
+        return round(self.netted_pads / self.multi_pad_nets, 2) if self.multi_pad_nets else 0.0
+
+    @property
+    def routed_net_fraction(self) -> float:
+        """Share of multi-pad nets carrying copper (a trace, a via, or a pour).
+
+        A coarse proxy for "the human finished it": net-level copper presence,
+        not pad-level connectivity. A net whose copper connects 3 of its 4 pads
+        counts as routed here. Deliberate -- a true connectivity check needs a
+        DRC-grade connectivity solve per board, which is a harness's job, not a
+        census's. The proxy is *optimistic*, so a board it rejects is certainly
+        unusable while a board it accepts still needs the harness to confirm.
+
+        Pours count. Omitting them is the single most misleading thing this
+        metric could do: a ground net served entirely by a filled zone has no
+        segments at all, and a trace-only definition scores a perfectly routed
+        board as two-thirds finished (measured on this repo's own boards -- see
+        ``pour_served_nets``).
+        """
+        if not self.multi_pad_nets:
+            return 0.0
+        return round(self.multi_pad_nets_with_copper / self.multi_pad_nets, 4)
+
+    @property
+    def pour_served_nets(self) -> int:
+        """Multi-pad nets whose only copper is a pour, not a trace or via.
+
+        A route-vs-human harness must decide what to do with these before it
+        can score anything: our router serves such nets by pour too, so
+        counting them as "unrouted by us" would understate completion, while
+        counting the human's pour as a route would overstate wirelength.
+        """
+        return max(0, self.multi_pad_nets_with_copper - self.multi_pad_nets_with_trace_copper)
+
+    def to_dict(self) -> dict[str, Any]:
+        data = asdict(self)
+        data.update(
+            {
+                "pad_density_per_cm2": self.pad_density_per_cm2,
+                "net_density_per_cm2": self.net_density_per_cm2,
+                "avg_pads_per_net": self.avg_pads_per_net,
+                "routed_net_fraction": self.routed_net_fraction,
+                "pour_served_nets": self.pour_served_nets,
+            }
+        )
+        return data
+
+
+def extract_features(
+    board: Any,
+    text: str,
+    *,
+    board_id: str,
+    group: str = "corpus",
+    source: str = "",
+    declared_version: str | None = None,
+) -> BoardFeatures:
+    """Derive :class:`BoardFeatures` from a parsed ``PCB`` and its source text.
+
+    ``text`` is needed for the two signals that only exist *before* parsing:
+    the declared file-format version and the legacy ``(module ...)`` token
+    count that explains an empty component graph.
+    """
+    pads = [pad for fp in board.footprints for pad in fp.pads]
+    netted = [pad for pad in pads if pad.net_number > 0]
+
+    pads_per_net: Counter[int] = Counter(pad.net_number for pad in netted)
+    multi_pad_nets = {net for net, count in pads_per_net.items() if count >= 2}
+
+    trace_nets: set[int] = set()
+    for seg in board.segments:
+        if seg.net_number > 0:
+            trace_nets.add(seg.net_number)
+    for via in board.vias:
+        if via.net_number > 0:
+            trace_nets.add(via.net_number)
+
+    # Pours carry copper too. ``rule_areas`` (keepouts) do not -- they are
+    # constraints, not conductors -- so they are excluded here.
+    rule_area_ids = {id(zone) for zone in board.rule_areas}
+    pour_zones = [
+        zone for zone in board.zones if zone.net_number > 0 and id(zone) not in rule_area_ids
+    ]
+    pour_nets = {zone.net_number for zone in pour_zones}
+    copper_nets = trace_nets | pour_nets
+
+    try:
+        width, height = board.board_size
+        board_mm = [round(float(width), 2), round(float(height), 2)]
+    except Exception:  # a missing/degenerate outline is data, not an error
+        board_mm = [0.0, 0.0]
+    area_cm2 = round(board_mm[0] * board_mm[1] / 100.0, 3)
+
+    try:
+        outline_points = len(board.get_board_outline())
+    except Exception:
+        outline_points = 0
+
+    try:
+        trace_length = round(float(board.total_trace_length()), 2)
+    except Exception:
+        trace_length = 0.0
+
+    return BoardFeatures(
+        board_id=board_id,
+        group=group,
+        source=source,
+        declared_version=declared_version or sniff_declared_version(text),
+        size_bytes=len(text.encode("utf-8")),
+        footprints=len(board.footprints),
+        pads=len(pads),
+        netted_pads=len(netted),
+        nets_declared=len(board.nets),
+        multi_pad_nets=len(multi_pad_nets),
+        max_net_degree=max(pads_per_net.values(), default=0),
+        copper_layers=len(board.copper_layers),
+        board_mm=board_mm,
+        area_cm2=area_cm2,
+        outline_points=outline_points,
+        segments=board.segment_count,
+        vias=board.via_count,
+        zones=board.zone_count,
+        pour_zones_with_net=len(pour_zones),
+        trace_length_mm=trace_length,
+        nets_with_copper=len(copper_nets),
+        multi_pad_nets_with_copper=len(multi_pad_nets & copper_nets),
+        multi_pad_nets_with_trace_copper=len(multi_pad_nets & trace_nets),
+        legacy_module_tokens=len(_MODULE_TOKEN_RE.findall(text)),
+    )
+
+
+def features_for_file(
+    path: Path,
+    *,
+    board_id: str | None = None,
+    group: str = "local",
+    declared_version: str | None = None,
+) -> BoardFeatures:
+    """Load a ``.kicad_pcb`` and featurize it (parse errors propagate)."""
+    from kicad_tools.schema import PCB
+
+    text = path.read_text(encoding="utf-8", errors="replace")
+    board = PCB.load(path)
+    return extract_features(
+        board,
+        text,
+        board_id=board_id or path.stem,
+        group=group,
+        source=str(path),
+        declared_version=declared_version,
+    )
+
+
+# --------------------------------------------------------------------------
+# Verdicts
+# --------------------------------------------------------------------------
+@dataclass
+class Readiness:
+    """Per-board verdict for each of the two proposed capabilities."""
+
+    board_id: str
+    group: str = "corpus"
+    label: str = LABEL_NONE
+    #: features extractable: pad graph + net bindings + geometry
+    capacity_features: bool = False
+    #: features *and* a positive routability label -- a calibration example
+    capacity_labeled: bool = False
+    #: usable as a route-vs-human benchmark case
+    harness_candidate: bool = False
+    capacity_blockers: list[str] = field(default_factory=list)
+    harness_blockers: list[str] = field(default_factory=list)
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+def evaluate(features: BoardFeatures) -> Readiness:
+    """Score one board against both capabilities' preconditions."""
+    blockers: list[str] = []
+
+    if features.footprints == 0 or features.pads == 0:
+        blockers.append(BLOCK_NO_PAD_GRAPH)
+        if features.legacy_module_tokens > 0:
+            # Name the cause, not just the symptom: this one is fixable in the
+            # parser and would recover the whole bucket at once.
+            blockers.append(BLOCK_LEGACY_MODULE_SCHEMA)
+    elif features.multi_pad_nets < MIN_MULTI_PAD_NETS:
+        blockers.append(BLOCK_NO_NET_BINDING)
+
+    if features.area_cm2 <= 0.0:
+        blockers.append(BLOCK_NO_OUTLINE)
+    elif features.outline_points < MIN_OUTLINE_POINTS:
+        blockers.append(BLOCK_OUTLINE_NOT_POLYGONAL)
+
+    capacity_features = not blockers
+
+    label = LABEL_NONE
+    if capacity_features:
+        fraction = features.routed_net_fraction
+        if fraction >= COMPLETE_REFERENCE_FRACTION:
+            label = LABEL_COMPLETE
+        elif fraction > 0.0:
+            label = LABEL_PARTIAL
+        else:
+            label = LABEL_UNROUTED
+
+    harness_blockers = list(blockers)
+    if capacity_features:
+        if label == LABEL_UNROUTED:
+            harness_blockers.append(BLOCK_NO_REFERENCE_COPPER)
+        elif label == LABEL_PARTIAL:
+            harness_blockers.append(BLOCK_PARTIAL_REFERENCE_ROUTING)
+
+    return Readiness(
+        board_id=features.board_id,
+        group=features.group,
+        label=label,
+        capacity_features=capacity_features,
+        capacity_labeled=capacity_features and label == LABEL_COMPLETE,
+        harness_candidate=not harness_blockers,
+        capacity_blockers=blockers,
+        harness_blockers=harness_blockers,
+    )
+
+
+# --------------------------------------------------------------------------
+# Census
+# --------------------------------------------------------------------------
+def census(
+    features: list[BoardFeatures],
+    verdicts: list[Readiness],
+    *,
+    unavailable: list[dict[str, str]] | None = None,
+) -> dict[str, Any]:
+    """Aggregate per-board verdicts into a machine-readable readiness report."""
+    unavailable = unavailable or []
+    total = len(verdicts)
+    by_label = Counter(v.label for v in verdicts)
+
+    blocker_counts: Counter[str] = Counter()
+    for verdict in verdicts:
+        for code in set(verdict.harness_blockers):
+            blocker_counts[code] += 1
+
+    labeled = [f for f, v in zip(features, verdicts, strict=True) if v.capacity_labeled]
+    candidates = [f for f, v in zip(features, verdicts, strict=True) if v.harness_candidate]
+
+    def _rate(count: int) -> float | None:
+        return round(count / total, 4) if total else None
+
+    return {
+        "schema_version": 1,
+        "generated_utc": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "thresholds": {
+            "min_multi_pad_nets": MIN_MULTI_PAD_NETS,
+            "complete_reference_fraction": COMPLETE_REFERENCE_FRACTION,
+            "min_outline_points": MIN_OUTLINE_POINTS,
+        },
+        "totals": {
+            "boards": total,
+            "unavailable": len(unavailable),
+            "capacity_features": sum(1 for v in verdicts if v.capacity_features),
+            "capacity_labeled": len(labeled),
+            "harness_candidates": len(candidates),
+            "capacity_feature_rate": _rate(sum(1 for v in verdicts if v.capacity_features)),
+            "capacity_label_rate": _rate(len(labeled)),
+            "harness_candidate_rate": _rate(len(candidates)),
+            # Candidates where at least one net is served by a pour alone: the
+            # harness has to define how it scores those before it scores at all.
+            "pour_dependent_candidates": sum(1 for f in candidates if f.pour_served_nets > 0),
+        },
+        "by_label": dict(sorted(by_label.items())),
+        "blockers": dict(sorted(blocker_counts.items(), key=lambda kv: (-kv[1], kv[0]))),
+        "candidate_profile": _profile(candidates),
+        "labeled_profile": _profile(labeled),
+        "boards": [
+            {**f.to_dict(), **v.to_dict()}
+            for f, v in sorted(
+                zip(features, verdicts, strict=True), key=lambda pair: pair[0].board_id
+            )
+        ],
+        "unavailable_boards": unavailable,
+    }
+
+
+def _profile(features: list[BoardFeatures]) -> dict[str, Any]:
+    """Range/median summary of a board subset (empty subset -> empty dict)."""
+    if not features:
+        return {}
+
+    def _span(values: list[float]) -> dict[str, float]:
+        ordered = sorted(values)
+        middle = ordered[len(ordered) // 2]
+        return {
+            "min": round(ordered[0], 3),
+            "median": round(middle, 3),
+            "max": round(ordered[-1], 3),
+        }
+
+    return {
+        "count": len(features),
+        "pads": _span([float(f.pads) for f in features]),
+        "multi_pad_nets": _span([float(f.multi_pad_nets) for f in features]),
+        "copper_layers": _span([float(f.copper_layers) for f in features]),
+        "area_cm2": _span([f.area_cm2 for f in features]),
+        "pad_density_per_cm2": _span([f.pad_density_per_cm2 for f in features]),
+        "trace_length_mm": _span([f.trace_length_mm for f in features]),
+    }
+
+
+def render_census(report: dict[str, Any]) -> str:
+    """Human-readable rendering of :func:`census` output."""
+    totals = report["totals"]
+    lines: list[str] = []
+    lines.append("=" * 78)
+    lines.append("corpus benchmark-readiness census")
+    lines.append("=" * 78)
+    lines.append(f"generated  : {report['generated_utc']}")
+    lines.append(
+        "thresholds : "
+        f"multi-pad nets >= {report['thresholds']['min_multi_pad_nets']}, "
+        f"complete reference >= {report['thresholds']['complete_reference_fraction']:.0%} "
+        "of multi-pad nets routed, "
+        f"outline >= {report['thresholds']['min_outline_points']} points"
+    )
+    lines.append("")
+    lines.append("-- totals " + "-" * 68)
+    lines.append(f"boards evaluated       : {totals['boards']} ({totals['unavailable']} skipped)")
+    for key, rate_key, caption in (
+        ("capacity_features", "capacity_feature_rate", "featurizable (#4799)"),
+        ("capacity_labeled", "capacity_label_rate", "labeled examples"),
+        ("harness_candidates", "harness_candidate_rate", "route-vs-human cases"),
+    ):
+        rate = totals[rate_key]
+        suffix = f" ({rate:.1%})" if rate is not None else ""
+        lines.append(f"{caption:<23}: {totals[key]}{suffix}")
+    lines.append(
+        f"{'  of which pour-served':<23}: {totals['pour_dependent_candidates']} "
+        "(>= 1 net whose only copper is a pour)"
+    )
+    lines.append("")
+    lines.append("-- routing labels " + "-" * 60)
+    for label, count in report["by_label"].items():
+        lines.append(f"  {label:<22} {count:>4}")
+    lines.append("")
+    lines.append("-- blockers (boards disqualified, by cause) " + "-" * 34)
+    if not report["blockers"]:
+        lines.append("  (none -- every board is benchmark-ready)")
+    for code, count in report["blockers"].items():
+        lines.append(f"  {code:<28} {count:>4}")
+    for key, caption in (
+        ("candidate_profile", "route-vs-human candidates"),
+        ("labeled_profile", "labeled calibration examples"),
+    ):
+        profile = report[key]
+        if not profile:
+            continue
+        lines.append("")
+        lines.append(f"-- {caption} (n={profile['count']}) " + "-" * 30)
+        for metric in (
+            "pads",
+            "multi_pad_nets",
+            "copper_layers",
+            "area_cm2",
+            "pad_density_per_cm2",
+            "trace_length_mm",
+        ):
+            span = profile[metric]
+            lines.append(
+                f"  {metric:<22} min={span['min']:<10} median={span['median']:<10} "
+                f"max={span['max']}"
+            )
+    lines.append("")
+    lines.append("-- per board " + "-" * 65)
+    lines.append(
+        f"  {'board':<24} {'ver':<9} {'pads':>5} {'nets':>5} {'lay':>4} "
+        f"{'area':>8} {'routed':>7} {'pour':>5}  label / blockers"
+    )
+    for board in report["boards"]:
+        blockers = ",".join(board["harness_blockers"]) or "-"
+        lines.append(
+            f"  {board['board_id']:<24} {str(board['declared_version'] or '?'):<9} "
+            f"{board['pads']:>5} {board['multi_pad_nets']:>5} {board['copper_layers']:>4} "
+            f"{board['area_cm2']:>8.1f} {board['routed_net_fraction']:>7.2f} "
+            f"{board['pour_served_nets']:>5}  {board['label']} / {blockers}"
+        )
+    if report["unavailable_boards"]:
+        lines.append("")
+        lines.append("-- skipped " + "-" * 67)
+        for item in report["unavailable_boards"]:
+            lines.append(f"  {item['board_id']:<24} {item['reason']}")
+    lines.append("")
+    return "\n".join(lines)
+
+
+# --------------------------------------------------------------------------
+# CLI
+# --------------------------------------------------------------------------
+def collect_manifest_boards(
+    manifest_path: Path,
+    cache_dir: Path,
+) -> tuple[list[BoardFeatures], list[dict[str, str]]]:
+    """Featurize every cached PCB entry of a manifest.
+
+    Entries that were never fetched are reported as unavailable rather than
+    counted as failures: a cold cache is an operator state, not a data property.
+    """
+    manifest = load_manifest(manifest_path)
+    features: list[BoardFeatures] = []
+    unavailable: list[dict[str, str]] = []
+
+    for entry in manifest.by_kind("pcb"):
+        path = cache_path_for(entry, cache_dir)
+        if not path.is_file():
+            unavailable.append(
+                {
+                    "board_id": entry.id,
+                    "reason": "not cached (run check_manifest.py first)",
+                }
+            )
+            continue
+        try:
+            features.append(
+                features_for_file(
+                    path,
+                    board_id=entry.id,
+                    group="corpus",
+                    declared_version=entry.declared_version,
+                )
+            )
+        except Exception as exc:  # a parse failure is check_manifest.py's beat
+            unavailable.append(
+                {
+                    "board_id": entry.id,
+                    "reason": f"{type(exc).__name__}: {exc}"[:160],
+                }
+            )
+    return features, unavailable
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Score corpus boards for capacity-predictor calibration and "
+        "route-vs-human benchmarking (issue #4830, slice 4).",
+    )
+    parser.add_argument("--manifest", type=Path, default=DEFAULT_MANIFEST)
+    parser.add_argument("--cache-dir", type=Path, default=DEFAULT_CACHE_DIR)
+    parser.add_argument(
+        "--board",
+        type=Path,
+        action="append",
+        default=[],
+        metavar="PATH",
+        help="extra local .kicad_pcb to score (repeatable) -- e.g. an in-repo board, "
+        "for comparison against the corpus distribution",
+    )
+    parser.add_argument(
+        "--no-manifest",
+        action="store_true",
+        help="score only the --board paths, ignoring the cached manifest",
+    )
+    parser.add_argument("--out", type=Path, default=DEFAULT_OUT_DIR)
+    parser.add_argument("-q", "--quiet", action="store_true")
+    args = parser.parse_args(argv)
+
+    features: list[BoardFeatures] = []
+    unavailable: list[dict[str, str]] = []
+
+    if not args.no_manifest:
+        try:
+            manifest_features, unavailable = collect_manifest_boards(args.manifest, args.cache_dir)
+        except ManifestError as exc:
+            print(f"error: {exc}", file=sys.stderr)
+            return 2
+        features.extend(manifest_features)
+
+    for path in args.board:
+        try:
+            features.append(features_for_file(path, group="local"))
+        except Exception as exc:
+            unavailable.append({"board_id": path.stem, "reason": f"{type(exc).__name__}: {exc}"})
+
+    if not features:
+        print(
+            "error: no boards to score -- run check_manifest.py to populate the "
+            "payload cache, or pass --board PATH",
+            file=sys.stderr,
+        )
+        return 2
+
+    verdicts = [evaluate(f) for f in features]
+    report = census(features, verdicts, unavailable=unavailable)
+    text = render_census(report)
+    if not args.quiet:
+        print(text)
+
+    args.out.mkdir(parents=True, exist_ok=True)
+    stamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    json_path = args.out / f"benchmark-readiness-{stamp}.json"
+    text_path = args.out / f"benchmark-readiness-{stamp}.txt"
+    json_path.write_text(json.dumps(report, indent=2) + "\n", encoding="utf-8")
+    text_path.write_text(text, encoding="utf-8")
+    print(f"JSON report : {json_path}")
+    print(f"text report : {text_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/corpus/benchmark_readiness.py
+++ b/scripts/corpus/benchmark_readiness.py
@@ -65,10 +65,12 @@ DEFAULT_OUT_DIR = REPO_ROOT / "scripts" / "corpus" / ".cache"
 # measurement, it is an opinion.
 # --------------------------------------------------------------------------
 
-#: A net needs >= 2 pads to be routable at all; a board needs a few such nets
-#: before "our router vs. the human" means anything. Two is the floor at which
-#: a comparison is arithmetically possible, not the floor at which it is
-#: interesting -- the census reports net counts so a harness can raise it.
+#: How many *routable nets* (nets with >= 2 pads) a board must have before
+#: "our router vs. the human" means anything. Note the two levels: a net needs
+#: >= 2 pads to be routable at all, and a board needs at least this many such
+#: nets. Two *such nets* is the floor at which a comparison is arithmetically
+#: possible, not the floor at which it is interesting -- the census reports
+#: net counts so a harness can raise it.
 MIN_MULTI_PAD_NETS = 2
 
 #: Fraction of multi-pad nets that must carry copper before the board counts as
@@ -89,17 +91,23 @@ BLOCK_NO_PAD_GRAPH = "no-pad-graph"
 #: the pre-KiCad-6 ``(module ...)`` token, which this repo's parser silently
 #: ignores (it reads ``(footprint ...)`` only). Actionable as parser work.
 BLOCK_LEGACY_MODULE_SCHEMA = "legacy-module-schema"
-#: Pads exist but none carry a net, or no net has >= 2 pads: nothing to route.
+#: Pads exist but the board has fewer than ``MIN_MULTI_PAD_NETS`` routable
+#: nets -- usually none carry a net at all (a panel or a mechanical board), but
+#: a board with exactly one multi-pad net also lands here: nothing to route,
+#: or too little to compare.
 BLOCK_NO_NET_BINDING = "no-net-binding"
 #: No Edge.Cuts outline with positive area: no area, hence no density feature
 #: and no routing region.
 BLOCK_NO_OUTLINE = "no-outline"
 #: The outline has area (its bounding box is fine) but cannot be reconstructed
-#: as a polygon -- measured, not theoretical: a rounded-rectangle outline of
-#: 4 ``gr_line`` + 4 ``gr_arc`` yields 2 points, which makes ``kct route``
-#: false-positive its off-board preflight and then die inside shapely with
-#: "A linearring requires at least 4 coordinates". Distinct from
-#: ``no-outline`` because the fix is arc handling, not a missing Edge.Cuts.
+#: as a polygon -- measured, not theoretical: a rounded rectangle whose corner
+#: arcs use the pre-KiCad-6 centre+angle form (no ``mid`` token, so
+#: ``GraphicArc.from_sexp`` defaults ``mid`` to the origin) yields 2 points,
+#: which makes ``kct route`` false-positive its off-board preflight and then
+#: die inside shapely with "A linearring requires at least 4 coordinates".
+#: The equivalent KiCad-6 ``(start)(mid)(end)`` board chains fine. Distinct
+#: from ``no-outline`` because the fix is legacy arc *parsing*, not a missing
+#: Edge.Cuts.
 BLOCK_OUTLINE_NOT_POLYGONAL = "outline-not-polygonal"
 #: No copper at all: usable as an unrouted *input*, never as a human reference.
 BLOCK_NO_REFERENCE_COPPER = "no-reference-copper"
@@ -128,6 +136,10 @@ LABEL_PARTIAL = "partially-routed"
 LABEL_UNROUTED = "unrouted-input"  # features only, no label
 LABEL_NONE = "unusable"  # features not extractable
 
+# Deliberately a raw token scan, not a parse: it also matches a "(module "
+# occurrence inside a quoted string or a comment. Harmless -- it is only a
+# cause *hint*, read behind an already-failed pad-graph gate, never a gate of
+# its own.
 _MODULE_TOKEN_RE = re.compile(r"\(\s*module\s", re.MULTILINE)
 
 
@@ -472,6 +484,10 @@ def _profile(features: list[BoardFeatures]) -> dict[str, Any]:
         return {}
 
     def _span(values: list[float]) -> dict[str, float]:
+        # "median" here is the upper-middle order statistic, not an interpolated
+        # median: for an even-sized subset it is the higher of the two middle
+        # values. Good enough for a distribution sketch over ~8 boards; do not
+        # read it as a statistic.
         ordered = sorted(values)
         middle = ordered[len(ordered) // 2]
         return {

--- a/tests/test_corpus_readiness.py
+++ b/tests/test_corpus_readiness.py
@@ -20,7 +20,11 @@ a benchmark verdict rather than crash:
   when that is the cause, because that blocker is fixable in the parser and the
   generic "no pads" bucket hides how much of the corpus it would unlock;
 * a partially-routed board is disqualified as a *reference*, not silently scored
-  against.
+  against;
+* an outline whose corner arcs use the pre-KiCad-6 centre+angle form collapses
+  to a 2-point chain (the ``mid=(0, 0)`` parse default), while the same
+  geometry in KiCad-6 ``(start)(mid)(end)`` form chains fine -- both are pinned
+  so the blocker keeps naming the legacy *parse* gap rather than the chainer.
 """
 
 from __future__ import annotations
@@ -62,22 +66,55 @@ OUTLINE = "\n".join(
     for x1, y1, x2, y2 in [(0, 0, 20, 0), (20, 0, 20, 10), (20, 10, 0, 10), (0, 10, 0, 0)]
 )
 
-# A rounded rectangle: 4 straight edges joined by 4 corner arcs. Same bounding
-# box as OUTLINE, but ``get_board_outline()`` only chains the straight
-# segments, so it yields 2 points -- the shape that made ``kct route`` die
-# inside shapely on corpus board os-0003340-pcb0 ("A linearring requires at
-# least 4 coordinates"). Reproduced here by hand: it is a library gap, not a
-# property of any one corpus file.
-ROUNDED_OUTLINE = "\n".join(
-    [
-        '  (gr_line (start 2 0) (end 18 0) (layer "Edge.Cuts") (width 0.05))',
-        '  (gr_line (start 20 2) (end 20 8) (layer "Edge.Cuts") (width 0.05))',
-        '  (gr_line (start 18 10) (end 2 10) (layer "Edge.Cuts") (width 0.05))',
-        '  (gr_line (start 0 8) (end 0 2) (layer "Edge.Cuts") (width 0.05))',
-        '  (gr_arc (start 2 2) (mid 0.6 0.6) (end 2 0) (layer "Edge.Cuts") (width 0.05))',
-        '  (gr_arc (start 18 2) (mid 19.4 0.6) (end 20 2) (layer "Edge.Cuts") (width 0.05))',
-        '  (gr_arc (start 18 8) (mid 19.4 9.4) (end 18 10) (layer "Edge.Cuts") (width 0.05))',
-        '  (gr_arc (start 2 8) (mid 0.6 9.4) (end 0 8) (layer "Edge.Cuts") (width 0.05))',
+# The four straight edges of a 20x10 rounded rectangle -- same bounding box as
+# OUTLINE, with 2 mm cut off each corner for an arc to bridge.
+_ROUNDED_STRAIGHTS = [
+    '  (gr_line (start 2 0) (end 18 0) (layer "Edge.Cuts") (width 0.05))',
+    '  (gr_line (start 20 2) (end 20 8) (layer "Edge.Cuts") (width 0.05))',
+    '  (gr_line (start 18 10) (end 2 10) (layer "Edge.Cuts") (width 0.05))',
+    '  (gr_line (start 0 8) (end 0 2) (layer "Edge.Cuts") (width 0.05))',
+]
+
+# The defect fixture. These corner arcs use the *pre-KiCad-6* form: ``(start)``
+# is the arc **centre**, ``(end)`` is one endpoint, and the sweep is given by
+# ``(angle ...)``. There is no ``mid`` token at all, so
+# ``GraphicArc.from_sexp`` (src/kicad_tools/schema/pcb.py) leaves ``mid`` at
+# its ``(0.0, 0.0)`` default. ``get_board_outline()`` then dutifully emits
+# ``start->mid`` and ``mid->end`` for each arc -- four segments to the origin,
+# which poison the chain down to 2 points.
+#
+# That is the shape that made ``kct route`` die inside shapely on corpus board
+# os-0003340-pcb0 ("A linearring requires at least 4 coordinates"); that board
+# declares ``version 20210623`` and writes exactly these arcs. The bug is the
+# legacy *parse*, not the chainer -- ROUNDED_OUTLINE_V6 below is the same
+# geometry in KiCad-6 form and chains fine. When the parser learns to derive
+# ``mid`` from centre+endpoint+angle, this test flips.
+ROUNDED_OUTLINE_LEGACY_ARC = "\n".join(
+    _ROUNDED_STRAIGHTS
+    + [
+        '  (gr_arc (start 2 2) (end 2 0) (angle -90) (layer "Edge.Cuts") (width 0.05))',
+        '  (gr_arc (start 18 2) (end 20 2) (angle -90) (layer "Edge.Cuts") (width 0.05))',
+        '  (gr_arc (start 18 8) (end 18 10) (angle -90) (layer "Edge.Cuts") (width 0.05))',
+        '  (gr_arc (start 2 8) (end 0 8) (angle -90) (layer "Edge.Cuts") (width 0.05))',
+    ]
+)
+
+# The control fixture: the same rounded rectangle written the KiCad-6 way,
+# ``(start)(mid)(end)`` with a real on-arc midpoint (centre +/- r/sqrt(2)).
+# This one chains to 13 points today, which is what pins "the chainer already
+# handles arcs" and stops a future legacy-arc fix from regressing it.
+_R = 2 - 2 * 0.7071067811865476  # 0.585786: corner offset of the arc midpoint
+ROUNDED_OUTLINE_V6 = "\n".join(
+    _ROUNDED_STRAIGHTS
+    + [
+        f"  (gr_arc (start 2 0) (mid {_R:.6f} {_R:.6f}) (end 0 2)"
+        ' (layer "Edge.Cuts") (width 0.05))',
+        f"  (gr_arc (start 20 2) (mid {20 - _R:.6f} {_R:.6f}) (end 18 0)"
+        ' (layer "Edge.Cuts") (width 0.05))',
+        f"  (gr_arc (start 18 10) (mid {20 - _R:.6f} {10 - _R:.6f}) (end 20 8)"
+        ' (layer "Edge.Cuts") (width 0.05))',
+        f"  (gr_arc (start 0 8) (mid {_R:.6f} {10 - _R:.6f}) (end 2 10)"
+        ' (layer "Edge.Cuts") (width 0.05))',
     ]
 )
 
@@ -110,7 +147,7 @@ def _footprint(ref: str, x: float, gnd_pad: str, sig_pad: str) -> str:
 
 def board_text(
     *,
-    outline: str = "rect",  # "rect" | "rounded" | "none"
+    outline: str = "rect",  # "rect" | "rounded-legacy-arc" | "rounded-v6" | "none"
     pads: bool = True,
     nets: bool = True,
     copper: str = "",
@@ -119,9 +156,17 @@ def board_text(
 
     Two footprints share a GND net and a SIG net, so both nets are multi-pad
     (i.e. routable) -- which is what every gate in the module keys off.
+
+    The declared file version follows the outline form: the legacy centre+angle
+    arc form is only written by pre-KiCad-6 tooling, so a board carrying it
+    declares ``20210623`` (the version os-0003340-pcb0 declares) rather than
+    the modern ``20221018``. Nothing in the module gates on the version -- it
+    is declared for fidelity, so the fixture is a file KiCad could actually
+    have written.
     """
+    version = "20210623" if outline == "rounded-legacy-arc" else "20221018"
     body = [
-        "(kicad_pcb (version 20221018) (generator pcbnew)",
+        f"(kicad_pcb (version {version}) (generator pcbnew)",
         "  (general (thickness 1.6))",
         "  (paper A4)",
         '  (layers (0 "F.Cu" signal) (31 "B.Cu" signal) (44 "Edge.Cuts" user))',
@@ -131,8 +176,10 @@ def board_text(
     ]
     if outline == "rect":
         body.append(OUTLINE)
-    elif outline == "rounded":
-        body.append(ROUNDED_OUTLINE)
+    elif outline == "rounded-legacy-arc":
+        body.append(ROUNDED_OUTLINE_LEGACY_ARC)
+    elif outline == "rounded-v6":
+        body.append(ROUNDED_OUTLINE_V6)
     if pads:
         if nets:
             body.append(_footprint("R1", 5, "1", "2"))
@@ -219,9 +266,29 @@ class TestFeatureExtraction:
         assert f.net_density_per_cm2 == 0.0
 
     def test_rounded_outline_has_area_but_no_usable_polygon(self, tmp_path: Path) -> None:
-        f = features(tmp_path, "rounded", board_text(outline="rounded", copper=SIG_TRACE))
+        """Legacy centre+angle arcs parse to ``mid=(0, 0)`` and poison the chain.
+
+        This is the library defect behind corpus board os-0003340-pcb0. It is a
+        *parser* gap (``GraphicArc.from_sexp`` never reads the ``(angle ...)``
+        form), not a chainer gap -- see the v6 control below. When the parser
+        learns the legacy form, this assertion is the one that flips.
+        """
+        f = features(
+            tmp_path, "rounded", board_text(outline="rounded-legacy-arc", copper=SIG_TRACE)
+        )
         assert f.area_cm2 == pytest.approx(2.0), "the bounding box is fine"
-        assert f.outline_points < 3, "arcs are not chained into the outline polygon"
+        assert f.outline_points < 3, "the mid=(0,0) default collapses the outline chain"
+
+    def test_kicad6_rounded_outline_chains_into_a_real_polygon(self, tmp_path: Path) -> None:
+        """The control: identical geometry in ``(start)(mid)(end)`` form works.
+
+        ``get_board_outline()`` already emits ``start->mid`` and ``mid->end``
+        per arc, so a well-formed KiCad-6 rounded rectangle is fine today.
+        Pinned so a future legacy-arc fix cannot regress the working path.
+        """
+        f = features(tmp_path, "rounded-v6", board_text(outline="rounded-v6", copper=SIG_TRACE))
+        assert f.area_cm2 == pytest.approx(2.0)
+        assert f.outline_points >= 4, "modern arcs already chain -- the chainer is not the bug"
 
     def test_to_dict_carries_the_derived_metrics(self, tmp_path: Path) -> None:
         data = features(tmp_path, "derived", board_text(copper=GND_POUR)).to_dict()
@@ -280,17 +347,29 @@ class TestVerdicts:
         assert not verdict.capacity_features
 
     def test_rounded_outline_is_a_separate_blocker_from_a_missing_one(self, tmp_path: Path) -> None:
-        """The fix is arc chaining, not a missing Edge.Cuts -- keep them apart."""
+        """The fix is legacy arc parsing, not a missing Edge.Cuts -- keep them apart."""
         verdict = evaluate(
             features(
                 tmp_path,
                 "rounded",
-                board_text(outline="rounded", copper=f"{SIG_TRACE}\n{GND_TRACE}"),
+                board_text(outline="rounded-legacy-arc", copper=f"{SIG_TRACE}\n{GND_TRACE}"),
             )
         )
         assert verdict.capacity_blockers == [BLOCK_OUTLINE_NOT_POLYGONAL]
         assert BLOCK_NO_OUTLINE not in verdict.capacity_blockers
         assert not verdict.harness_candidate
+
+    def test_kicad6_rounded_outline_is_not_blocked_at_all(self, tmp_path: Path) -> None:
+        """The working path stays a candidate -- the blocker is legacy-specific."""
+        verdict = evaluate(
+            features(
+                tmp_path,
+                "rounded-v6",
+                board_text(outline="rounded-v6", copper=f"{SIG_TRACE}\n{GND_TRACE}"),
+            )
+        )
+        assert verdict.capacity_blockers == []
+        assert verdict.capacity_features and verdict.harness_candidate
 
 
 class TestCensus:

--- a/tests/test_corpus_readiness.py
+++ b/tests/test_corpus_readiness.py
@@ -1,0 +1,360 @@
+"""Tests for the corpus benchmark-readiness census (issue #4830, slice 4).
+
+``scripts/corpus/benchmark_readiness.py`` decides which corpus boards can serve
+as capacity-predictor calibration examples (#4799) and which can serve as
+route-vs-human benchmark cases. It is offline by construction -- it reads
+payloads that ``check_manifest.py`` already cached, or any local
+``.kicad_pcb`` -- so, like the slice-2/3 pure modules, the test suite may import
+it without violating the "no network in pytest" rule.
+
+Everything below runs on synthetic boards written to ``tmp_path``. No corpus
+payload is vendored or fetched.
+
+The properties worth pinning are the ones whose breakage would silently corrupt
+a benchmark verdict rather than crash:
+
+* a **pour** counts as copper (a ground net served only by a filled zone is
+  routed; scoring it unrouted mis-grades every board that has a plane), while a
+  **keepout rule area** does not (it is a constraint, not a conductor);
+* an empty component graph is attributed to the legacy ``(module ...)`` schema
+  when that is the cause, because that blocker is fixable in the parser and the
+  generic "no pads" bucket hides how much of the corpus it would unlock;
+* a partially-routed board is disqualified as a *reference*, not silently scored
+  against.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+CORPUS_DIR = ROOT / "scripts" / "corpus"
+
+# The corpus tooling lives under scripts/, not in the installed package (same
+# convention as tests/test_corpus_manifest.py).
+sys.path.insert(0, str(CORPUS_DIR))
+
+from benchmark_readiness import (  # noqa: E402  (sys.path manipulation above)
+    BLOCK_LEGACY_MODULE_SCHEMA,
+    BLOCK_NO_NET_BINDING,
+    BLOCK_NO_OUTLINE,
+    BLOCK_NO_PAD_GRAPH,
+    BLOCK_NO_REFERENCE_COPPER,
+    BLOCK_OUTLINE_NOT_POLYGONAL,
+    BLOCK_PARTIAL_REFERENCE_ROUTING,
+    LABEL_COMPLETE,
+    LABEL_NONE,
+    LABEL_PARTIAL,
+    LABEL_UNROUTED,
+    BoardFeatures,
+    census,
+    collect_manifest_boards,
+    evaluate,
+    features_for_file,
+    render_census,
+)
+
+OUTLINE = "\n".join(
+    f'  (gr_line (start {x1} {y1}) (end {x2} {y2}) (layer "Edge.Cuts") (width 0.05))'
+    for x1, y1, x2, y2 in [(0, 0, 20, 0), (20, 0, 20, 10), (20, 10, 0, 10), (0, 10, 0, 0)]
+)
+
+# A rounded rectangle: 4 straight edges joined by 4 corner arcs. Same bounding
+# box as OUTLINE, but ``get_board_outline()`` only chains the straight
+# segments, so it yields 2 points -- the shape that made ``kct route`` die
+# inside shapely on corpus board os-0003340-pcb0 ("A linearring requires at
+# least 4 coordinates"). Reproduced here by hand: it is a library gap, not a
+# property of any one corpus file.
+ROUNDED_OUTLINE = "\n".join(
+    [
+        '  (gr_line (start 2 0) (end 18 0) (layer "Edge.Cuts") (width 0.05))',
+        '  (gr_line (start 20 2) (end 20 8) (layer "Edge.Cuts") (width 0.05))',
+        '  (gr_line (start 18 10) (end 2 10) (layer "Edge.Cuts") (width 0.05))',
+        '  (gr_line (start 0 8) (end 0 2) (layer "Edge.Cuts") (width 0.05))',
+        '  (gr_arc (start 2 2) (mid 0.6 0.6) (end 2 0) (layer "Edge.Cuts") (width 0.05))',
+        '  (gr_arc (start 18 2) (mid 19.4 0.6) (end 20 2) (layer "Edge.Cuts") (width 0.05))',
+        '  (gr_arc (start 18 8) (mid 19.4 9.4) (end 18 10) (layer "Edge.Cuts") (width 0.05))',
+        '  (gr_arc (start 2 8) (mid 0.6 9.4) (end 0 8) (layer "Edge.Cuts") (width 0.05))',
+    ]
+)
+
+GND_POUR = """  (zone (net 1) (net_name "GND") (layer "B.Cu") (hatch edge 0.5)
+    (connect_pads (clearance 0.5))
+    (min_thickness 0.25)
+    (fill yes (thermal_gap 0.5) (thermal_bridge_width 0.5))
+    (polygon (pts (xy 0 0) (xy 20 0) (xy 20 10) (xy 0 10)))
+  )"""
+
+KEEPOUT = """  (zone (net 1) (net_name "GND") (layer "B.Cu") (hatch edge 0.5)
+    (keepout (tracks not_allowed) (vias not_allowed) (pads allowed)
+      (copperpour not_allowed) (footprints allowed))
+    (polygon (pts (xy 1 1) (xy 5 1) (xy 5 5) (xy 1 5)))
+  )"""
+
+SIG_TRACE = '  (segment (start 5.8 5) (end 11.2 5) (width 0.25) (layer "F.Cu") (net 2))'
+GND_TRACE = '  (segment (start 4.2 5) (end 12.8 5) (width 0.25) (layer "B.Cu") (net 1))'
+
+
+def _footprint(ref: str, x: float, gnd_pad: str, sig_pad: str) -> str:
+    return f"""  (footprint "R_0603" (layer "F.Cu") (at {x} 5)
+    (fp_text reference "{ref}" (at 0 0) (layer "F.SilkS"))
+    (pad "{gnd_pad}" smd rect (at -0.8 0) (size 0.9 0.8)
+      (layers "F.Cu" "F.Paste" "F.Mask") (net 1 "GND"))
+    (pad "{sig_pad}" smd rect (at 0.8 0) (size 0.9 0.8)
+      (layers "F.Cu" "F.Paste" "F.Mask") (net 2 "SIG"))
+  )"""
+
+
+def board_text(
+    *,
+    outline: str = "rect",  # "rect" | "rounded" | "none"
+    pads: bool = True,
+    nets: bool = True,
+    copper: str = "",
+) -> str:
+    """A minimal but genuinely parseable two-resistor board.
+
+    Two footprints share a GND net and a SIG net, so both nets are multi-pad
+    (i.e. routable) -- which is what every gate in the module keys off.
+    """
+    body = [
+        "(kicad_pcb (version 20221018) (generator pcbnew)",
+        "  (general (thickness 1.6))",
+        "  (paper A4)",
+        '  (layers (0 "F.Cu" signal) (31 "B.Cu" signal) (44 "Edge.Cuts" user))',
+        '  (net 0 "")',
+        '  (net 1 "GND")',
+        '  (net 2 "SIG")',
+    ]
+    if outline == "rect":
+        body.append(OUTLINE)
+    elif outline == "rounded":
+        body.append(ROUNDED_OUTLINE)
+    if pads:
+        if nets:
+            body.append(_footprint("R1", 5, "1", "2"))
+            body.append(_footprint("R2", 12, "2", "1"))
+        else:
+            # Same components, no net bindings: a mechanical/panel board.
+            body.append(
+                _footprint("R1", 5, "1", "2")
+                .replace('(net 1 "GND")', "")
+                .replace('(net 2 "SIG")', "")
+            )
+    if copper:
+        body.append(copper)
+    body.append(")")
+    return "\n".join(body) + "\n"
+
+
+LEGACY_MODULE_BOARD = """(kicad_pcb (version 4) (host pcbnew "(2017-11-30)")
+  (general (thickness 1.6))
+  (page A4)
+  (layers (0 F.Cu signal) (31 B.Cu signal) (44 Edge.Cuts user))
+  (net 0 "")
+  (net 1 GND)
+  (gr_line (start 0 0) (end 20 0) (layer Edge.Cuts) (width 0.05))
+  (gr_line (start 20 0) (end 20 10) (layer Edge.Cuts) (width 0.05))
+  (gr_line (start 20 10) (end 0 10) (layer Edge.Cuts) (width 0.05))
+  (gr_line (start 0 10) (end 0 0) (layer Edge.Cuts) (width 0.05))
+  (module R_0603 (layer F.Cu) (tedit 0) (at 5 5)
+    (fp_text reference R1 (at 0 0) (layer F.SilkS))
+    (pad 1 smd rect (at -0.8 0) (size 0.9 0.8) (layers F.Cu F.Paste F.Mask) (net 1 GND))
+  )
+  (segment (start 4.2 5) (end 12.8 5) (width 0.25) (layer F.Cu) (net 1))
+)
+"""
+
+
+def write_board(tmp_path: Path, name: str, text: str) -> Path:
+    path = tmp_path / f"{name}.kicad_pcb"
+    path.write_text(text, encoding="utf-8")
+    return path
+
+
+def features(tmp_path: Path, name: str, text: str) -> BoardFeatures:
+    return features_for_file(write_board(tmp_path, name, text), board_id=name)
+
+
+class TestFeatureExtraction:
+    def test_counts_the_component_and_net_graph(self, tmp_path: Path) -> None:
+        f = features(tmp_path, "complete", board_text(copper=f"{SIG_TRACE}\n{GND_TRACE}"))
+        assert (f.footprints, f.pads, f.netted_pads) == (2, 4, 4)
+        assert f.multi_pad_nets == 2  # GND and SIG each span both parts
+        assert f.max_net_degree == 2
+        assert f.copper_layers == 2
+        assert f.board_mm == [20.0, 10.0]
+        assert f.area_cm2 == pytest.approx(2.0)
+        assert f.pad_density_per_cm2 == pytest.approx(2.0)
+        assert f.avg_pads_per_net == pytest.approx(2.0)
+        assert f.trace_length_mm > 0.0
+
+    def test_a_pour_counts_as_copper_but_a_keepout_does_not(self, tmp_path: Path) -> None:
+        pour = features(tmp_path, "pour", board_text(copper=f"{SIG_TRACE}\n{GND_POUR}"))
+        assert pour.pour_zones_with_net == 1
+        assert pour.multi_pad_nets_with_copper == 2
+        assert pour.multi_pad_nets_with_trace_copper == 1
+        assert pour.pour_served_nets == 1
+        assert pour.routed_net_fraction == pytest.approx(1.0)
+
+        keepout = features(tmp_path, "keepout", board_text(copper=f"{SIG_TRACE}\n{KEEPOUT}"))
+        assert keepout.pour_zones_with_net == 0, "a rule area is a constraint, not a conductor"
+        assert keepout.multi_pad_nets_with_copper == 1
+        assert keepout.routed_net_fraction == pytest.approx(0.5)
+
+    def test_legacy_module_board_parses_but_yields_no_pads(self, tmp_path: Path) -> None:
+        f = features(tmp_path, "legacy", LEGACY_MODULE_BOARD)
+        assert f.footprints == 0 and f.pads == 0
+        assert f.legacy_module_tokens == 1, "the (module ...) token is the diagnosable cause"
+        assert f.segments == 1, "copper still parses -- only the component graph is missing"
+
+    def test_missing_outline_yields_zero_area_without_raising(self, tmp_path: Path) -> None:
+        f = features(tmp_path, "no-outline", board_text(outline="none", copper=SIG_TRACE))
+        assert f.area_cm2 == 0.0
+        assert f.outline_points == 0
+        assert f.pad_density_per_cm2 == 0.0
+        assert f.net_density_per_cm2 == 0.0
+
+    def test_rounded_outline_has_area_but_no_usable_polygon(self, tmp_path: Path) -> None:
+        f = features(tmp_path, "rounded", board_text(outline="rounded", copper=SIG_TRACE))
+        assert f.area_cm2 == pytest.approx(2.0), "the bounding box is fine"
+        assert f.outline_points < 3, "arcs are not chained into the outline polygon"
+
+    def test_to_dict_carries_the_derived_metrics(self, tmp_path: Path) -> None:
+        data = features(tmp_path, "derived", board_text(copper=GND_POUR)).to_dict()
+        for key in (
+            "pad_density_per_cm2",
+            "net_density_per_cm2",
+            "avg_pads_per_net",
+            "routed_net_fraction",
+            "pour_served_nets",
+        ):
+            assert key in data
+
+
+class TestVerdicts:
+    def test_fully_routed_board_is_a_candidate_for_both_capabilities(self, tmp_path: Path) -> None:
+        verdict = evaluate(
+            features(tmp_path, "complete", board_text(copper=f"{SIG_TRACE}\n{GND_TRACE}"))
+        )
+        assert verdict.label == LABEL_COMPLETE
+        assert verdict.capacity_features and verdict.capacity_labeled
+        assert verdict.harness_candidate
+        assert verdict.capacity_blockers == [] and verdict.harness_blockers == []
+
+    def test_partial_routing_disqualifies_the_reference_not_the_features(
+        self, tmp_path: Path
+    ) -> None:
+        verdict = evaluate(features(tmp_path, "partial", board_text(copper=SIG_TRACE)))
+        assert verdict.label == LABEL_PARTIAL
+        assert verdict.capacity_features, "features are still extractable"
+        assert not verdict.capacity_labeled
+        assert not verdict.harness_candidate
+        assert verdict.harness_blockers == [BLOCK_PARTIAL_REFERENCE_ROUTING]
+
+    def test_unrouted_board_is_an_input_not_a_reference(self, tmp_path: Path) -> None:
+        verdict = evaluate(features(tmp_path, "bare", board_text()))
+        assert verdict.label == LABEL_UNROUTED
+        assert verdict.capacity_features and not verdict.capacity_labeled
+        assert verdict.harness_blockers == [BLOCK_NO_REFERENCE_COPPER]
+
+    def test_legacy_module_board_names_the_fixable_cause(self, tmp_path: Path) -> None:
+        verdict = evaluate(features(tmp_path, "legacy", LEGACY_MODULE_BOARD))
+        assert verdict.label == LABEL_NONE
+        assert not verdict.capacity_features
+        assert verdict.capacity_blockers == [BLOCK_NO_PAD_GRAPH, BLOCK_LEGACY_MODULE_SCHEMA]
+
+    def test_pads_without_nets_are_a_distinct_blocker(self, tmp_path: Path) -> None:
+        verdict = evaluate(features(tmp_path, "mech", board_text(nets=False)))
+        assert verdict.capacity_blockers == [BLOCK_NO_NET_BINDING]
+        assert not verdict.capacity_features
+
+    def test_missing_outline_blocks_featurization(self, tmp_path: Path) -> None:
+        verdict = evaluate(
+            features(tmp_path, "no-outline", board_text(outline="none", copper=SIG_TRACE))
+        )
+        assert BLOCK_NO_OUTLINE in verdict.capacity_blockers
+        assert not verdict.capacity_features
+
+    def test_rounded_outline_is_a_separate_blocker_from_a_missing_one(self, tmp_path: Path) -> None:
+        """The fix is arc chaining, not a missing Edge.Cuts -- keep them apart."""
+        verdict = evaluate(
+            features(
+                tmp_path,
+                "rounded",
+                board_text(outline="rounded", copper=f"{SIG_TRACE}\n{GND_TRACE}"),
+            )
+        )
+        assert verdict.capacity_blockers == [BLOCK_OUTLINE_NOT_POLYGONAL]
+        assert BLOCK_NO_OUTLINE not in verdict.capacity_blockers
+        assert not verdict.harness_candidate
+
+
+class TestCensus:
+    def _mixed(self, tmp_path: Path) -> tuple[list[BoardFeatures], list]:
+        boards = [
+            features(tmp_path, "complete", board_text(copper=f"{SIG_TRACE}\n{GND_TRACE}")),
+            features(tmp_path, "pour", board_text(copper=f"{SIG_TRACE}\n{GND_POUR}")),
+            features(tmp_path, "partial", board_text(copper=SIG_TRACE)),
+            features(tmp_path, "legacy", LEGACY_MODULE_BOARD),
+        ]
+        return boards, [evaluate(f) for f in boards]
+
+    def test_aggregates_rates_labels_and_blockers(self, tmp_path: Path) -> None:
+        boards, verdicts = self._mixed(tmp_path)
+        report = census(boards, verdicts, unavailable=[{"board_id": "x", "reason": "not cached"}])
+
+        totals = report["totals"]
+        assert totals["boards"] == 4
+        assert totals["unavailable"] == 1
+        assert totals["capacity_features"] == 3
+        assert totals["capacity_labeled"] == 2
+        assert totals["harness_candidates"] == 2
+        assert totals["harness_candidate_rate"] == pytest.approx(0.5)
+        assert totals["pour_dependent_candidates"] == 1
+
+        assert report["by_label"] == {LABEL_COMPLETE: 2, LABEL_PARTIAL: 1, LABEL_NONE: 1}
+        assert report["blockers"][BLOCK_LEGACY_MODULE_SCHEMA] == 1
+        assert report["blockers"][BLOCK_PARTIAL_REFERENCE_ROUTING] == 1
+        assert report["candidate_profile"]["count"] == 2
+        assert [b["board_id"] for b in report["boards"]] == sorted(
+            b["board_id"] for b in report["boards"]
+        )
+
+    def test_empty_input_does_not_divide_by_zero(self) -> None:
+        report = census([], [])
+        assert report["totals"]["boards"] == 0
+        assert report["totals"]["harness_candidate_rate"] is None
+        assert report["candidate_profile"] == {}
+        assert "corpus benchmark-readiness census" in render_census(report)
+
+    def test_render_names_every_blocker_and_board(self, tmp_path: Path) -> None:
+        boards, verdicts = self._mixed(tmp_path)
+        text = render_census(census(boards, verdicts))
+        assert BLOCK_LEGACY_MODULE_SCHEMA in text
+        assert BLOCK_PARTIAL_REFERENCE_ROUTING in text
+        for board in boards:
+            assert board.board_id in text
+        assert "route-vs-human candidates" in text
+
+
+class TestManifestIntegration:
+    def test_uncached_entries_are_unavailable_not_failures(self, tmp_path: Path) -> None:
+        """A cold payload cache is an operator state, never a data verdict."""
+        boards, unavailable = collect_manifest_boards(
+            CORPUS_DIR / "manifests" / "open-schematics-sample.json",
+            tmp_path,  # deliberately empty cache dir
+        )
+        assert boards == []
+        assert unavailable, "every PCB entry should be reported as uncached"
+        assert all("not cached" in item["reason"] for item in unavailable)
+
+
+class TestZeroCIImpact:
+    def test_not_referenced_from_any_workflow(self) -> None:
+        """The corpus tooling stays opt-in and local (issue #4830 constraint)."""
+        for workflow in (ROOT / ".github" / "workflows").glob("*.yml"):
+            assert "benchmark_readiness" not in workflow.read_text(encoding="utf-8"), workflow.name


### PR DESCRIPTION
## Summary

Slice 4 of #4830 (the last planned deliverable): **feasibility notes for the two follow-on capabilities** — capacity-predictor calibration (feeds #4799) and a route-vs-human benchmark harness — backed by a measurement tool rather than an opinion.

Slices 1–3 established that the corpus *parses* (30/30 manifest entries). That says nothing about whether a board can be used as benchmark **input**. `scripts/corpus/benchmark_readiness.py` scores each cached board against the preconditions each capability actually needs and names the blocking cause when it cannot, one blocker code per distinct engineering action.

**Measured on the 22 pinned corpus PCBs**: 10 featurizable (45%), 8 labeled examples (36%), 8 route-vs-human candidates (36%). The dominant blocker is **one parser gap**: 9 boards (41%) use the pre-KiCad-6 `(module …)` token, parse cleanly, and yield **zero footprints and zero pads** — their nets/segments/vias read fine, so only the component graph is lost. Supporting (or explicitly refusing) that schema roughly doubles the usable sample.

Three pilot strip-and-reroute runs turned the "is a harness feasible?" question into evidence:

| Board | Human reference | `kct route` |
|-------|-----------------|-------------|
| `os-0007182-pcb0` (20 pads) | 22 seg, 0 vias, 26.9 mm | **83% (5/6 nets)**, 42.5 mm — **1.58× the human wirelength** |
| `os-0003340-pcb0` (73 pads) | 143 seg, 45 vias | **crash** — arc-cornered outline yields a 2-point polygon: off-board preflight false-positives 25/47 footprints, then `ValueError: A linearring requires at least 4 coordinates` |
| `os-0009947-pcb1` (110 pads) | 183 seg, 45 vias | **refused** — auto-grid safety gate under our default manufacturer profile (the human routed to the board's own rules) |

That is the first time this repo has measured itself against human-authored copper. The two failures are generic library gaps, not corpus artifacts — the arc-outline one is reproduced by a hand-written 8-primitive board in the tests, and the census now *predicts* it (`outline-not-polygonal`) instead of discovering it at crash time.

Two definitions carry the result and are pinned by tests:
- **Pours count as copper.** A trace-only definition scores 7 of this repo's own 8 routed boards as unfinished (`simple_led` at 0.33) — it would mis-grade every board with a plane.
- **Completion is net-level and optimistic**, which makes the census a screen: it rejects confidently, accepts provisionally.

## Changes

- `scripts/corpus/benchmark_readiness.py` (new) — offline census: feature extraction (`BoardFeatures`), per-board verdicts (`evaluate`), aggregation (`census`/`render_census`), CLI over the cached manifest and/or arbitrary `--board` paths. JSON + text reports into the gitignored `.cache/`.
- `docs/research/corpus-benchmark-feasibility.md` (new) — the verdicts, the measured tables, the three pilots, and five concrete follow-up issues to file.
- `tests/test_corpus_readiness.py` (new) — 18 tests on synthetic boards (no payload vendored or fetched).
- `scripts/README.md`, `scripts/corpus/README.md`, `docs/README.md` — document the tool and index the note.

## Acceptance Criteria Verification

This PR closes out deliverable 4 of the issue's plan ("feasibility notes for the two follow-on capabilities: capacity-predictor calibration, and a route-vs-human benchmark harness; each its own issue if viable"):

- [x] **Capacity-predictor calibration assessed** — verdict: viable but *defer*; 36% yield means a manifest ~3× larger than the naive estimate, and the path there runs through the `(module …)` gap. Numbers, not adjectives.
- [x] **Route-vs-human harness assessed** — verdict: viable, **demonstrated end-to-end**; build it first, scoped to 5–10 boards, with a per-board preflight (rule import + outline validation).
- [x] **Each viable capability has concrete next issues** — five listed in §4 of the note, all generic library capability.
- [x] Generic-library outcome, not per-board fixes — every finding is a parser/router/harness property reproducible off-corpus.
- [x] No corpus payload committed; census reads the gitignored cache, pilots wrote to scratch outside the repo (`git status` clean after runs).
- [x] Zero CI impact — offline, no network I/O, not referenced from any workflow (asserted by `TestZeroCIImpact`).
- [x] Zero new dependencies.

## Test Plan

```
uv run pytest tests/test_corpus_readiness.py tests/test_corpus_manifest.py tests/test_corpus_omnieda.py -q
# 91 passed in 0.71s  (18 of them new)

uv run ruff format --check scripts/corpus/benchmark_readiness.py tests/test_corpus_readiness.py   # 2 files already formatted
uv run ruff check   scripts/corpus/benchmark_readiness.py tests/test_corpus_readiness.py          # All checks passed!
MYPYPATH=scripts/corpus uv run mypy scripts/corpus/benchmark_readiness.py                          # no errors in the new file
```

Manual (needs network once, then offline):

```
uv run python scripts/corpus/check_manifest.py        # 30/30 parse, 0 regressions
uv run python scripts/corpus/benchmark_readiness.py   # the census reproduced in the note
uv run python scripts/corpus/benchmark_readiness.py --no-manifest --board boards/*/output/*_routed.kicad_pcb
#   -> 8/8 featurizable, 7/8 labeled (the in-repo comparison distribution)
```

`git status --porcelain` clean after every run.

Part of #4830 — this completes deliverable 4 of the four-deliverable plan; the issue can close once its remaining scope (deliverables 1–3 already merged in #4839, #4858, #4864) is confirmed, or stay open to track the follow-up issues §4 recommends.