### PR TITLE
feat(router): placement-only pre-route escape-capacity forecast

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Placement-only pre-route escape-capacity forecast** (part of #4799) —
+  `kct route --capacity-forecast` (and `--capacity-forecast-json <path>` for the
+  JSON document) prints, before any router or component loading, whether each
+  multi-ring pad field's interior pins can physically leave it. Unlike the
+  earlier slices of #4799 — the crossing-tail census report (#4852), its replay
+  (#4862) and gate (#4865), all of which need a *previous* run's measurement —
+  this predictor reads placement and design rules only, so it is exact on the
+  first route of a brand-new board. The model
+  (`router/capacity_forecast.py`) peels each pad field into rings, counts the
+  tracks each inter-pad channel carries, tests whether a via can be dropped at
+  the **interstitial** site (the diagonal gap a dogbone actually uses — a
+  1.27 mm/0.45 mm array leaves 0.41 mm orthogonally but 0.58 mm diagonally, and
+  modelling the wrong one turns a healthy BGA into a false blockage), and
+  reports `demand / supply` per ring cut with verdicts
+  `not-applicable` / `ample` / `tight` / `over-capacity` / `infeasible`. Pins on
+  poured nets are deferred only where a via drop exists. **Advisory in every
+  case**: the preflight returns no value for the caller to turn into an exit
+  code, and an unreadable board or unwritable report degrades to one stderr
+  line. Measured on the fleet (2026-08-15): 1–23 ms per board (0.9 s on a
+  90-footprint external design), two multi-ring fields found — boards 06 and
+  07's 7×7 arrays, both `ample` at 0.08×/0.05× — and **no board flagged**, the
+  honest reading, since both blocked boards fail for mechanisms this counting
+  model does not claim to see. Its positive controls are pinned as tests: the
+  same array with no legal via drop is 1.04× over capacity, and a 0.5 mm-pitch
+  array is `infeasible`. A board-scale RUDY estimate was measured first and
+  rejected — 1.2–3.5 % utilisation on every board, including the two that do not
+  route. Docs: `docs/reference/capacity-forecast.md`.
+
 - **HV pairwise proof run on the softstart rev-C mains board** (part of #4507,
   epic #4431 Phase 2) — `docs/hv-pairwise-softstart-proof.md` records the T4
   manual criterion's local run: the fixture is local-only by design, so the

--- a/docs/README.md
+++ b/docs/README.md
@@ -35,6 +35,7 @@ Detailed reference documentation:
 | [CLI Commands](reference/cli.md) | Complete command-line reference |
 | [Machine Output](reference/machine-output.md) | The canonical `--format json` idiom: inventory, exemptions, rules |
 | [Crossing-Tail Census Report](reference/crosstail-census-report.md) | Report-only diff-pair crossover legality aggregate (`KCT_CROSSTAIL_CENSUS_REPORT`) |
+| [Escape-Capacity Forecast](reference/capacity-forecast.md) | Placement-only pre-route pad-field solvability check (`kct route --capacity-forecast`) |
 | [Python API](reference/api.md) | Module-by-module API documentation |
 | [Manufacturer Rules](reference/manufacturers.md) | JLCPCB, OSHPark, PCBWay design rules |
 | [Circuit Blocks](reference/circuit-blocks.md) | Reusable schematic building blocks |

--- a/docs/reference/capacity-forecast.md
+++ b/docs/reference/capacity-forecast.md
@@ -1,0 +1,256 @@
+# Pre-route escape-capacity forecast (`kct route --capacity-forecast`)
+
+A **placement-only** capacity/solvability predictor. It runs before any router
+or component loading and answers one counting question per dense pad field:
+
+> can every pin that has to leave this footprint physically get out, given the
+> channels the pad geometry leaves and the layers the stack offers?
+
+Issue [#4799]. Unlike the [crossing-tail census report](crosstail-census-report.md)
+— the earlier slices of the same issue — this predictor needs **no prior run**:
+ring depth, inter-pad channels and the pin count that must leave a footprint are
+properties of the placement, so the forecast is exact on the first route of a
+brand-new board.
+
+```bash
+uv run kct route board.kicad_pcb --capacity-forecast
+uv run kct route board.kicad_pcb --capacity-forecast-json forecast.json
+```
+
+Both flags are **off by default**, and neither can change what ships or what
+`kct route` returns.
+
+## Why a *local* model
+
+Feeding the in-repo fleet through the existing RUDY estimator
+(`CongestionEstimator`, `router/congestion_estimator.py`) and dividing per-tile
+demand by a per-tile track supply gives **1.2–3.5 % global utilisation and a
+peak tile of 0.24×** on *every* board — including the two with open router
+epics ([#4409], [#3438]). A board-scale predictor would hand out a clean bill
+of health to the boards that do not route. Escape geometry is local, so this
+model is local. (Measured 2026-08-15; the RUDY probe is not shipped, only the
+conclusion it produced.)
+
+## The model
+
+For each footprint with at least `MIN_PADS_FOR_FIELD` (5) pads:
+
+1. **Ring depth, by onion peel** (`ring_depths`). A pad is on the boundary
+   (depth 0) when it is missing a near neighbour in one of the four cardinal
+   directions; peel the boundary away and repeat for depth 1, 2, …
+   Shape-agnostic on purpose: a two-row connector (USB-C, a pin header) is
+   *all* boundary and must not be modelled as an array, while a 7×7 grid peels
+   into four rings. A bbox-inset rule gets the connector wrong and invents
+   interior pins that do not exist.
+2. **Channel width** (`channels_in_gap`). `gap` is the smallest clear spacing
+   between neighbouring pads; a channel of clear width *g* carries
+   `floor((g - clearance) / (track + clearance))` tracks.
+3. **Via drop** (`via_site_clearance`). An interior pin reaches another layer
+   only if a barrel can be placed: *in* the pad (a fab-tier capability, taken
+   from `--manufacturer`) or at an **interstitial** site — for a grid array the
+   diagonal gap between four pads, which is `sqrt(2)` further from every pad
+   centre than the orthogonal one. On a 1.27 mm / 0.45 mm array the orthogonal
+   half-gap is 0.41 mm but the interstice is 0.58 mm: modelling the drop on the
+   orthogonal gap is the difference between "this BGA cannot reach an inner
+   layer" and the dogbone every BGA in the world uses.
+4. **Ring cuts.** Every pin at depth ≥ *d* must cross the ring at depth
+   *d − 1*. Demand is those pins; supply is that ring's gap count times the
+   channels per gap — the pad's own layer, plus (only where a via drop exists)
+   the other signal layers, whose channels are narrowed by via barrels rather
+   than by pads.
+
+The worst cut's `demand / supply` is the field's utilisation; the worst field
+is the board's.
+
+| Verdict | Condition | Reading |
+|---------|-----------|---------|
+| `not-applicable` | no multi-ring pad field with interior pins to route | Every pad field is a single ring — perimeter pins escape outward directly. **Not** an `ample` result. |
+| `ample` | worst ratio < `TIGHT_RATIO` (0.8) | The rings are not the binding constraint. Not a routability guarantee — see the biases below. |
+| `tight` | ≥ 0.8 | Clears the cut with little margin; the counting model ignores neck-down, keepouts and teardrops, so expect the real escape to be harder. |
+| `over-capacity` | ≥ `OVER_CAPACITY_RATIO` (1.0) | More pins must cross the ring than there are channels crossing it. The shortfall is geometric: no ordering, budget or engine setting fixes it. |
+| `infeasible` | demand > 0 with **zero** supply | No track fits between the pads and no via can be dropped — those pins cannot leave on any layer. |
+
+`TIGHT_RATIO` is a documented judgement call, not a calibrated constant; 1.0 is
+arithmetic.
+
+### Poured pins
+
+A pad on a net that will be a copper pour reaches its plane straight down, so
+it is deferred from ring demand — **but only where a via drop actually
+exists**. If no barrel can be placed, that pin has to leave through the surface
+rings exactly like a signal, and crediting it anyway is how a counting model
+talks itself out of a real blockage. Pour nets are the union of the zones
+already in the file and the POWER/GROUND nets `kct route`'s auto-pour would
+create zones for (`auto_pour.classify_pour_candidates`, including its
+all-power-board guard), so an unrouted board is forecast the way it will
+actually be routed. The deferred count is printed and reported.
+
+## What it says on this fleet
+
+Every board's *unrouted* input, default rules (2026-08-15, same machine):
+
+| Board | Footprints | Multi-ring fields | Worst field | Verdict | Ratio | Forecast cost |
+|-------|-----------:|------------------:|-------------|---------|------:|--------------:|
+| 00-simple-led | 3 | 0 | — | `not-applicable` | — | 1 ms |
+| 01-voltage-divider | 4 | 0 | — | `not-applicable` | — | 1 ms |
+| 02-charlieplex-led | 14 | 0 | — | `not-applicable` | — | 4 ms |
+| 03-usb-joystick | 19 | 0 | — | `not-applicable` | — | 9 ms |
+| 04-stm32-devboard | 17 | 0 | — | `not-applicable` | — | 8 ms |
+| 05-bldc-motor-controller | 55 | 0 | — | `not-applicable` | — | 23 ms |
+| 06-diffpair-test | 7 | 1 | U2, 49 pads / 4 rings | `ample` | 0.08× | 13 ms |
+| 07-matchgroup-test | 8 | 1 | U4, 49 pads / 4 rings | `ample` | 0.05× | 16 ms |
+| chorus-test-revA v24 (local-only, 90 footprints) | 90 | 0 | — | `not-applicable` | — | 883 ms |
+
+**No board in the fleet is escape-capacity blocked**, and the model says so
+rather than inventing a finding: boards 06 and 07 carry the only two multi-ring
+arrays, both have a legal dogbone interstice, and both read `ample`. Those two
+boards fail for reasons this counting model does not claim to see (#4409's
+diff-pair coupling, #3438's bundle congestion) — the
+[crossing-tail census](crosstail-census-report.md) is the instrument for the
+first of them.
+
+The cost line matters as much as the verdict: **1–23 ms** on the fleet, 0.9 s on
+a 90-footprint external design whose route takes tens of minutes. A leading
+indicator that costs what it is trying to avoid is not one.
+
+### The counterfactuals it exists for
+
+The same board-06 array, routed with a via too big for its interstice:
+
+```console
+$ uv run kct route boards/06-diffpair-test/output/diffpair_test.kicad_pcb \
+    --capacity-forecast --via-diameter 1.0 --dry-run
+[capacity-forecast] pre-route escape-capacity forecast for boards/06-diffpair-test/output/diffpair_test.kicad_pcb (placement-only, #4799)
+[capacity-forecast]   rules: 4 signal layer(s), track 0.200 mm, clearance 0.150 mm, via 1.000 mm, via-in-pad no
+[capacity-forecast]   1 multi-ring pad field(s) of 7 footprint(s), verdict=over-capacity
+[capacity-forecast]   U2 (Package_BGA:BGA-49_5.0x5.0mm_Layout7x7_P0.5mm): 49 pads / 4 rings, pitch 1.270 mm, gap 0.820 mm -> 1.04x at ring cut 1 (25 pin(s) must cross 24 channel(s)) [over-capacity]
+[capacity-forecast]   reading: U2 has more interior pins than channels to carry them; the router will spend its budget and leave some of them unrouted whatever the ordering, because the shortfall is geometric
+[capacity-forecast]   FIX LAYER: make a via drop possible (a fab tier with via-in-pad, or a via small enough for the interstice between pads) so the inner layers become reachable; widen the pad field's pitch or shrink track/clearance; move pins so fewer interior nets have to leave the part -- placement / stackup, not the router
+[capacity-forecast]   ADVISORY ONLY -- this route is unchanged by the above (#4799)
+```
+
+A 0.5 mm-pitch array (0.25 mm pads, 0.1/0.1 rules, 0.45 mm vias) reads
+`infeasible`: no track fits between the pads and no via fits between them
+either, so the interior cannot leave on any layer — the HDI/microvia case, in
+milliseconds, before the router starts. Both counterfactuals are pinned in
+`tests/router/test_capacity_forecast_4799.py`.
+
+## Document schema (v1)
+
+`--capacity-forecast-json` writes one JSON object with sorted keys, following
+the [machine-output](machine-output.md) conventions. Verbatim values from
+board-06 at `--via-diameter 1.0`, shown here in logical rather than sorted
+order and with the two inner ring cuts (`depth: 2` at 9/16, `depth: 3` at 1/8)
+elided:
+
+```json
+{
+  "schema_version": 1,
+  "generated_at": "2026-08-15T00:00:00+00:00",
+  "report": "capacity-forecast",
+  "source": "board.kicad_pcb",
+  "rules": {
+    "signal_layers": 4,
+    "track_width_mm": 0.2,
+    "clearance_mm": 0.15,
+    "via_diameter_mm": 1.0,
+    "via_in_pad": false
+  },
+  "summary": {
+    "applicable": true,
+    "footprints_seen": 7,
+    "fields_modelled": 1,
+    "worst_ref": "U2",
+    "worst_ratio": 1.042,
+    "verdict": "over-capacity",
+    "over_capacity_ratio": 1.0,
+    "tight_ratio": 0.8
+  },
+  "fields": [
+    {
+      "ref": "U2",
+      "footprint": "Package_BGA:BGA-49_5.0x5.0mm_Layout7x7_P0.5mm",
+      "pads": 49,
+      "escaping_pads": 49,
+      "pour_pads_deferred": 0,
+      "pitch_mm": 1.27,
+      "gap_mm": 0.82,
+      "rings": 4,
+      "surface_channels_per_gap": 1,
+      "drop_channels_per_gap": 0,
+      "via_drop_available": false,
+      "worst_depth": 1,
+      "worst_ratio": 1.042,
+      "verdict": "over-capacity",
+      "cuts": [
+        {"depth": 1, "gaps": 24, "channels_per_gap": 1, "supply": 24, "demand": 25, "ratio": 1.042}
+      ]
+    }
+  ],
+  "warnings": []
+}
+```
+
+`ratio` is `null` — not a huge number — when supply is zero, so `infeasible` is
+distinguishable from "very congested" by a reader that only looks at the JSON.
+Fields are ordered worst-first; cuts are ordered outermost-first.
+
+## Biases (both directions, deliberately not tuned away)
+
+* Pad extent is approximated by `min(width, height)`, so the gap between oblong
+  pads is understated in one axis — **pessimistic**.
+* Supply assumes every gap in a ring is usable, ignoring neck-down rules,
+  keepouts and teardrops — **optimistic**.
+* Escaping pins are counted as pads, not nets: two pads of one net inside a
+  field could in principle share one exit — **pessimistic**, rarely by much.
+* Deferred pour pins consume interstitial barrels that are not charged against
+  the drop-layer channels — **optimistic**.
+* Nothing outside the footprint is modelled. A field that escapes cleanly can
+  still fail in the corridor beyond it (board-05's sense band), so `ample` is
+  not a routability guarantee.
+
+## Advisory, and only advisory
+
+`--capacity-forecast` cannot fail a route. The preflight returns nothing for
+the caller to turn into an exit code; a board that cannot be read or parsed
+prints one `[capacity-forecast] no forecast: …` line and routing proceeds, and
+an unwritable `--capacity-forecast-json` path prints a diagnostic without
+losing the printed block. This is the `_offboard_preflight` precedent that
+report-only surfaces must never block a route, restated for every advisory
+surface on #4799.
+
+Promoting it to a go/no-go the way `--census-advisory-gate` did for the census
+([#4865]) is deliberate follow-up work, not an oversight: the thresholds above
+are one fleet's judgement, and a gate needs calibration first.
+
+## API
+
+```python
+from kicad_tools.router.capacity_forecast import (
+    FieldPad,  # x/y/width/height/ref/net_name -- the model's whole input
+    build_forecast,  # pads -> CapacityForecast (pure; no file needed)
+    forecast_from_board,  # .kicad_pcb -> CapacityForecast
+    emit_forecast,  # the above + print (+ optional JSON); never raises
+    write_report,  # CapacityForecast -> JSON document
+    channels_in_gap,  # tracks through a clear channel
+    ring_depths,  # onion-peel ring index per pad
+    via_site_clearance,  # largest clear radius at an interstitial site
+)
+
+forecast = forecast_from_board("board.kicad_pcb", via_in_pad=True)
+print(forecast.verdict, forecast.worst_ratio)
+for field in forecast.ranked_fields:
+    print(field.ref, field.rings, field.worst_cut.demand, field.worst_cut.supply)
+```
+
+`build_forecast` accepts any object with the `FieldPad` attributes, so a board
+script or a test can drive it from pads it already has. Board files are read
+through `kicad_tools.schema.PCB`, which understands both the legacy
+`(fp_text reference …)` and the modern `(property "Reference" …)` spellings —
+the regex loader in `router/io.py` reads only the former and silently sees zero
+footprints on a board saved by a current KiCad.
+
+[#3438]: https://github.com/rjwalters/kicad-tools/issues/3438
+[#4409]: https://github.com/rjwalters/kicad-tools/issues/4409
+[#4799]: https://github.com/rjwalters/kicad-tools/issues/4799
+[#4865]: https://github.com/rjwalters/kicad-tools/pull/4865

--- a/docs/reference/crosstail-census-report.md
+++ b/docs/reference/crosstail-census-report.md
@@ -171,12 +171,15 @@ replay side adds one opt-in exception: `kct route --census-advisory-gate` turns
 the same verdict into a go/no-go that can abort a run with exit 9 (see
 [the gate](#turning-the-prediction-into-a-gate) below).
 It is off by default, so an un-flagged route is byte-identical to the
-advisory-only behaviour. What remains follow-up work is a genuine *pre*-routing
-predictor (the census's legality checks consult order-dependent state — drills
+advisory-only behaviour. *This* measurement cannot be hoisted ahead of the
+first A* expansion — its legality checks consult order-dependent state (drills
 already placed by earlier crossovers, the escape-channel registry keyed on
-which nets are still unrouted, and the pair's own guide route — so it cannot
-simply be hoisted ahead of the first A* expansion) and calibrating the
-threshold against a corpus of real designs.
+which nets are still unrouted, and the pair's own guide route) — so replaying
+the previous run remains the only way to have it early. A genuinely
+placement-only predictor of a *different* quantity now exists alongside it:
+[the escape-capacity forecast](capacity-forecast.md) counts interior pins
+against pad-field channels with no prior run at all. Calibrating this
+threshold against a corpus of real designs is still open.
 
 ## Replaying it before the next route (`--census-advisory`)
 

--- a/src/kicad_tools/cli/commands/routing.py
+++ b/src/kicad_tools/cli/commands/routing.py
@@ -753,6 +753,13 @@ def run_route_command(args) -> int:
         sub_argv.append("--census-advisory-gate")
     if getattr(args, "census_advisory_gate_pct", None) is not None:
         sub_argv.extend(["--census-advisory-gate-pct", str(args.census_advisory_gate_pct)])
+    # Issue #4799: forward the placement-only escape-capacity forecast.  Both
+    # default off/None; forwarded only when set so an un-flagged route is
+    # byte-identical.
+    if getattr(args, "capacity_forecast", False):
+        sub_argv.append("--capacity-forecast")
+    if getattr(args, "capacity_forecast_json", None):
+        sub_argv.extend(["--capacity-forecast-json", str(args.capacity_forecast_json)])
     if getattr(args, "auto_fix", False):
         sub_argv.append("--auto-fix")
     if getattr(args, "auto_fix_passes", None) is not None:

--- a/src/kicad_tools/cli/parser.py
+++ b/src/kicad_tools/cli/parser.py
@@ -4131,6 +4131,32 @@ def _add_route_parser(subparsers) -> None:
             "verdict uses). Passing this implies --census-advisory-gate."
         ),
     )
+    # Issue #4799: placement-only pad-field escape-capacity forecast.  Mirror
+    # of the inner route_cmd.py flags; both sites must stay in sync per
+    # ``tests/test_cli_parser_drift.py``.
+    route_parser.add_argument(
+        "--capacity-forecast",
+        action="store_true",
+        default=False,
+        help=(
+            "Print a pre-route escape-capacity forecast before any router "
+            "work: for every multi-ring pad field (BGA/LGA-style), how many "
+            "interior pins must cross each ring versus how many channels the "
+            "pad geometry and layer stack provide. Placement-only, so it needs "
+            "no prior run. Advisory only -- never changes routing or the exit "
+            "code."
+        ),
+    )
+    route_parser.add_argument(
+        "--capacity-forecast-json",
+        metavar="PATH",
+        default=None,
+        help=(
+            "Also write the --capacity-forecast result as a JSON document to "
+            "PATH (implies --capacity-forecast). Still advisory: an unwritable "
+            "path prints a diagnostic and routing continues."
+        ),
+    )
     # Issue #4178: hard-gate on native (kicad-cli) DRC actually running.
     # Mirror of the inner route_cmd.py flag; both sites must stay in sync per
     # ``tests/test_cli_parser_drift.py``.

--- a/src/kicad_tools/cli/route_cmd.py
+++ b/src/kicad_tools/cli/route_cmd.py
@@ -10292,6 +10292,70 @@ def _census_advisory_preflight(pcb_path: Path, args) -> int:
         return 0
 
 
+def _forecast_signal_layers(args) -> int | None:
+    """Signal-layer count the run will actually route on (#4799).
+
+    Mirrors the ``--layers`` handling of the routing sub-flows: an explicit
+    stack choice yields that stack's routable-layer count, while ``auto``
+    returns ``None`` so the forecast detects the stack from the board itself.
+    Any failure also returns ``None`` — an advisory never guesses loudly.
+    """
+    choice = getattr(args, "layers", "auto")
+    if choice in (None, "auto"):
+        return None
+    try:
+        from kicad_tools.router.layers import LayerStack
+
+        stack = {
+            "2": LayerStack.two_layer,
+            "4": LayerStack.four_layer_sig_gnd_pwr_sig,
+            "4-sig": LayerStack.four_layer_sig_sig_gnd_pwr,
+            "4-all": LayerStack.four_layer_all_signal,
+            "6": LayerStack.six_layer_sig_gnd_sig_sig_pwr_sig,
+        }[choice]()
+        return len(stack.signal_layers)
+    except Exception:
+        return None
+
+
+def _capacity_forecast_preflight(pcb_path: Path, args) -> None:
+    """Print the pre-route pad-field escape-capacity forecast (#4799).
+
+    Unlike the census advisory above, this predictor needs **no prior run**:
+    ring depth, inter-pad gaps and the pin count that has to leave a footprint
+    are properties of the placement, so the forecast is exact on the first
+    route of a brand-new board.  It answers the counting question the router
+    otherwise discovers by exhausting its budget — are there more interior pins
+    than channels to carry them?
+
+    Off by default and **advisory in every case**: this function returns
+    ``None`` and its caller ignores the outcome, so an armed forecast cannot
+    change an exit code.  Wiring it into a go/no-go the way ``#4865`` did for
+    the census is deliberate follow-up work.
+    """
+    if not getattr(args, "capacity_forecast", False) and not getattr(
+        args, "capacity_forecast_json", None
+    ):
+        return
+    try:
+        from kicad_tools.router.capacity_forecast import emit_forecast
+
+        emit_forecast(
+            pcb_path,
+            report_path=getattr(args, "capacity_forecast_json", None),
+            signal_layers=_forecast_signal_layers(args),
+            track_width_mm=_effective_trace_width(args),
+            clearance_mm=getattr(args, "clearance", None),
+            via_diameter_mm=getattr(args, "via_diameter", None),
+            via_in_pad=_mfr_supports_via_in_pad(getattr(args, "manufacturer", None)),
+        )
+    except Exception:
+        # A predictor that cannot run must never block routing — the
+        # ``_offboard_preflight`` precedent, and ``emit_forecast`` already
+        # swallows its own errors; this catches an import failure.
+        return
+
+
 def _apply_complete_mode_defaults(args, parser, argv: list[str] | None = None) -> None:
     """Apply the ``--complete`` mode implications (Issue #4471, epic #4465).
 
@@ -12224,6 +12288,30 @@ def _main_impl(argv: list[str] | None = None) -> int:
             "verdict uses). Passing this implies --census-advisory-gate."
         ),
     )
+    # Issue #4799: placement-only pad-field escape-capacity forecast.
+    parser.add_argument(
+        "--capacity-forecast",
+        action="store_true",
+        default=False,
+        help=(
+            "Print a pre-route escape-capacity forecast before any router "
+            "work: for every multi-ring pad field (BGA/LGA-style), how many "
+            "interior pins must cross each ring versus how many channels the "
+            "pad geometry and layer stack provide. Placement-only, so it needs "
+            "no prior run. Advisory only -- never changes routing or the exit "
+            "code."
+        ),
+    )
+    parser.add_argument(
+        "--capacity-forecast-json",
+        metavar="PATH",
+        default=None,
+        help=(
+            "Also write the --capacity-forecast result as a JSON document to "
+            "PATH (implies --capacity-forecast). Still advisory: an unwritable "
+            "path prints a diagnostic and routing continues."
+        ),
+    )
     parser.add_argument(
         "--manufacturer",
         "--mfr",
@@ -13134,6 +13222,12 @@ def _main_impl(argv: list[str] | None = None) -> int:
     rc = _census_advisory_preflight(pcb_path, args)
     if rc != 0:
         return rc
+
+    # Issue #4799: pad-field escape-capacity forecast.  Placement-only, so
+    # unlike the census replay above it needs no prior run — it is exact on the
+    # first route of a new board.  Runs in the same pre-router window and is
+    # advisory in every case (no return value is consulted).
+    _capacity_forecast_preflight(pcb_path, args)
 
     # Issue #2996: Validate and load the optional --net-class-map sidecar
     # early -- before dispatching to any of the route_with_* sub-flows --

--- a/src/kicad_tools/router/capacity_forecast.py
+++ b/src/kicad_tools/router/capacity_forecast.py
@@ -1,0 +1,1014 @@
+"""Pre-route pad-field escape-capacity forecast (issue #4799).
+
+A **genuinely pre-route** capacity/solvability predictor: it reads placement
+and design rules only, runs before the first A\\* expansion, and answers one
+counting question per dense pad field --
+
+    can every pin that has to leave this footprint physically get out,
+    given the channels the pad geometry leaves and the layers the stack
+    offers?
+
+Why this and not the crossing-tail census
+-----------------------------------------
+
+The earlier slices of #4799 (#4852 report, #4862 replay, #4865 gate) made the
+diff-pair *crossing-tail* census a leading indicator, but that measurement is
+order-dependent (it consults drills placed by earlier crossovers and an
+escape-channel registry keyed on which nets are still unrouted), so it can only
+be replayed from a **previous run** -- and it only exists on boards that route
+coupled differential pairs through the shadow constructor.  This model has
+neither limitation: ring depth, inter-pad gaps and pin counts are properties of
+the placement, so the forecast is exact on the first run of a brand-new board
+and applies to any board with a multi-ring pad field.
+
+Why the pad field and not the whole board (fleet run, 2026-08-15)
+-----------------------------------------------------------------
+
+A **board-scale** estimate is not the binding constraint on real designs here.
+Feeding the in-repo fleet through the existing
+:class:`~kicad_tools.router.congestion_estimator.CongestionEstimator` (RUDY) and
+dividing per-tile demand by a per-tile track supply gives 1.2-3.5% global
+utilisation and a peak tile of 0.24x on **every** board, including the two with
+open router epics (#4409, #3438).  A predictor built on that would call every
+board healthy, which is worth exactly nothing.  Escape geometry is local, so
+this model is local.
+
+The same fleet run through *this* model finds two multi-ring pad fields -- the
+7x7 / 1.27 mm arrays on boards 06 and 07 -- and reports both as ``ample``
+(0.08x and 0.05x): a 0.6 mm via fits their diagonal interstice, so the interior
+reaches the inner layers.  That is the honest reading, and it is the one the
+model must give: those two boards fail for reasons this counting model does not
+claim to see.  Its positive controls are the counterfactuals it is built for --
+the same array on a stack with no legal via drop is 1.04x **over capacity**
+(25 interior pins, 24 single-track gaps), and a 0.5 mm-pitch array is
+``infeasible`` outright (no track fits between pads and no via fits between
+them either, so nothing gets out on any layer).
+
+The model (ring-cut counting)
+-----------------------------
+
+For each footprint with at least :data:`MIN_PADS_FOR_FIELD` pads:
+
+1. **Ring depth** by onion peel.  A pad is on the boundary (depth 0) when it is
+   missing a near neighbour in one of the four cardinal directions; peel the
+   boundary away and repeat for depth 1, 2, ...  This is shape-agnostic, which
+   matters: a two-row connector (USB-C) is *all* boundary and must not be
+   modelled as an array, while a 7x7 grid peels into four rings.
+2. **Channel width.**  ``gap`` is the smallest clear spacing between
+   neighbouring pads; a channel of clear width *g* carries
+   ``floor((g - clearance) / (track + clearance))`` tracks
+   (:func:`channels_in_gap`).
+3. **Via drop.**  An interior pin reaches another layer only if a barrel can be
+   placed: in the pad (a fab-tier capability) or at an *interstitial* site --
+   for a grid array the diagonal gap between four pads, which is ``sqrt(2)``
+   further from every pad centre than the orthogonal one
+   (:func:`via_site_clearance`).  Modelling this on the orthogonal gap is the
+   difference between "this BGA cannot reach an inner layer" and the dogbone
+   every BGA in the world uses.
+4. **Ring cuts.**  Every pin at depth >= *d* must cross the ring at depth
+   *d - 1* to leave the part.  Demand is those pins; supply is the number of
+   gaps in that ring times the channels each gap carries, on the pad's own
+   layer plus -- only when a via drop exists -- the other signal layers, whose
+   channels are narrowed by the via barrels rather than the pads.
+
+The worst cut's ``demand / supply`` is the field's utilisation, and the worst
+field is the board's.  Anything at or above 1.0 is a pin count that does not
+fit through the geometry, i.e. a *solvability* statement rather than a
+congestion guess.
+
+**Advisory.**  Nothing here changes routing or an exit code.  ``kct route
+--capacity-forecast`` prints the block before any router or component loading
+and returns 0 whatever it finds; a crash inside the predictor degrades to a
+one-line diagnostic (the ``_offboard_preflight`` precedent).  Wiring it into a
+go/no-go the way #4865 did for the census is deliberate follow-up work.
+
+Known biases (both directions, deliberately not tuned away)
+-----------------------------------------------------------
+
+* Pad extent is approximated by ``min(width, height)``, so the gap between
+  oblong pads is *under*-stated in one axis -- pessimistic.
+* Supply assumes every gap in a ring is usable, ignoring the neck-down rules,
+  keepouts and teardrops that consume some of them -- optimistic.
+* Escaping pins are counted as pads, not nets: two pads of one net inside a
+  field could in principle share a single exit -- pessimistic, rarely by much.
+* Pins on a poured net are deferred (they drop straight to their plane) only
+  where a via drop exists; the barrels they consume at interstitial sites are
+  not charged against the drop-layer channels -- optimistic.
+* Nothing outside the footprint is modelled.  A field that escapes cleanly can
+  still fail in the corridor beyond it (board-05's sense band), so ``ample`` is
+  *not* a routability guarantee.
+"""
+
+from __future__ import annotations
+
+import json
+import math
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Iterable, Sequence
+
+__all__ = [
+    "MAX_PADS_FOR_VIA_SITE_SEARCH",
+    "MIN_PADS_FOR_FIELD",
+    "NEIGHBOUR_REACH_FACTOR",
+    "OVER_CAPACITY_RATIO",
+    "REPORT_KIND",
+    "SCHEMA_VERSION",
+    "TIGHT_RATIO",
+    "VERDICT_AMPLE",
+    "VERDICT_INFEASIBLE",
+    "VERDICT_NOT_APPLICABLE",
+    "VERDICT_OVER_CAPACITY",
+    "VERDICT_TIGHT",
+    "WORST_FIELDS_SHOWN",
+    "CapacityForecast",
+    "CapacityForecastError",
+    "FieldPad",
+    "PadFieldForecast",
+    "RingCut",
+    "build_forecast",
+    "channels_in_gap",
+    "emit_forecast",
+    "forecast_from_board",
+    "load_field_pads",
+    "pour_nets_for_board",
+    "ring_depths",
+    "via_site_clearance",
+    "write_report",
+    "zone_net_names",
+]
+
+#: Bump only on a breaking change to the document (additions are free).
+SCHEMA_VERSION = 1
+
+#: ``report`` discriminator in the JSON envelope.
+REPORT_KIND = "capacity-forecast"
+
+#: Footprints with fewer pads than this are never modelled as pad fields.
+#: Discretes, two-pin connectors and small SOT packages have no interior by
+#: construction, and running the peel on them only adds noise.
+MIN_PADS_FOR_FIELD = 5
+
+#: Two pads are neighbours when their centres are within this multiple of the
+#: field's nearest-neighbour pitch.  1.6 admits the orthogonal neighbours of a
+#: square grid (1.0 pitch) and its diagonals (1.41) while excluding the next
+#: row out (2.0).
+NEIGHBOUR_REACH_FACTOR = 1.6
+
+#: Utilisation at or above which a ring cut is over capacity: the pins that
+#: must cross it outnumber the channels crossing it.
+OVER_CAPACITY_RATIO = 1.0
+
+#: Utilisation at or above which a field is called ``tight``.  Advisory and
+#: **uncalibrated** -- 0.8 leaves one channel in five for the detours, guard
+#: traces and teardrops the counting model does not see.
+TIGHT_RATIO = 0.8
+
+#: How many fields the human block names before eliding.
+WORST_FIELDS_SHOWN = 5
+
+#: Above this pad count the interstitial via-site search
+#: (:func:`via_site_clearance`, O(pads * neighbour pairs)) is skipped and the
+#: orthogonal gap is used instead -- pessimistic, but bounded.  Nothing in the
+#: in-repo fleet comes close; a 1000-ball BGA would.
+MAX_PADS_FOR_VIA_SITE_SEARCH = 400
+
+#: Slack on "does this fit" comparisons.  Board dimensions are authored in mm
+#: at four decimal places, so 1e-9 only absorbs float representation error
+#: (0.6 - 0.2 == 0.39999999999999997), never a real 0.0001 mm difference --
+#: the same reasoning as ``route_cmd._TRACE_WIDTH_EPS``.
+_FIT_EPS = 1e-9
+
+VERDICT_NOT_APPLICABLE = "not-applicable"
+VERDICT_AMPLE = "ample"
+VERDICT_TIGHT = "tight"
+VERDICT_OVER_CAPACITY = "over-capacity"
+VERDICT_INFEASIBLE = "infeasible"
+
+#: Worst-first ordering of the verdicts, used to roll fields up to a board.
+_VERDICT_RANK = {
+    VERDICT_NOT_APPLICABLE: 0,
+    VERDICT_AMPLE: 1,
+    VERDICT_TIGHT: 2,
+    VERDICT_OVER_CAPACITY: 3,
+    VERDICT_INFEASIBLE: 4,
+}
+
+
+class CapacityForecastError(ValueError):
+    """The forecast could not be built from the inputs given."""
+
+
+@dataclass(frozen=True)
+class FieldPad:
+    """One pad, in board coordinates -- the model's whole view of a footprint.
+
+    Deliberately minimal and loader-agnostic: :func:`build_forecast` accepts
+    anything with these attributes, so a caller that already has pads (a board
+    script, a test fabricating a synthetic array) never has to round-trip
+    through a file.
+    """
+
+    x: float
+    y: float
+    width: float
+    height: float
+    ref: str
+    net_name: str = ""
+    footprint_name: str = ""
+
+
+def _pad_net_name(pad: Any) -> str:
+    """Net name of *pad*, tolerating the two shapes in this codebase.
+
+    ``FieldPad`` and ``router.io``'s ``Pad`` both carry ``net_name``; the
+    latter also carries a numeric ``net``, which is used as the key when the
+    name is empty so an unnamed-but-numbered net still groups correctly.
+    """
+    name = str(getattr(pad, "net_name", "") or "")
+    if name:
+        return name
+    net = getattr(pad, "net", None)
+    if isinstance(net, str):
+        return net
+    if isinstance(net, int) and net:
+        return f"#{net}"
+    return ""
+
+
+def channels_in_gap(gap_mm: float, track_width_mm: float, clearance_mm: float) -> int:
+    """How many tracks fit through a clear channel *gap_mm* wide.
+
+    ``n`` tracks need ``n * track + (n + 1) * clearance`` of clear width (a
+    clearance either side and between each pair), so
+    ``n = floor((gap - clearance) / (track + clearance))``, floored at 0.
+
+    Dimensions are authored in mm at a few decimal places, so an exactly-fitting
+    channel (0.60 mm for one 0.2/0.2 track) must not be lost to binary
+    representation error -- hence :data:`_FIT_EPS`.
+    """
+    pitch = track_width_mm + clearance_mm
+    if pitch <= 0 or gap_mm <= clearance_mm:
+        return 0
+    return max(0, int((gap_mm - clearance_mm) / pitch + _FIT_EPS))
+
+
+def ring_depths(points: Sequence[tuple[float, float]], pitch_mm: float) -> list[int]:
+    """Onion-peel ring depth for each point in *points*.
+
+    Depth 0 is the boundary of the field: a point missing a near neighbour in
+    any of the four cardinal directions.  Peeling the boundary away and
+    repeating gives depth 1, 2, ...  The classification is shape-agnostic on
+    purpose -- a two-row connector peels to a single ring (every pad has open
+    sky on one side) while a square grid peels to ``ceil(n / 2)`` rings -- and
+    a bbox-inset rule gets both of those wrong.
+
+    Returns a list parallel to *points*.  An empty input returns ``[]``; a
+    non-positive pitch puts everything on the boundary.
+    """
+    n = len(points)
+    depths = [0] * n
+    if n == 0:
+        return depths
+    if pitch_mm <= 0:
+        return depths
+    reach = NEIGHBOUR_REACH_FACTOR * pitch_mm
+    lateral = 0.5 * pitch_mm
+    alive = set(range(n))
+    depth = 0
+    while alive:
+        boundary: set[int] = set()
+        for i in alive:
+            xi, yi = points[i]
+            east = west = south = north = False
+            for j in alive:
+                if i == j:
+                    continue
+                dx = points[j][0] - xi
+                dy = points[j][1] - yi
+                if math.hypot(dx, dy) > reach:
+                    continue
+                if dx > lateral:
+                    east = True
+                elif dx < -lateral:
+                    west = True
+                if dy > lateral:
+                    south = True
+                elif dy < -lateral:
+                    north = True
+            if not (east and west and south and north):
+                boundary.add(i)
+        if not boundary:
+            # Fully enclosed remainder (a ring with no open direction, e.g. a
+            # 2x2 core): stop rather than loop forever, and call it one ring.
+            boundary = set(alive)
+        for i in boundary:
+            depths[i] = depth
+        alive -= boundary
+        depth += 1
+    return depths
+
+
+@dataclass(frozen=True)
+class RingCut:
+    """The boundary a pin at depth >= :attr:`depth` has to cross to get out."""
+
+    depth: int
+    #: Pads on the ring immediately outside the cut -- one channel per gap
+    #: between consecutive pads, so the pad count is the gap count.
+    gaps: int
+    #: Channels each gap carries, summed over the layers reachable here.
+    channels_per_gap: int
+    #: Pads at depth >= :attr:`depth` whose net leaves the footprint.
+    demand: int
+
+    @property
+    def supply(self) -> int:
+        return self.gaps * self.channels_per_gap
+
+    @property
+    def ratio(self) -> float:
+        """``demand / supply``; ``inf`` when demand exists with no supply."""
+        if self.supply > 0:
+            return self.demand / self.supply
+        return math.inf if self.demand > 0 else 0.0
+
+    def to_dict(self) -> dict[str, Any]:
+        ratio = self.ratio
+        return {
+            "depth": self.depth,
+            "gaps": self.gaps,
+            "channels_per_gap": self.channels_per_gap,
+            "supply": self.supply,
+            "demand": self.demand,
+            "ratio": None if math.isinf(ratio) else round(ratio, 3),
+        }
+
+
+@dataclass(frozen=True)
+class PadFieldForecast:
+    """One footprint's escape-capacity forecast."""
+
+    ref: str
+    footprint: str
+    pads: int
+    escaping_pads: int
+    #: Pads left out of demand because they sit on a poured net **and** a via
+    #: drop is available, so they reach their plane without crossing a ring.
+    pour_pads_deferred: int
+    pitch_mm: float
+    gap_mm: float
+    rings: int
+    surface_channels_per_gap: int
+    drop_channels_per_gap: int
+    via_drop_available: bool
+    cuts: tuple[RingCut, ...]
+
+    @property
+    def worst_cut(self) -> RingCut | None:
+        """The cut with the highest utilisation, or ``None`` for a flat field."""
+        if not self.cuts:
+            return None
+        return max(self.cuts, key=lambda c: (c.ratio, -c.depth))
+
+    @property
+    def worst_ratio(self) -> float:
+        cut = self.worst_cut
+        return cut.ratio if cut is not None else 0.0
+
+    @property
+    def verdict(self) -> str:
+        cut = self.worst_cut
+        if cut is None:
+            return VERDICT_NOT_APPLICABLE
+        if math.isinf(cut.ratio):
+            return VERDICT_INFEASIBLE
+        if cut.ratio >= OVER_CAPACITY_RATIO:
+            return VERDICT_OVER_CAPACITY
+        if cut.ratio >= TIGHT_RATIO:
+            return VERDICT_TIGHT
+        return VERDICT_AMPLE
+
+    def to_dict(self) -> dict[str, Any]:
+        ratio = self.worst_ratio
+        cut = self.worst_cut
+        return {
+            "ref": self.ref,
+            "footprint": self.footprint,
+            "pads": self.pads,
+            "escaping_pads": self.escaping_pads,
+            "pour_pads_deferred": self.pour_pads_deferred,
+            "pitch_mm": round(self.pitch_mm, 4),
+            "gap_mm": round(self.gap_mm, 4),
+            "rings": self.rings,
+            "surface_channels_per_gap": self.surface_channels_per_gap,
+            "drop_channels_per_gap": self.drop_channels_per_gap,
+            "via_drop_available": self.via_drop_available,
+            "worst_depth": cut.depth if cut is not None else None,
+            "worst_ratio": None if math.isinf(ratio) else round(ratio, 3),
+            "verdict": self.verdict,
+            "cuts": [c.to_dict() for c in self.cuts],
+        }
+
+    def format_human(self, tag: str) -> str:
+        cut = self.worst_cut
+        if cut is None:  # pragma: no cover - fields with no cut are not listed
+            return f"{tag}   {self.ref}: single ring, no interior pins"
+        ratio = "no channel" if math.isinf(cut.ratio) else f"{cut.ratio:.2f}x"
+        deferred = (
+            f", {self.pour_pads_deferred} poured pin(s) dropped straight down"
+            if self.pour_pads_deferred
+            else ""
+        )
+        return (
+            f"{tag}   {self.ref} ({self.footprint or 'unknown footprint'}): "
+            f"{self.pads} pads / {self.rings} rings, pitch {self.pitch_mm:.3f} mm, "
+            f"gap {self.gap_mm:.3f} mm -> {ratio} at ring cut {cut.depth} "
+            f"({cut.demand} pin(s) must cross {cut.supply} channel(s){deferred}) "
+            f"[{self.verdict}]"
+        )
+
+
+@dataclass(frozen=True)
+class CapacityForecast:
+    """Board-level roll-up of every modelled pad field."""
+
+    source: str
+    signal_layers: int
+    track_width_mm: float
+    clearance_mm: float
+    via_diameter_mm: float
+    via_in_pad: bool
+    footprints_seen: int
+    fields_modelled: int
+    fields: tuple[PadFieldForecast, ...]
+    warnings: tuple[str, ...] = ()
+
+    @property
+    def applicable(self) -> bool:
+        """Did any footprint have an interior to model?
+
+        ``False`` is the honest answer for a board of discretes and
+        perimeter-pin packages -- distinct from ``ample``, which would claim
+        the model looked at a pad field and liked it.
+        """
+        return bool(self.fields)
+
+    @property
+    def ranked_fields(self) -> tuple[PadFieldForecast, ...]:
+        """Fields worst-first (utilisation, then pin count, then ref)."""
+        return tuple(
+            sorted(
+                self.fields,
+                key=lambda f: (
+                    -(f.worst_ratio if not math.isinf(f.worst_ratio) else 1e9),
+                    -f.escaping_pads,
+                    f.ref,
+                ),
+            )
+        )
+
+    @property
+    def worst_field(self) -> PadFieldForecast | None:
+        ranked = self.ranked_fields
+        return ranked[0] if ranked else None
+
+    @property
+    def worst_ratio(self) -> float:
+        field = self.worst_field
+        return field.worst_ratio if field is not None else 0.0
+
+    @property
+    def verdict(self) -> str:
+        field = self.worst_field
+        if field is None:
+            return VERDICT_NOT_APPLICABLE
+        return field.verdict
+
+    def to_dict(self) -> dict[str, Any]:
+        worst = self.worst_field
+        ratio = self.worst_ratio
+        return {
+            "schema_version": SCHEMA_VERSION,
+            "generated_at": datetime.now(timezone.utc).isoformat(),
+            "report": REPORT_KIND,
+            "source": self.source,
+            "rules": {
+                "signal_layers": self.signal_layers,
+                "track_width_mm": self.track_width_mm,
+                "clearance_mm": self.clearance_mm,
+                "via_diameter_mm": self.via_diameter_mm,
+                "via_in_pad": self.via_in_pad,
+            },
+            "summary": {
+                "applicable": self.applicable,
+                "footprints_seen": self.footprints_seen,
+                "fields_modelled": self.fields_modelled,
+                "worst_ref": worst.ref if worst is not None else None,
+                "worst_ratio": None if math.isinf(ratio) else round(ratio, 3),
+                "verdict": self.verdict,
+                "over_capacity_ratio": OVER_CAPACITY_RATIO,
+                "tight_ratio": TIGHT_RATIO,
+            },
+            "fields": [f.to_dict() for f in self.ranked_fields],
+            "warnings": list(self.warnings),
+        }
+
+    def format_human(self) -> str:
+        """Multi-line, greppable text form, every line tagged for interleaving."""
+        tag = "[capacity-forecast]"
+        head = f"{tag} pre-route escape-capacity forecast for {self.source} (placement-only, #4799)"
+        rules = (
+            f"{tag}   rules: {self.signal_layers} signal layer(s), track "
+            f"{self.track_width_mm:.3f} mm, clearance {self.clearance_mm:.3f} mm, "
+            f"via {self.via_diameter_mm:.3f} mm, via-in-pad "
+            f"{'yes' if self.via_in_pad else 'no'}"
+        )
+        if not self.applicable:
+            return "\n".join(
+                [
+                    head,
+                    rules,
+                    f"{tag}   {self.footprints_seen} footprint(s) examined, 0 with an "
+                    f"interior ring -- NOT APPLICABLE",
+                    f"{tag}   every pad field on this board is a single ring (perimeter "
+                    f"pins escape outward directly); this is not an 'ample' result",
+                    *[f"{tag}   WARNING: {w}" for w in self.warnings],
+                    f"{tag}   ADVISORY ONLY -- this route is unchanged by the above (#4799)",
+                ]
+            )
+        lines = [
+            head,
+            rules,
+            f"{tag}   {self.fields_modelled} multi-ring pad field(s) of "
+            f"{self.footprints_seen} footprint(s), verdict={self.verdict}",
+        ]
+        ranked = self.ranked_fields
+        for field in ranked[:WORST_FIELDS_SHOWN]:
+            lines.append(field.format_human(tag))
+        if len(ranked) > WORST_FIELDS_SHOWN:
+            lines.append(f"{tag}   (+{len(ranked) - WORST_FIELDS_SHOWN} more field(s))")
+        worst = self.worst_field
+        if worst is not None and self.verdict in (
+            VERDICT_OVER_CAPACITY,
+            VERDICT_INFEASIBLE,
+            VERDICT_TIGHT,
+        ):
+            lines.append(f"{tag}   reading: {self._reading(worst)}")
+            lines.append(f"{tag}   FIX LAYER: {self._fix_layer(worst)}")
+        lines.extend(f"{tag}   WARNING: {w}" for w in self.warnings)
+        lines.append(f"{tag}   ADVISORY ONLY -- this route is unchanged by the above (#4799)")
+        return "\n".join(lines)
+
+    def _reading(self, worst: PadFieldForecast) -> str:
+        if self.verdict == VERDICT_INFEASIBLE:
+            return (
+                f"{worst.ref}'s interior pins have NO channel out: the "
+                f"{worst.gap_mm:.3f} mm gap between pads carries 0 tracks at this "
+                f"track/clearance and no via can be dropped, so those pins cannot "
+                f"escape on any layer -- no router setting can fix this"
+            )
+        if self.verdict == VERDICT_OVER_CAPACITY:
+            return (
+                f"{worst.ref} has more interior pins than channels to carry them; the "
+                f"router will spend its budget and leave some of them unrouted "
+                f"whatever the ordering, because the shortfall is geometric"
+            )
+        return (
+            f"{worst.ref} clears its ring cut with little margin -- the counting model "
+            f"ignores neck-down, keepouts and teardrops, so expect the real escape to "
+            f"be harder than this ratio"
+        )
+
+    def _fix_layer(self, worst: PadFieldForecast) -> str:
+        parts = []
+        if not worst.via_drop_available and self.signal_layers > 1:
+            parts.append(
+                "make a via drop possible (a fab tier with via-in-pad, or a via small "
+                "enough for the interstice between pads) so the inner layers become "
+                "reachable"
+            )
+        if self.signal_layers < 4:
+            parts.append("add signal layers")
+        parts.append("widen the pad field's pitch or shrink track/clearance")
+        parts.append("move pins so fewer interior nets have to leave the part")
+        return "; ".join(parts) + " -- placement / stackup, not the router"
+
+
+def _pad_extent(pad: Any) -> float:
+    """Conservative pad extent: the smaller of the two footprint dimensions."""
+    width = float(getattr(pad, "width", 0.0) or 0.0)
+    height = float(getattr(pad, "height", 0.0) or 0.0)
+    if width <= 0 and height <= 0:
+        return 0.0
+    if width <= 0:
+        return height
+    if height <= 0:
+        return width
+    return min(width, height)
+
+
+def _pad_radius(pad: Any) -> float:
+    """Circumscribed pad radius -- half the diagonal of its bounding box."""
+    width = float(getattr(pad, "width", 0.0) or 0.0)
+    height = float(getattr(pad, "height", 0.0) or 0.0)
+    return 0.5 * math.hypot(width, height)
+
+
+def _field_geometry(pads: Sequence[Any]) -> tuple[float, float]:
+    """Nearest-neighbour pitch and the smallest clear gap in a pad field."""
+    pitch = math.inf
+    gap = math.inf
+    for i, a in enumerate(pads):
+        for b in pads[i + 1 :]:
+            dist = math.hypot(a.x - b.x, a.y - b.y)
+            if dist <= 0:
+                continue
+            if dist < pitch:
+                pitch = dist
+            clear = dist - 0.5 * (_pad_extent(a) + _pad_extent(b))
+            if clear < gap:
+                gap = clear
+    if not math.isfinite(pitch):
+        return (0.0, 0.0)
+    return (pitch, max(0.0, gap if math.isfinite(gap) else 0.0))
+
+
+def via_site_clearance(pads: Sequence[Any], pitch_mm: float) -> float:
+    """Largest clear radius available to a dogbone via inside a pad field.
+
+    A dogbone drop does **not** go through the orthogonal gap between two
+    adjacent pads -- it goes into the interstice between four of them, which on
+    a square grid is ``sqrt(2)`` further from every pad centre.  Modelling the
+    drop on the orthogonal gap is the difference between "this BGA cannot reach
+    an inner layer" and "of course it can", so the site is searched for
+    explicitly: every midpoint between two neighbouring pads is a candidate,
+    scored by its distance to the nearest pad copper (pads circumscribed by
+    :func:`_pad_radius`, i.e. conservatively round).
+
+    Returns the best candidate's clear radius in mm, ``0.0`` when there is no
+    room anywhere.  Fields larger than :data:`MAX_PADS_FOR_VIA_SITE_SEARCH`
+    skip the search and fall back to the orthogonal gap (see
+    :func:`build_forecast`), keeping the forecast's cost bounded.
+    """
+    if pitch_mm <= 0 or len(pads) < 2:
+        return 0.0
+    reach = NEIGHBOUR_REACH_FACTOR * pitch_mm
+    scan = 2.0 * pitch_mm
+    best = 0.0
+    for i, a in enumerate(pads):
+        for b in pads[i + 1 :]:
+            if math.hypot(a.x - b.x, a.y - b.y) > reach:
+                continue
+            mx = 0.5 * (a.x + b.x)
+            my = 0.5 * (a.y + b.y)
+            clear = math.inf
+            for pad in pads:
+                dist = math.hypot(pad.x - mx, pad.y - my)
+                if dist > scan:
+                    continue
+                clear = min(clear, dist - _pad_radius(pad))
+                if clear <= best:
+                    break
+            if math.isfinite(clear) and clear > best:
+                best = clear
+    return max(0.0, best)
+
+
+def build_forecast(
+    pads: Iterable[Any],
+    *,
+    source: str = "",
+    signal_layers: int = 2,
+    track_width_mm: float = 0.2,
+    clearance_mm: float = 0.2,
+    via_diameter_mm: float = 0.6,
+    via_in_pad: bool = False,
+    pour_nets: Iterable[str] = (),
+    warnings: Sequence[str] = (),
+) -> CapacityForecast:
+    """Model every multi-ring pad field among *pads*.
+
+    *pads* is any iterable of objects with ``x``, ``y``, ``width``, ``height``,
+    ``ref`` and a net name (``net_name``, or ``net`` when that is a string) --
+    both :class:`FieldPad` and the objects
+    :func:`kicad_tools.router.io.load_pads_for_analysis` returns satisfy it.
+    Pads are grouped by ``ref``; a net counts as *escaping* a field when it
+    also has a pad on some other reference, so an internal-only net (a
+    decoupling pair inside one footprint) never inflates demand.
+
+    Pads on a net in *pour_nets* are deferred from demand **only where a via
+    drop exists**: a poured pad reaches its plane straight down, but if no via
+    can be placed (not in pad, and no interstitial site big enough) that pad
+    has to leave through the rings exactly like a signal, and pretending
+    otherwise is how a counting model talks itself out of a real blockage.
+    """
+    pad_list = list(pads)
+    pours = {str(n) for n in pour_nets if str(n)}
+    by_ref: dict[str, list[Any]] = {}
+    net_refs: dict[str, set[str]] = {}
+    for pad in pad_list:
+        ref = str(getattr(pad, "ref", "") or "")
+        by_ref.setdefault(ref, []).append(pad)
+        net = _pad_net_name(pad)
+        if net:
+            net_refs.setdefault(net, set()).add(ref)
+
+    drop_layers = max(0, int(signal_layers) - 1)
+    fields: list[PadFieldForecast] = []
+    footprints_seen = 0
+    for ref, field_pads in sorted(by_ref.items()):
+        if not ref:
+            continue
+        footprints_seen += 1
+        if len(field_pads) < MIN_PADS_FOR_FIELD:
+            continue
+        pitch, gap = _field_geometry(field_pads)
+        if pitch <= 0:
+            continue
+        depths = ring_depths([(p.x, p.y) for p in field_pads], pitch)
+        rings = max(depths) + 1
+        if rings < 2:
+            # Every pad is on the boundary: perimeter pins escape outward with
+            # no ring to cross, so there is nothing for this model to say.
+            continue
+
+        surface_channels = channels_in_gap(gap, track_width_mm, clearance_mm)
+        # A via drop needs somewhere to put the barrel: either in the pad (a
+        # fab-tier capability) or at an interstitial site between pads with
+        # clearance all round -- for a grid array that is the diagonal
+        # interstice, not the orthogonal gap (see :func:`via_site_clearance`).
+        # Without one, the inner layers are simply unreachable from an interior
+        # pad, however many of them the stack has.
+        if len(field_pads) <= MAX_PADS_FOR_VIA_SITE_SEARCH:
+            site_clear = via_site_clearance(field_pads, pitch)
+        else:  # pragma: no cover - very large fields fall back to the gap
+            site_clear = 0.5 * gap
+        via_fits_between = site_clear + _FIT_EPS >= 0.5 * via_diameter_mm + clearance_mm
+        via_drop = bool(via_in_pad or via_fits_between)
+        # On the dropped-to layers the obstacles are the via barrels, not the
+        # pads, so the channel is measured against the via diameter.
+        drop_channels = (
+            channels_in_gap(pitch - via_diameter_mm, track_width_mm, clearance_mm)
+            if via_drop
+            else 0
+        )
+        channels_per_gap = surface_channels + drop_layers * drop_channels
+
+        escaping: list[int] = []
+        deferred = 0
+        for i, pad in enumerate(field_pads):
+            net = _pad_net_name(pad)
+            if not net or len(net_refs.get(net, set())) <= 1:
+                continue
+            if net in pours:
+                if via_drop:
+                    # Reaches its plane straight down; never crosses a ring.
+                    deferred += 1
+                    continue
+                # No via can be placed here, so the poured pad still has to
+                # leave through the surface rings like any other pin.
+            escaping.append(i)
+        cuts: list[RingCut] = []
+        for depth in range(1, rings):
+            gaps = sum(1 for d in depths if d == depth - 1)
+            demand = sum(1 for i in escaping if depths[i] >= depth)
+            if demand == 0:
+                continue
+            cuts.append(
+                RingCut(
+                    depth=depth,
+                    gaps=gaps,
+                    channels_per_gap=channels_per_gap,
+                    demand=demand,
+                )
+            )
+        if not cuts:
+            # Multi-ring, but nothing inside needs to leave (a thermal-pad
+            # array, or an interior tied entirely to a poured net).
+            continue
+        fields.append(
+            PadFieldForecast(
+                ref=ref,
+                footprint=str(getattr(field_pads[0], "footprint_name", "") or ""),
+                pads=len(field_pads),
+                escaping_pads=len(escaping),
+                pour_pads_deferred=deferred,
+                pitch_mm=pitch,
+                gap_mm=gap,
+                rings=rings,
+                surface_channels_per_gap=surface_channels,
+                drop_channels_per_gap=drop_channels,
+                via_drop_available=via_drop,
+                cuts=tuple(cuts),
+            )
+        )
+
+    return CapacityForecast(
+        source=source,
+        signal_layers=int(signal_layers),
+        track_width_mm=float(track_width_mm),
+        clearance_mm=float(clearance_mm),
+        via_diameter_mm=float(via_diameter_mm),
+        via_in_pad=bool(via_in_pad),
+        footprints_seen=footprints_seen,
+        fields_modelled=len(fields),
+        fields=tuple(fields),
+        warnings=tuple(warnings),
+    )
+
+
+def zone_net_names(pcb) -> set[str]:
+    """Net names that already own a copper zone on a loaded board."""
+    names: set[str] = set()
+    for zone in getattr(pcb, "zones", ()) or ():
+        name = str(getattr(zone, "net_name", "") or "")
+        if name:
+            names.add(name)
+    return names
+
+
+def pour_nets_for_board(pcb, pad_net_names: Iterable[str]) -> set[str]:
+    """Net names this board's route will carry as copper pour, not as tracks.
+
+    Two sources, unioned:
+
+    * zones already drawn in the file (:func:`zone_net_names`);
+    * the POWER/GROUND nets ``kct route``'s auto-pour would create zones for,
+      via the shared
+      :func:`kicad_tools.router.auto_pour.classify_pour_candidates` helper --
+      an unrouted board usually has no zones yet, and forecasting its power
+      pins as track demand would describe a run nobody performs.
+
+    The helper's all-power-board guard is honoured: when *every* net is a pour
+    candidate no zones are created (#2740), so nothing is deferred.
+    """
+    pours = zone_net_names(pcb)
+    names = sorted({str(n) for n in pad_net_names if str(n)})
+    if not names:
+        return pours
+    try:
+        from kicad_tools.router.auto_pour import classify_pour_candidates
+
+        pour_candidates, _signal_count, is_all_power = classify_pour_candidates(
+            dict(enumerate(names, start=1))
+        )
+        if not is_all_power:
+            pours |= {name for name, _cls in pour_candidates}
+    except Exception:  # pragma: no cover - the classifier is best-effort here
+        pass
+    return pours
+
+
+def load_field_pads(pcb) -> list[FieldPad]:
+    """Absolute-positioned pads of every footprint on a loaded board.
+
+    Rotation is applied through
+    :func:`kicad_tools.core.geometry.rotate_pad_offset`, the single source of
+    truth for KiCad's negated-angle convention (#3739) -- this model measures
+    inter-pad distances, so a mis-rotated pad field would silently change every
+    number it reports.
+    """
+    from kicad_tools.core.geometry import rotate_pad_offset
+
+    pads: list[FieldPad] = []
+    for footprint in getattr(pcb, "footprints", ()) or ():
+        ref = str(getattr(footprint, "reference", "") or "")
+        if not ref:
+            continue
+        origin = getattr(footprint, "position", (0.0, 0.0))
+        rotation = float(getattr(footprint, "rotation", 0.0) or 0.0)
+        name = str(getattr(footprint, "library_link", "") or getattr(footprint, "name", "") or "")
+        for pad in getattr(footprint, "pads", ()) or ():
+            local_x, local_y = pad.position
+            offset_x, offset_y = rotate_pad_offset(local_x, local_y, rotation)
+            size = getattr(pad, "size", (0.0, 0.0)) or (0.0, 0.0)
+            pads.append(
+                FieldPad(
+                    x=float(origin[0]) + offset_x,
+                    y=float(origin[1]) + offset_y,
+                    width=float(size[0]),
+                    height=float(size[1]),
+                    ref=ref,
+                    net_name=str(getattr(pad, "net_name", "") or ""),
+                    footprint_name=name,
+                )
+            )
+    return pads
+
+
+def forecast_from_board(
+    pcb_path: Path | str,
+    *,
+    signal_layers: int | None = None,
+    track_width_mm: float | None = None,
+    clearance_mm: float | None = None,
+    via_diameter_mm: float | None = None,
+    via_in_pad: bool = False,
+) -> CapacityForecast:
+    """Build the forecast for a board file.
+
+    Any rule left as ``None`` is taken from the board's own ``(setup ...)``
+    section (and the layer count from its ``(layers ...)`` section), so the
+    forecast describes the board as drawn; ``kct route`` passes the values the
+    run will actually use instead.
+
+    Raises :class:`CapacityForecastError` when the board cannot be read.
+    """
+    target = Path(pcb_path)
+    try:
+        pcb_text = target.read_text()
+    except OSError as exc:
+        raise CapacityForecastError(f"cannot read {target}: {exc}") from exc
+
+    from kicad_tools.router.io import detect_layer_stack, parse_pcb_design_rules
+    from kicad_tools.schema import PCB
+
+    warnings: list[str] = []
+    rules = parse_pcb_design_rules(pcb_text)
+    if signal_layers is None:
+        try:
+            signal_layers = len(detect_layer_stack(pcb_text).signal_layers)
+        except Exception as exc:  # pragma: no cover - malformed layer section
+            warnings.append(f"layer stack unreadable ({exc}); assuming 2 signal layers")
+            signal_layers = 2
+    try:
+        pcb = PCB.load(str(target))
+    except Exception as exc:
+        raise CapacityForecastError(f"cannot parse {target}: {exc}") from exc
+    pads = load_field_pads(pcb)
+    if not pads:
+        warnings.append("no footprint pads parsed from the board")
+    return build_forecast(
+        pads,
+        source=str(target),
+        signal_layers=signal_layers,
+        track_width_mm=rules.min_track_width if track_width_mm is None else track_width_mm,
+        clearance_mm=rules.min_clearance if clearance_mm is None else clearance_mm,
+        via_diameter_mm=(rules.min_via_diameter if via_diameter_mm is None else via_diameter_mm),
+        via_in_pad=via_in_pad,
+        pour_nets=pour_nets_for_board(pcb, (p.net_name for p in pads)),
+        warnings=warnings,
+    )
+
+
+def write_report(path: Path | str, forecast: CapacityForecast) -> Path:
+    """Write *forecast* as the JSON document at *path* and return the path.
+
+    Keys are sorted and the payload is a single object, matching ``kct``'s
+    machine-output contract (``docs/reference/machine-output.md``).
+    """
+    target = Path(path)
+    if target.parent and not target.parent.exists():
+        target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(json.dumps(forecast.to_dict(), indent=2, sort_keys=True, default=str) + "\n")
+    return target
+
+
+def emit_forecast(
+    pcb_path: Path | str,
+    *,
+    stream: Any = None,
+    report_path: Path | str | None = None,
+    signal_layers: int | None = None,
+    track_width_mm: float | None = None,
+    clearance_mm: float | None = None,
+    via_diameter_mm: float | None = None,
+    via_in_pad: bool = False,
+) -> CapacityForecast | None:
+    """Print the pre-route forecast for *pcb_path*.  Never raises.
+
+    Returns the forecast, or ``None`` when it could not be built (a one-line
+    diagnostic goes to *stream*).  A predictor that cannot run is a missing
+    diagnostic, not a reason to refuse to route -- the ``_offboard_preflight``
+    precedent, restated for every advisory surface on #4799.
+    """
+    import sys
+
+    out = stream if stream is not None else sys.stderr
+    try:
+        forecast = forecast_from_board(
+            pcb_path,
+            signal_layers=signal_layers,
+            track_width_mm=track_width_mm,
+            clearance_mm=clearance_mm,
+            via_diameter_mm=via_diameter_mm,
+            via_in_pad=via_in_pad,
+        )
+    except Exception as exc:
+        print(f"[capacity-forecast] no forecast for {pcb_path}: {exc}", file=out)
+        return None
+    print(forecast.format_human(), file=out)
+    if report_path is not None:
+        try:
+            written = write_report(report_path, forecast)
+        except Exception as exc:
+            print(f"[capacity-forecast] report NOT written to {report_path}: {exc}", file=out)
+        else:
+            print(
+                f"[capacity-forecast] report written to {written} "
+                f"({forecast.fields_modelled} field(s), verdict={forecast.verdict})",
+                file=out,
+            )
+    return forecast

--- a/tests/router/test_capacity_forecast_4799.py
+++ b/tests/router/test_capacity_forecast_4799.py
@@ -1,0 +1,620 @@
+"""Issue #4799: the placement-only pad-field escape-capacity forecast.
+
+The earlier slices of #4799 (#4852 report, #4862 replay, #4865 gate) all rest on
+a measurement taken *during* a previous route.  This module pins the first
+predictor on this issue that needs no prior run at all: ring depth, inter-pad
+channels and the pin count that must leave a footprint are properties of the
+placement, so the forecast is exact on the first route of a brand-new board.
+
+Sections:
+
+1. The primitives -- ``channels_in_gap`` boundaries, onion-peel ``ring_depths``
+   (a two-row connector must NOT be modelled as an array), and the interstitial
+   ``via_site_clearance`` (a dogbone goes diagonally between four pads, not
+   through the orthogonal gap -- getting this wrong flips a healthy BGA into a
+   false "cannot reach an inner layer").
+2. The ring-cut model -- demand/supply per cut, and the three verdicts that
+   matter: ``infeasible`` (no channel at all), ``over-capacity`` (more pins than
+   channels) and ``ample``.
+3. What is *not* demand -- internal-only nets, and poured pins, which are
+   deferred **only** where a via drop actually exists.
+4. The document + human block, including "not applicable" staying distinct from
+   a clean bill of health.
+5. ``emit_forecast`` never raising, and the ``kct route`` wiring: both parsers
+   carry the flags, the shim forwards them only when set, and the preflight
+   cannot change an exit code.
+
+Everything but the two file-based tests runs on fabricated :class:`FieldPad`
+arrays, so this file costs milliseconds -- the point of a leading indicator.
+"""
+
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+
+import pytest
+
+from kicad_tools.router.capacity_forecast import (
+    MIN_PADS_FOR_FIELD,
+    OVER_CAPACITY_RATIO,
+    REPORT_KIND,
+    SCHEMA_VERSION,
+    TIGHT_RATIO,
+    VERDICT_AMPLE,
+    VERDICT_INFEASIBLE,
+    VERDICT_NOT_APPLICABLE,
+    VERDICT_OVER_CAPACITY,
+    CapacityForecastError,
+    FieldPad,
+    build_forecast,
+    channels_in_gap,
+    emit_forecast,
+    forecast_from_board,
+    ring_depths,
+    via_site_clearance,
+    write_report,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures: fabricated pad fields
+# ---------------------------------------------------------------------------
+
+
+def grid_field(
+    rows: int,
+    cols: int,
+    pitch: float,
+    pad: float,
+    *,
+    ref: str = "U1",
+    net_of=None,
+) -> list[FieldPad]:
+    """A ``rows x cols`` grid array centred on the origin.
+
+    ``net_of(row, col)`` names each pad's net; by default every pad gets its
+    own net so demand is maximal.
+    """
+    pads: list[FieldPad] = []
+    for row in range(rows):
+        for col in range(cols):
+            name = net_of(row, col) if net_of else f"N_{row}_{col}"
+            pads.append(
+                FieldPad(
+                    x=col * pitch,
+                    y=row * pitch,
+                    width=pad,
+                    height=pad,
+                    ref=ref,
+                    net_name=name,
+                )
+            )
+    return pads
+
+
+def sinks(nets, ref: str = "J9") -> list[FieldPad]:
+    """One off-field pad per net, so every net counts as *leaving* the field."""
+    return [
+        FieldPad(x=100.0 + i, y=100.0, width=1.0, height=1.0, ref=ref, net_name=net)
+        for i, net in enumerate(sorted(set(nets)))
+    ]
+
+
+def field_and_sinks(rows, cols, pitch, pad, **kwargs):
+    field = grid_field(rows, cols, pitch, pad, **kwargs)
+    return field + sinks(p.net_name for p in field)
+
+
+# ---------------------------------------------------------------------------
+# 1. Primitives
+# ---------------------------------------------------------------------------
+
+
+class TestChannelsInGap:
+    def test_one_track_needs_clearance_both_sides(self):
+        # 0.2 track + 0.2 clearance either side = 0.6mm of clear channel.
+        assert channels_in_gap(0.59, 0.2, 0.2) == 0
+        assert channels_in_gap(0.60, 0.2, 0.2) == 1
+
+    def test_second_track_needs_a_further_track_plus_clearance(self):
+        assert channels_in_gap(0.99, 0.2, 0.2) == 1
+        assert channels_in_gap(1.00, 0.2, 0.2) == 2
+
+    def test_gap_at_or_below_clearance_carries_nothing(self):
+        assert channels_in_gap(0.2, 0.2, 0.2) == 0
+        assert channels_in_gap(0.0, 0.2, 0.2) == 0
+        assert channels_in_gap(-1.0, 0.2, 0.2) == 0
+
+    def test_degenerate_rules_do_not_raise(self):
+        assert channels_in_gap(1.0, 0.0, 0.0) == 0
+
+
+class TestRingDepths:
+    def test_square_grid_peels_into_rings(self):
+        pads = grid_field(7, 7, 1.27, 0.45)
+        depths = ring_depths([(p.x, p.y) for p in pads], 1.27)
+        assert max(depths) == 3  # 7x7 -> 4 rings
+        assert sum(1 for d in depths if d == 0) == 24  # perimeter
+        assert sum(1 for d in depths if d >= 1) == 25  # interior
+        centre = depths[3 * 7 + 3]
+        assert centre == 3
+
+    def test_two_row_connector_is_all_boundary(self):
+        # Every pad of a dual-row header has open sky on one side, so the
+        # model must NOT treat it as an array with an interior (a bbox-inset
+        # rule gets this wrong and invents interior pins).
+        pads = grid_field(2, 12, 0.5, 0.3)
+        depths = ring_depths([(p.x, p.y) for p in pads], 0.5)
+        assert set(depths) == {0}
+
+    def test_single_row_is_all_boundary(self):
+        pads = grid_field(1, 8, 0.8, 0.4)
+        assert set(ring_depths([(p.x, p.y) for p in pads], 0.8)) == {0}
+
+    def test_empty_and_degenerate_inputs(self):
+        assert ring_depths([], 1.0) == []
+        assert ring_depths([(0.0, 0.0)], 1.0) == [0]
+        assert ring_depths([(0.0, 0.0), (1.0, 0.0)], 0.0) == [0, 0]
+
+
+class TestViaSiteClearance:
+    def test_dogbone_site_is_diagonal_not_orthogonal(self):
+        # 1.27mm grid, 0.45mm square pads: the orthogonal gap leaves only
+        # 0.41mm of half-clearance, but the diagonal interstice leaves ~0.58mm
+        # -- which is the difference between "no via can be dropped here" and
+        # the dogbone every BGA in the world uses.
+        pads = grid_field(5, 5, 1.27, 0.45)
+        clear = via_site_clearance(pads, 1.27)
+        assert clear == pytest.approx(0.58, abs=0.02)
+        assert clear > 0.5 * (1.27 - 0.45)
+
+    def test_fine_pitch_array_has_no_room(self):
+        pads = grid_field(5, 5, 0.5, 0.25)
+        assert via_site_clearance(pads, 0.5) < 0.25
+
+    def test_degenerate_inputs(self):
+        assert via_site_clearance([], 1.0) == 0.0
+        assert via_site_clearance(grid_field(2, 2, 1.0, 0.4), 0.0) == 0.0
+
+
+# ---------------------------------------------------------------------------
+# 2. The ring-cut model
+# ---------------------------------------------------------------------------
+
+
+class TestRingCutModel:
+    def test_coarse_bga_with_a_dogbone_site_is_ample(self):
+        # 7x7 @ 1.27mm, 0.6mm vias: a via fits in the diagonal interstice, so
+        # the interior reaches the inner layers and the ring is not binding.
+        forecast = build_forecast(
+            field_and_sinks(7, 7, 1.27, 0.45),
+            signal_layers=4,
+            track_width_mm=0.2,
+            clearance_mm=0.2,
+            via_diameter_mm=0.6,
+        )
+        assert forecast.applicable
+        field = forecast.worst_field
+        assert field is not None
+        assert field.rings == 4
+        assert field.via_drop_available is True
+        assert forecast.verdict == VERDICT_AMPLE
+        assert forecast.worst_ratio < 1.0
+
+    def test_same_array_without_a_via_drop_is_over_capacity(self):
+        # Two layers and a via too big for the interstice: every interior pin
+        # has to squeeze through the outer ring's 24 single-track gaps.
+        forecast = build_forecast(
+            field_and_sinks(7, 7, 1.27, 0.45),
+            signal_layers=2,
+            track_width_mm=0.2,
+            clearance_mm=0.2,
+            via_diameter_mm=1.0,
+        )
+        field = forecast.worst_field
+        assert field is not None
+        assert field.via_drop_available is False
+        cut = field.worst_cut
+        assert cut is not None
+        assert cut.depth == 1
+        assert cut.demand == 25
+        assert cut.gaps == 24
+        assert cut.channels_per_gap == 1
+        assert cut.supply == 24
+        assert cut.ratio == pytest.approx(25 / 24)
+        assert forecast.verdict == VERDICT_OVER_CAPACITY
+        assert cut.ratio >= OVER_CAPACITY_RATIO
+
+    def test_via_in_pad_capability_reopens_the_inner_layers(self):
+        # Oversized pads (0.9mm on a 1.27mm pitch) leave neither a surface
+        # channel nor an interstice big enough for a 0.6mm via, so the field is
+        # sealed -- until the fab tier allows the via to sit *in* the pad.
+        sealed = build_forecast(
+            field_and_sinks(7, 7, 1.27, 0.9),
+            signal_layers=4,
+            via_diameter_mm=0.6,
+        )
+        assert sealed.worst_field is not None
+        assert sealed.worst_field.via_drop_available is False
+        assert sealed.verdict == VERDICT_INFEASIBLE
+
+        rescued = build_forecast(
+            field_and_sinks(7, 7, 1.27, 0.9),
+            signal_layers=4,
+            via_diameter_mm=0.6,
+            via_in_pad=True,
+        )
+        assert rescued.worst_field is not None
+        assert rescued.worst_field.via_drop_available is True
+        assert rescued.worst_field.drop_channels_per_gap == 1
+        assert rescued.verdict == VERDICT_AMPLE
+
+    def test_fine_pitch_bga_is_infeasible_not_merely_tight(self):
+        # 0.5mm pitch, 0.25mm pads: no track fits between pads and no via fits
+        # in the interstice, so interior pins have nowhere to go on any layer.
+        forecast = build_forecast(
+            field_and_sinks(8, 8, 0.5, 0.25),
+            signal_layers=4,
+            track_width_mm=0.1,
+            clearance_mm=0.1,
+            via_diameter_mm=0.45,
+        )
+        field = forecast.worst_field
+        assert field is not None
+        assert field.surface_channels_per_gap == 0
+        assert field.via_drop_available is False
+        cut = field.worst_cut
+        assert cut is not None and cut.supply == 0 and cut.demand > 0
+        assert forecast.verdict == VERDICT_INFEASIBLE
+
+    def test_worst_cut_is_the_binding_one(self):
+        forecast = build_forecast(
+            field_and_sinks(7, 7, 1.27, 0.45),
+            signal_layers=2,
+            via_diameter_mm=1.0,
+        )
+        field = forecast.worst_field
+        assert field is not None
+        ratios = [cut.ratio for cut in field.cuts]
+        assert field.worst_ratio == max(ratios)
+        # Cuts are emitted outermost-first and demand falls monotonically.
+        assert [cut.depth for cut in field.cuts] == sorted(cut.depth for cut in field.cuts)
+        demands = [cut.demand for cut in field.cuts]
+        assert demands == sorted(demands, reverse=True)
+
+    def test_thresholds_bracket_the_tight_band(self):
+        assert 0.0 < TIGHT_RATIO < OVER_CAPACITY_RATIO
+
+
+# ---------------------------------------------------------------------------
+# 3. What is not demand
+# ---------------------------------------------------------------------------
+
+
+class TestDemandDefinition:
+    def test_nets_that_never_leave_the_footprint_are_not_demand(self):
+        # Same pads, but every net is internal to the field: nothing has to
+        # cross a ring, so the field is not modelled at all.
+        field = grid_field(7, 7, 1.27, 0.45)
+        forecast = build_forecast(field, signal_layers=2, via_diameter_mm=1.0)
+        assert forecast.fields_modelled == 0
+        assert forecast.verdict == VERDICT_NOT_APPLICABLE
+
+    def test_poured_pins_are_deferred_when_a_via_drop_exists(self):
+        pads = field_and_sinks(
+            7, 7, 1.27, 0.45, net_of=lambda r, c: "GND" if (r + c) % 2 else f"S_{r}_{c}"
+        )
+        forecast = build_forecast(pads, signal_layers=4, via_diameter_mm=0.6, pour_nets={"GND"})
+        field = forecast.worst_field
+        assert field is not None
+        assert field.via_drop_available is True
+        assert field.pour_pads_deferred > 0
+        cut = field.worst_cut
+        assert cut is not None
+        assert cut.demand < 25  # the GND interior pins dropped straight down
+
+    def test_poured_pins_still_count_when_no_via_can_be_placed(self):
+        # A pour net is only "free" if the pad can actually reach the plane.
+        pads = field_and_sinks(
+            7, 7, 1.27, 0.45, net_of=lambda r, c: "GND" if (r + c) % 2 else f"S_{r}_{c}"
+        )
+        forecast = build_forecast(pads, signal_layers=4, via_diameter_mm=1.0, pour_nets={"GND"})
+        field = forecast.worst_field
+        assert field is not None
+        assert field.via_drop_available is False
+        assert field.pour_pads_deferred == 0
+        assert field.worst_cut is not None and field.worst_cut.demand == 25
+
+    def test_small_footprints_are_never_modelled(self):
+        pads = [
+            FieldPad(x=i * 1.0, y=0.0, width=0.4, height=0.4, ref="R1", net_name=f"N{i}")
+            for i in range(MIN_PADS_FOR_FIELD - 1)
+        ]
+        forecast = build_forecast(pads + sinks(p.net_name for p in pads))
+        assert forecast.fields_modelled == 0
+
+    def test_perimeter_only_package_is_not_applicable(self):
+        # A QFN escapes outward from every pad; there is no ring to cross.
+        pads = []
+        for i in range(12):
+            pads.append(
+                FieldPad(x=i * 0.5, y=0.0, width=0.3, height=0.3, ref="U9", net_name=f"A{i}")
+            )
+            pads.append(
+                FieldPad(x=i * 0.5, y=6.0, width=0.3, height=0.3, ref="U9", net_name=f"B{i}")
+            )
+        forecast = build_forecast(pads + sinks(p.net_name for p in pads))
+        assert forecast.applicable is False
+        assert forecast.verdict == VERDICT_NOT_APPLICABLE
+
+
+# ---------------------------------------------------------------------------
+# 4. Document + human block
+# ---------------------------------------------------------------------------
+
+
+class TestDocument:
+    def _forecast(self):
+        return build_forecast(
+            field_and_sinks(7, 7, 1.27, 0.45),
+            source="board.kicad_pcb",
+            signal_layers=2,
+            via_diameter_mm=1.0,
+        )
+
+    def test_envelope_matches_the_machine_output_convention(self):
+        doc = self._forecast().to_dict()
+        assert doc["schema_version"] == SCHEMA_VERSION
+        assert doc["report"] == REPORT_KIND
+        assert doc["source"] == "board.kicad_pcb"
+        assert "generated_at" in doc
+        assert doc["rules"]["signal_layers"] == 2
+        assert doc["summary"]["verdict"] == VERDICT_OVER_CAPACITY
+        assert doc["summary"]["worst_ref"] == "U1"
+        assert doc["summary"]["worst_ratio"] == pytest.approx(1.042, abs=0.001)
+        assert doc["fields"][0]["cuts"][0]["depth"] == 1
+
+    def test_infinite_ratio_serialises_as_null(self):
+        doc = build_forecast(
+            field_and_sinks(8, 8, 0.5, 0.25),
+            signal_layers=2,
+            track_width_mm=0.1,
+            clearance_mm=0.1,
+            via_diameter_mm=0.45,
+        ).to_dict()
+        assert doc["summary"]["verdict"] == VERDICT_INFEASIBLE
+        assert doc["summary"]["worst_ratio"] is None
+        assert doc["fields"][0]["cuts"][0]["ratio"] is None
+        json.dumps(doc)  # must stay serialisable
+
+    def test_human_block_is_tagged_and_advisory(self):
+        text = self._forecast().format_human()
+        assert all(line.startswith("[capacity-forecast]") for line in text.splitlines())
+        assert "ADVISORY ONLY" in text
+        assert "U1" in text
+        assert "FIX LAYER" in text
+
+    def test_not_applicable_is_not_a_clean_bill_of_health(self):
+        text = build_forecast([], source="empty.kicad_pcb").format_human()
+        assert "NOT APPLICABLE" in text
+        assert "not an 'ample' result" in text
+        assert "ADVISORY ONLY" in text
+
+    def test_write_report_creates_parents_and_sorts_keys(self, tmp_path):
+        target = tmp_path / "nested" / "forecast.json"
+        written = write_report(target, self._forecast())
+        assert written == target
+        payload = target.read_text()
+        doc = json.loads(payload)
+        assert doc["report"] == REPORT_KIND
+        assert list(doc) == sorted(doc)
+
+
+# ---------------------------------------------------------------------------
+# 5. Board loading, emit, and the ``kct route`` wiring
+# ---------------------------------------------------------------------------
+
+
+def _synthetic_board(tmp_path, rows=7, cols=7, pitch=1.27, pad=0.45):
+    """A minimal but real ``.kicad_pcb`` holding one grid array."""
+    pads = []
+    nets = []
+    n = 0
+    for row in range(rows):
+        for col in range(cols):
+            n += 1
+            nets.append(f"N{n}")
+            pads.append(
+                f'    (pad "{n}" smd rect (at {col * pitch:.3f} {row * pitch:.3f}) '
+                f'(size {pad} {pad}) (layers "F.Cu") (net {n} "N{n}"))'
+            )
+    # A second footprint gives every net a pad outside the array, so all of
+    # them count as leaving it.
+    sink_pads = [
+        f'    (pad "{i + 1}" smd rect (at {i * 1.0:.3f} 0) (size 0.6 0.6) '
+        f'(layers "F.Cu") (net {i + 1} "N{i + 1}"))'
+        for i in range(len(nets))
+    ]
+    net_decls = "\n".join(f'  (net {i + 1} "N{i + 1}")' for i in range(len(nets)))
+    text = f"""(kicad_pcb (version 20221018) (generator test)
+  (general (thickness 1.6))
+  (paper "A4")
+  (layers
+    (0 "F.Cu" signal)
+    (31 "B.Cu" signal)
+    (44 "Edge.Cuts" user)
+  )
+  (setup)
+  (net 0 "")
+{net_decls}
+  (footprint "Test:BGA" (layer "F.Cu") (at 50 50)
+    (fp_text reference "U1" (at 0 -6) (layer "F.SilkS"))
+{chr(10).join(pads)}
+  )
+  (footprint "Test:SINK" (layer "F.Cu") (at 120 50)
+    (fp_text reference "J9" (at 0 -6) (layer "F.SilkS"))
+{chr(10).join(sink_pads)}
+  )
+)
+"""
+    board = tmp_path / "synthetic.kicad_pcb"
+    board.write_text(text)
+    return board
+
+
+class TestBoardLoading:
+    def test_forecast_from_board_models_the_array(self, tmp_path):
+        board = _synthetic_board(tmp_path)
+        forecast = forecast_from_board(board, signal_layers=2, via_diameter_mm=1.0)
+        assert forecast.footprints_seen == 2
+        assert forecast.fields_modelled == 1
+        field = forecast.worst_field
+        assert field is not None and field.ref == "U1" and field.rings == 4
+        assert forecast.verdict == VERDICT_OVER_CAPACITY
+
+    def test_missing_board_raises_the_module_error(self, tmp_path):
+        with pytest.raises(CapacityForecastError):
+            forecast_from_board(tmp_path / "nope.kicad_pcb")
+
+    def test_emit_forecast_prints_and_writes(self, tmp_path, capsys):
+        board = _synthetic_board(tmp_path)
+        report = tmp_path / "out" / "forecast.json"
+        forecast = emit_forecast(board, report_path=report, signal_layers=2, via_diameter_mm=1.0)
+        assert forecast is not None
+        err = capsys.readouterr().err
+        assert "[capacity-forecast]" in err
+        assert "report written to" in err
+        assert json.loads(report.read_text())["report"] == REPORT_KIND
+
+    def test_emit_forecast_never_raises_on_a_bad_board(self, tmp_path, capsys):
+        assert emit_forecast(tmp_path / "missing.kicad_pcb") is None
+        assert "no forecast" in capsys.readouterr().err
+
+    def test_emit_forecast_survives_an_unwritable_report_path(self, tmp_path, capsys):
+        board = _synthetic_board(tmp_path)
+        blocked = tmp_path / "file.txt"
+        blocked.write_text("not a directory")
+        forecast = emit_forecast(board, report_path=blocked / "forecast.json")
+        assert forecast is not None  # the forecast itself still succeeded
+        assert "report NOT written" in capsys.readouterr().err
+
+
+class TestRouteWiring:
+    def test_outer_parser_accepts_and_forwards_the_flags(self):
+        """`kct route` parses with the OUTER parser and shells the inner one.
+
+        Adding the flags to ``route_cmd.py`` alone leaves ``kct route
+        --capacity-forecast`` dying with "unrecognized arguments" -- the #4862
+        lesson, restated for this pair.
+        """
+        from kicad_tools.cli import route_cmd
+        from kicad_tools.cli.commands import routing
+        from kicad_tools.cli.parser import create_parser
+
+        captured: list[list[str]] = []
+
+        def fake_main(argv):
+            captured.append(list(argv))
+            return 0
+
+        original = route_cmd.main
+        route_cmd.main = fake_main  # imported inside run_route_command
+        try:
+            args = create_parser().parse_args(
+                [
+                    "route",
+                    "board.kicad_pcb",
+                    "--capacity-forecast",
+                    "--capacity-forecast-json",
+                    "f.json",
+                ]
+            )
+            assert args.capacity_forecast is True
+            assert args.capacity_forecast_json == "f.json"
+            assert routing.run_route_command(args) == 0
+
+            plain = create_parser().parse_args(["route", "board.kicad_pcb"])
+            assert plain.capacity_forecast is False
+            assert plain.capacity_forecast_json is None
+            assert routing.run_route_command(plain) == 0
+        finally:
+            route_cmd.main = original
+
+        with_flags, without_flags = captured
+        assert "--capacity-forecast" in with_flags
+        assert with_flags[with_flags.index("--capacity-forecast-json") + 1] == "f.json"
+        assert "--capacity-forecast" not in without_flags
+        assert "--capacity-forecast-json" not in without_flags
+
+    def test_inner_parser_accepts_the_flags(self):
+        import argparse
+        from unittest.mock import patch
+
+        from kicad_tools.cli.route_cmd import main as route_main
+
+        captured: dict[str, argparse.Namespace] = {}
+        real_parse_args = argparse.ArgumentParser.parse_args
+
+        def fake_parse_args(self, *args, **kwargs):
+            if getattr(self, "prog", "") == "kicad-tools route":
+                captured["args"] = real_parse_args(self, *args, **kwargs)
+                raise SystemExit(0)
+            return real_parse_args(self, *args, **kwargs)
+
+        with patch.object(argparse.ArgumentParser, "parse_args", fake_parse_args):
+            with pytest.raises(SystemExit):
+                route_main(
+                    [
+                        "board.kicad_pcb",
+                        "--capacity-forecast",
+                        "--capacity-forecast-json",
+                        "f.json",
+                    ]
+                )
+        assert captured["args"].capacity_forecast is True
+        assert captured["args"].capacity_forecast_json == "f.json"
+
+    def test_preflight_is_silent_when_unarmed(self, tmp_path, capsys):
+        from kicad_tools.cli.route_cmd import _capacity_forecast_preflight
+
+        board = _synthetic_board(tmp_path)
+        args = SimpleNamespace(capacity_forecast=False, capacity_forecast_json=None)
+        assert _capacity_forecast_preflight(board, args) is None
+        assert capsys.readouterr().err == ""
+
+    def test_preflight_prints_but_cannot_fail_a_route(self, tmp_path, capsys):
+        from kicad_tools.cli.route_cmd import _capacity_forecast_preflight
+
+        board = _synthetic_board(tmp_path)
+        args = SimpleNamespace(
+            capacity_forecast=True,
+            capacity_forecast_json=None,
+            layers="2",
+            trace_width=0.2,
+            clearance=0.2,
+            via_diameter=1.0,
+            manufacturer=None,
+        )
+        # No return value at all: the caller has nothing to turn into an exit
+        # code, which is what "advisory in every case" means here.
+        assert _capacity_forecast_preflight(board, args) is None
+        err = capsys.readouterr().err
+        assert "[capacity-forecast]" in err
+        assert "over-capacity" in err
+
+    def test_preflight_swallows_a_broken_board(self, tmp_path, capsys):
+        from kicad_tools.cli.route_cmd import _capacity_forecast_preflight
+
+        broken = tmp_path / "broken.kicad_pcb"
+        broken.write_text("(this is not a board")
+        args = SimpleNamespace(
+            capacity_forecast=True,
+            capacity_forecast_json=None,
+            layers="auto",
+            trace_width=None,
+            clearance=0.15,
+            via_diameter=0.6,
+            manufacturer=None,
+        )
+        assert _capacity_forecast_preflight(broken, args) is None
+        assert "[capacity-forecast]" in capsys.readouterr().err


### PR DESCRIPTION
## Part of #4799 — slice 4: a predictor that needs no prior run

Slices 1–3 (#4852 report, #4862 replay, #4865 gate) made the diff-pair
crossing-tail census a leading indicator — but all three rest on a measurement
taken during a **previous** route. The census consults order-dependent state
(drills placed by earlier crossovers, the escape-channel registry), so it can
only be replayed, and it only exists on boards that route coupled diff pairs
through the shadow constructor. Boards 05 and 07 will forever report
`not-applicable`.

This slice adds the first predictor on #4799 that is **placement-only**: ring
depth, inter-pad channels and the pin count that must leave a footprint are
properties of the placement, so the forecast is exact on the **first** route of
a brand-new board, on any board with a multi-ring pad field.

```bash
uv run kct route board.kicad_pcb --capacity-forecast
uv run kct route board.kicad_pcb --capacity-forecast-json forecast.json
```

### The model (`src/kicad_tools/router/capacity_forecast.py`)

1. **Onion-peel ring depth** — shape-agnostic on purpose. A two-row connector
   (USB-C) is *all* boundary and must not be modelled as an array; a bbox-inset
   rule invents interior pins there (I tried it first; it produced a false
   `infeasible` on board-03's J1).
2. **Channels per gap** at the run's track/clearance.
3. **Via drop at the interstitial site** — the diagonal gap a dogbone actually
   uses. On a 1.27/0.45 array the orthogonal half-gap is 0.41 mm but the
   interstice is 0.58 mm; my first version tested the orthogonal gap and
   declared board-06's BGA unable to reach an inner layer, which is false. This
   correction is the single most load-bearing detail in the diff.
4. **Ring cuts** — every pin at depth ≥ d crosses the ring at depth d−1;
   demand = those pins, supply = that ring's gaps × channels (own layer, plus
   the drop layers *only where a via drop exists*). Verdicts:
   `not-applicable` / `ample` / `tight` / `over-capacity` / `infeasible`.

Poured pins are deferred only where a via drop exists — crediting them
otherwise is how a counting model talks itself out of a real blockage. Pour
nets = the file's zones ∪ the POWER/GROUND nets `kct route`'s own auto-pour
would create (`auto_pour.classify_pour_candidates`, all-power guard honoured),
so an unrouted board is forecast the way it will actually be routed.

### Two measurements shaped this, and one of them is a negative result

**Board-scale RUDY was tried first and rejected.** Feeding the fleet through
the existing `CongestionEstimator` and dividing per-tile demand by a per-tile
track supply gives **1.2–3.5 % utilisation and a 0.24× peak tile on every
board**, including the two with open router epics. A predictor built on it
would hand a clean bill of health to the boards that do not route. Escape
geometry is local, so this model is local. (The probe is not shipped — only the
conclusion, in the docs.)

**The fleet, through this model** (unrouted inputs, default rules):

| Board | Fields | Worst | Verdict | Cost |
|---|---:|---|---|---:|
| 00 / 01 / 02 / 03 / 04 / 05 | 0 | — | `not-applicable` | 1–23 ms |
| 06-diffpair-test | 1 | U2, 49 pads / 4 rings | `ample` 0.08× | 13 ms |
| 07-matchgroup-test | 1 | U4, 49 pads / 4 rings | `ample` 0.05× | 16 ms |
| chorus-test-revA v24 (local-only, 90 fps) | 0 | — | `not-applicable` | 883 ms |

**No board is flagged, and that is the honest reading** — both multi-ring
arrays have a legal dogbone interstice. Boards 06/07 fail for mechanisms this
counting model does not claim to see. I would rather ship a predictor that
declines to cry wolf than tune a threshold until the fleet lights up.

Its positive controls are the counterfactuals it exists for, both pinned as
tests and one reproduced verbatim in the docs:

* the same board-06 array at `--via-diameter 1.0` (no legal interstice) →
  **1.04× over capacity**, 25 interior pins against 24 single-track gaps, with
  the fix layer named (via-in-pad tier / smaller via / pitch / stackup);
* a 0.5 mm-pitch array → **`infeasible`**: no track between pads and no via
  between them, so nothing leaves on any layer — the HDI case, in milliseconds.

### Advisory, structurally

`_capacity_forecast_preflight` returns **nothing** — there is no value for the
caller to turn into an exit code, which is a stronger guarantee than "returns
0". An unreadable/unparseable board prints one `no forecast:` line; an
unwritable `--capacity-forecast-json` path prints a diagnostic without losing
the block. Both flags default off, live on **both** parsers, and are forwarded
by `commands/routing.py` only when set (`tests/test_cli_parser_drift.py` passes
with no allowlist edit). Promoting this to a go/no-go the way #4865 did is
explicitly follow-up: these thresholds are one fleet's judgement.

### Incidental finding (not fixed here)

`router/io.py :: load_pads_for_analysis` matches only `(fp_text reference …)`,
so on a board saved by a current KiCad — `(property "Reference" …)`, e.g. the
local chorus fixture — it returns pads with an empty `ref` and any consumer
sees **zero footprints**. This forecast therefore loads through
`kicad_tools.schema.PCB` instead (also cross-checked: both loaders agree
digit-for-digit on the fleet's legacy-format boards). Filing separately; that
loader also feeds fine-pitch grid planning.

### Verification

```
tests/router/test_capacity_forecast_4799.py ..................... 37 passed (0.7 s)
+ test_crosstail_advisory_4799 + test_cli_parser_drift
  + test_crosstail_census_report_4799 + test_diffpair_census_budget
  + test_docs_source_citations + test_check_doc_drift ............ 206 passed
pytest -k "cli and route" ...................................... 324 passed, 2 skipped
tests/test_cli_commands.py + test_route_offboard_gate.py ......... 45 passed
ruff check . / ruff format --check . ............................ clean
scripts/ci/check_mypy_baseline.py (no --update) ................. 1464 / 1472, no new errors
```

The docs transcript in `docs/reference/capacity-forecast.md` was diffed against
live CLI output rather than hand-written.

### Still open on #4799

1. Generalising beyond pad fields — #3438's *inter-component* bundle
   congestion is a corridor problem this model does not see.
2. A go/no-go gate on this forecast (needs calibration first).
3. Calibrating both this model's `TIGHT_RATIO` and the census's inert
   threshold against #4830's corpus.

Part of #4799.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
