### PR TITLE
feat(router): re-score the #4507 T4 softstart proof and name what it found

### DIFF
--- a/docs/hv-pairwise-softstart-proof.md
+++ b/docs/hv-pairwise-softstart-proof.md
@@ -2,19 +2,14 @@
 
 Point-in-time working document — it describes the tree as of its date.
 
-> **Update (#4867 fixed):** the root cause this run isolated — the `abs()`
-> collapse of signed potentials, described in
+> **Re-scored (#4867's fix landed as #4868).** The root cause the first run
+> isolated — the `abs()` collapse of signed potentials, described in
 > [The root cause](#the-root-cause-signed-potentials-are-collapsed-to-magnitudes)
-> — has since been fixed. Re-measuring the table over the **same**
-> `vmap.json` (md5 `cc72a701a6c4c3c335859bcc6029ab94`) now yields **1922
-> cross-pairs**, matching the census exactly: the 99 missing pairs are back,
-> the 240 under-required pairs carry their full requirement, and **no pair is
-> lost**. Everything below the update is the *pre-fix* measurement and is kept
-> as the record of the diagnosis. The routing arms have **not** been re-run, so
-> the 49/82 · 42-census-fail · 3-gate-hit numbers in the verdict table are
-> stale: per #4867's acceptance criteria the leak set is expected to **grow**
-> before it shrinks, because 99 pairs re-enter the matrix. **#4507's T4 must be
-> re-scored** on top of the fix.
+> — is fixed, and the routing arms have now been **re-run on top of it**.
+> [The re-score](#the-re-score-same-recipe-corrected-table) is the current
+> record and supersedes the pre-fix numbers; everything from
+> [Verdict (pre-fix run)](#verdict-of-the-pre-fix-run-t4-fails--but-the-machinery-is-measurably-doing-its-job)
+> downwards is kept verbatim as the record of the diagnosis.
 
 This is the record of the **T4 manual criterion** of issue
 [#4507](https://github.com/rjwalters/kicad-tools/issues/4507) (router Phase 2 of
@@ -29,7 +24,168 @@ cannot live in CI: softstart rev-C is a **local-only** consumer fixture
 (`github.com/rjwalters/softstart`, deliberately no CI presence here), so the
 proof is a documented local run. This file is that record.
 
-## Verdict: **T4 FAILS** — but the machinery is measurably doing its job
+## The re-score: same recipe, corrected table
+
+Re-run on `main` @ `090086b4` (C++ backend build 21) with the **same** fixture at
+`7800b046`, the **same** four input files at the same md5s, and the same three
+commands. The only difference from the pre-fix run below is that
+`build_pairwise_clearance_table()` and the CLI's `--voltage-map` preload now
+difference the potentials **as supplied** (#4868), so the banner prints
+`84 mapped nets, 1922 cross-pairs` instead of 1823.
+
+### Verdict: **T4 still FAILS** — 25, not 0
+
+| Measure | T4 requires | **post-fix (this run)** | pre-fix | control: matrix off |
+|---|---|---|---|---|
+| Signal nets routed | 100 % | **50 / 82 (61 %)** | 49 / 82 | 50 / 82 |
+| Cross-pairs in the matrix | = census | **1922** | 1823 | dormant |
+| Board-level census fails, after step 2 | **0** | **25** | 57 | 107 |
+| Board-level census fails, after step 3 (HV keepouts) | **0** | **35** | 42 | — (pass not run) |
+| Router's own gate on the finished board (same-layer track↔track, #4506 zones honoured) | 0 | **2** | 3 | 54 |
+| Router's inline post-route audit | 0 | **1** | 5 | (dormant) |
+
+The headline: **restoring the 99 missing pairs and correcting 240 more did not
+cost routability and did not grow the leak set.** #4867's acceptance criteria
+expected the leaks to *grow* before shrinking; on this board they shrank in every
+column — one net *more* routed (50 vs 49), less than half the board-level census
+fails (25 vs 57 at the same step), and one fewer router-gate leak (2 vs 3).
+
+Wall clock is **not** comparable this time: the grid arm ran concurrently on the
+same machine (step 1 258 s, step 2 1291 s vs 109 s / 1032 s uncontended).
+Nothing else in the recipe changed.
+
+### Two new findings, neither of them a search defect
+
+**1. `--hv-threshold` hides pairs the census scores (405 of them here).**
+`build_pairwise_clearance_table()` omits every pair whose `|ΔV|` is below
+`--hv-threshold` (30 V by default), leaving it at the scalar DRU floor. The
+census has no threshold: it looks IEC 60664-1 up at the pair's *actual* `|ΔV|`,
+and the standard's low-voltage rows are **above** a 0.2 mm fab floor:
+
+```
+mapped-net pairs below the 30 V threshold requiring more than the DRU floor : 811
+  ...of which the census actually scores on this board                      : 405
+their census requirement                                : 0.40 / 0.42 / 0.45 / 0.48 / 0.50 / 0.53 mm
+their |ΔV| range                                        : 1.6 V .. 28.0 V
+what the router requires for them                       : 0.200 mm (the DRU floor)
+```
+
+This is not the sign collapse returning — those 405 pairs difference correctly,
+they are simply *below the threshold*. It is nonetheless load-bearing for T4:
+**5 of the 25 residual board-level fails are sub-30 V pairs** (e.g.
+`/PRE_D_POS`↔`/PRECHARGE_POS`, 0.400 mm against 0.420 mm at 11.7 V), and after
+step 1 alone it was 10 of 36. No search can close them, because the requirement
+never reaches the search.
+
+The threshold itself is deliberate policy — it exists so LV↔LV pairs are not
+over-segregated — so this run does **not** propose changing the default. What it
+does propose (and #4507's next increment ships) is that the run *say so*: the
+`--voltage-map` banner now reports the hidden-pair count, the worst pair, and the
+`--hv-threshold 0` escape hatch, instead of printing a cross-pair count that
+reads like full coverage. Verified end to end: at `--hv-threshold 0` the pairs
+enter the matrix and the #4588 audit fails the copper the census was already
+failing.
+
+**2. The HV keepout pass now makes this board worse (25 → 35).** Pre-fix, step 3
+retired 15 fails (57 → 42). Post-fix it *adds* 15 and retires 5:
+
+```
+kct zones hv-keepout --clearance 1.6 --refill   →  8 voids planned (pre-fix: 5)
+  retired : 5 genuine fails (0.425-0.967 mm against 1.3-1.6 mm)
+  created : 15 marginal fails at 1.5931-1.5942 mm against 1.600 mm
+```
+
+Every one of the 15 is the *same* defect: the carved void leaves the pour edge
+**6-7 µm short** of the clearance it was asked for, so a pair that was not
+failing before the pass fails by 0.4 % of its requirement afterwards. Carving at
+exactly the required clearance has no margin for the polygon discretisation of
+the void, and the refill lands inside. This is `zones/hv_keepout.py`, not the
+router search — recorded here (with the numbers to reproduce it) rather than
+fixed in a Phase 2 PR. **The best board this recipe produces is therefore step 2
+at 25, and step 3 should be run with a clearance margin (or not at all) until
+that is addressed.**
+
+### What the residual 25 actually are
+
+| Class | Count | Can Phase 2's search fix it? |
+|---|---|---|
+| Involves a plane pour (`GND` / `+3.3V` auto-pour copper) | 9 | No — the router's gate is trace↔trace; pour geometry is the census' remit (#3901) |
+| Sub-30 V pair, absent from the matrix by `--hv-threshold` | 5 (1 also pour) | No — the requirement never reaches the search |
+| Pad/via geometry or placement-fixed copper | 12 | Partly — but only 1 net pair of the 12 is same-layer track↔track |
+| **Router's own gate on the finished board** | **2 instances, 1 net pair** | Yes — `/I_SENSE_OUT`↔`/SCAP_NEG`, 0.600 mm against 1.400 mm on B.Cu |
+
+The 2 remaining gate leaks are what the router is genuinely responsible for, down
+from 3 pre-fix and 54 with the matrix off. Replaying `segment_pair_violation`
+over the finished board with and without the #4506 attach zones:
+
+```
+step2.kicad_pcb: 1940 segments over 55 nets, 135 attach zones, 1922 cross-pairs
+  track-track pairwise violations WITH #4506 attach zones :  2  (1 net pair)
+  track-track pairwise violations WITHOUT attach zones    :  8  (3 net pairs)
+```
+
+The 6 waived instances are the same two optocoupler pairs the pre-fix run found
+(`/GATE_POS_A`↔`/LED_K_POS`, `/GATE_NEG_A`↔`/LED_K_NEG`, 0.892-1.000 mm inside
+the part's own pad bbox) — #4506 working as designed on real geometry, twice.
+
+### The grid arm, re-run
+
+Same third arm as before (the one that exercises #4507's *own* C++ kernels rather
+than the lattice's): **0 / 82 nets** (pre-fix 2 / 82), 55 partial, 27 with no
+segments, 22 min 44 s, 12 HV pairwise violations in the copper it did commit. The
+fine-pitch escape wall this board hits is unchanged and predates #4431; the
+stricter table costs it the two nets it used to finish.
+
+`FAILURE_PAIRWISE_BLOCKED` (#4860) fired on **8** nets (pre-fix 10), naming six
+distinct blockers:
+
+| drained net | blocker reported | blocker's name |
+|---|---|---|
+| `/SCAP_NEG_RTN`, `/GATE_NEG_A` | `blocking net id 33` | `/LED_A_NEG` |
+| `/V_AC_SENSE_RAW`, `/V_BUS_DVDT` | `blocking net id 4` | `/AC_LINE` |
+| `/PRECHARGE_NEG` | `blocking net id 50` | `/SCAP_NEG` |
+| `/STATUS_LED` | `blocking net id 54` | `/SRC_NEG` |
+| `/SRC_NEG` | `blocking net id 51` | `/SCAP_NEG_RTN` |
+| `/GATE_RTN_NEG` | `blocking net id 21` | `/GATE_BUS_NEG` |
+
+The right-hand column is a lookup this run had to do by hand — the operator-facing
+gap the pre-fix run flagged in passing. #4507's next increment closes it: the
+diagnostic resolves the id through the pathfinder's own net map, falling back to
+the bare id only when no map is threaded. Confirmed on this same board (a
+shorter, `--timeout 420` replay of the arm above, on the patched tree):
+
+```
+Net /SCAP_NEG_RTN: C++ pathfinder gave up (open set drained with expansions
+  refused by pairwise (HV-isolation) clearance (blocking net /LED_A_NEG));
+  falling back to the pure-Python A* ...
+```
+
+— the same refusal that printed `blocking net id 33` two paragraphs above.
+
+### What T4 needs now
+
+The pre-fix list's item 1 (the sign collapse) is **done**. The rest, re-derived
+from this run:
+
+1. **The `--hv-threshold` policy question** (5 of 25). A board that must pass
+   `kct creepage` cleanly has to route with `--hv-threshold 0`, which no
+   documentation said and no run reported. Now reported; whether the *default*
+   should change is an owner call, not a Builder one.
+2. **Pour-vs-trace scope** (9 of 25). The router's gate audits trace copper; the
+   census measures pours too. Either the gate grows a pour-aware pass or T4 is
+   scored on a pour-free board. Not a Phase 2 deliverable (#3901).
+3. **`kct zones hv-keepout` margin** (the 25 → 35 regression above).
+4. **The 2 genuine gate leaks** — the only line item Phase 2's own machinery
+   owns, and the smallest one on the list.
+5. **32 nets still unrouted** — `PLACEMENT_BOUND` / `CONGESTION_SATURATED` /
+   `BUDGET_STARVED`, unchanged in character since 2026-07-21. Placement capacity,
+   not pairwise.
+
+## Verdict of the pre-fix run: **T4 FAILS** — but the machinery is measurably doing its job
+
+> Everything from here down is the original 2026-08-15 pre-fix measurement,
+> retained as the record of the diagnosis. Its counts are superseded by
+> [the re-score](#the-re-score-same-recipe-corrected-table) above.
 
 | Measure | T4 requires | matrix **on** | control: matrix **off** |
 |---|---|---|---|
@@ -376,21 +532,26 @@ placement capacity wall, and a definitional mismatch between two gates.
 
 ## #4507 criterion status after this run
 
+> Re-scored against the post-#4868 run. Rows 1-3 and T1-T3 are unchanged; the
+> "observed live" evidence in 2b / 3 and the T4 row carry the **re-score's**
+> numbers, with the pre-fix figures in parentheses.
+
 | # | Criterion | Status | Evidence |
 |---|---|---|---|
 | 1 | C++ `validate_route` + search-time check consume a domain-id array + domain-pair matrix | **MET** | `Grid3D::set_pairwise_domains` / `pairwise_required_clearance` (#4510 via #4524/#4533) |
 | 2 | Search-time avoidance: hard blocking + halo/pricing widening around HV copper | **MET** | C++ kernels + `pairwise_avoidance_cost` (#4511); Python-fallback mirrors (#4791); soft gradient (#4849); nearest-band pricing (#4859) |
-| 2b | Failed avoidance must be *actionable*, not silent | **MET** | `FAILURE_PAIRWISE_BLOCKED` + blocker net → `via_blocked_ripup` (#4860). **Observed live here**: 10 nets on the grid arm drained specifically on cross-domain refusals and named their blocker |
-| 3 | #4506 attach-zone exemption threaded into the C++ check | **MET** | `Grid3D::set_attach_zones` / `attach_zone_exempts(..., layer)`; layer scoping in #4780. **Confirmed live on a real board here**: 2 of 5 track-track shortfalls waived inside an optocoupler's pad bbox |
+| 2b | Failed avoidance must be *actionable*, not silent | **MET** | `FAILURE_PAIRWISE_BLOCKED` + blocker net → `via_blocked_ripup` (#4860). **Observed live here**: 8 (pre-fix 10) nets on the grid arm drained specifically on cross-domain refusals and named their blocker — by *id* in this run, by *name* after the follow-up increment |
+| 3 | #4506 attach-zone exemption threaded into the C++ check | **MET** | `Grid3D::set_attach_zones` / `attach_zone_exempts(..., layer)`; layer scoping in #4780. **Confirmed live on a real board here**: 6 of 8 (pre-fix 2 of 5) track-track shortfalls waived inside an optocoupler's pad bbox |
 | T1 | Parity: C++ and Python validators agree | **MET** | `tests/router/test_pairwise_cpp_parity.py` |
 | T2 | Two-domain fixture converges | **MET** | `test_two_domain_board_converges_with_search_time_avoidance` |
 | T3 | Backward compat: no `--voltage-map` → unchanged routes | **MET** | `test_no_voltage_map_route_leaves_grid_dormant` + this run's control arm (dormant, no banner, 7/7 in 32 s) |
-| **T4** | **softstart rev-C: route completes, 0 board-level census fails** | **FAILS (must be re-scored)** | **49/82 nets; 42 board-level fails; 3 router-gate leaks — root-caused to the signed/magnitude collapse above. That collapse is fixed (#4867), which restores 99 missing pairs and corrects 240 more; the routing arms have not been re-run, so these three numbers are pre-fix and no longer describe the tool** |
+| **T4** | **softstart rev-C: route completes, 0 board-level census fails** | **FAILS — re-scored, and no longer blocked on a correctness defect** | **50/82 nets (was 49); 25 board-level fails after step 2 (was 57), 35 after step 3 (was 42); 2 router-gate leaks (was 3); 1922 cross-pairs (was 1823). The sign collapse is fixed and did *not* grow the leak set. What remains: 9 pour-scope + 5 sub-`--hv-threshold` + 12 pad/placement fails and 32 unrouted nets — none of them a Phase 2 search defect** |
 
 ## Reproducing
 
-Everything is deterministic given the fixture and this repo at `2d5fc9b2` with
-the C++ backend at build 21. The three analysis helpers used above are:
+Everything is deterministic given the fixture and this repo at `090086b4`
+(pre-fix run: `2d5fc9b2`) with the C++ backend at build 21. The four analysis
+helpers used above are:
 
 * softstart's own `hardware/kicad/classify_creepage_fails.py` (census → track↔track
   vs pad-involved), used unmodified;
@@ -398,7 +559,15 @@ the C++ backend at build 21. The three analysis helpers used above are:
 * a throwaway replay of `segment_pair_violation` over the finished board with and
   without `build_attach_zones(...)` — 60 lines, reproduced from the snippet in
   [Attributing the 26](#attributing-the-26-which-are-the-routers-fault); it
-  imports only public router API.
+  imports only public router API. **Frame note for anyone re-running it:** read
+  the segments *and* the attach zones from the same board file and do **not**
+  apply the `pcb.board_origin` shift that `_pairwise_attach_zones` uses — that
+  shift exists because the CLI audit's `Route` objects live in the router's
+  internal frame, and applying it to file-frame copper silently moves every zone
+  off the board (the exemption then waives nothing, and the replay over-reports
+  8 leaks instead of 2);
+* a `subthreshold_coverage_gap(...)` call over the same `vmap.json` for the
+  `--hv-threshold` numbers — public API as of the increment that reported them.
 
 No board artifacts are committed to this repo: routed boards are `DO_NOT_FAB`
 work-in-progress and live in scratch, per the fixture repo's own policy.

--- a/src/kicad_tools/cli/route_cmd.py
+++ b/src/kicad_tools/cli/route_cmd.py
@@ -4381,6 +4381,56 @@ def _apply_pairwise_clearance(router: "Autorouter", args, quiet: bool = False) -
             f"  HV pairwise clearance: {len(voltages)} mapped nets, "
             f"{len(required)} cross-pairs ({enforcement})"
         )
+        _warn_subthreshold_coverage_gap(args, voltages, float(rules.trace_clearance))
+
+
+def _warn_subthreshold_coverage_gap(args, voltages, dru: float) -> None:
+    """Name the pairs ``--hv-threshold`` drops but ``kct creepage`` will score (#4507).
+
+    The banner above counts the pairs the router *will* enforce.  It said
+    nothing about the ones it will not: every mapped pair whose ``|Delta V|``
+    sits below ``--hv-threshold`` (30 V by default) keeps only the scalar DRU
+    floor, while the census looks the standard up at the pair's actual
+    ``|Delta V|`` -- and IEC 60664-1's low-voltage rows (0.40-0.53 mm at PD2 /
+    IIIa) are *above* a 0.2 mm fab floor.
+
+    On softstart rev-C that is **405 pairs** the router does not widen and the
+    census does score, which is why the #4507 T4 criterion ("0 board-level
+    creepage census fails") is unreachable at default settings regardless of
+    how good the search is.  Keeping that silent is the same failure mode
+    #4588 / #4699 / #4867 each closed in turn: a reassuring banner over an
+    under-constrained matrix.  Advisory only -- nothing is gated here.
+    """
+    from kicad_tools.cli.progress import flush_print
+    from kicad_tools.router.pairwise_clearance import subthreshold_coverage_gap
+
+    hv_threshold = float(getattr(args, "hv_threshold", 30.0))
+    gap = subthreshold_coverage_gap(
+        voltages,
+        dru=dru,
+        standard_id=getattr(args, "creepage_standard", "iec60664"),
+        pollution_degree=getattr(args, "pollution_degree", 2),
+        material_group=getattr(args, "material_group", "IIIa"),
+        hv_threshold=hv_threshold,
+    )
+    if gap.pair_count == 0:
+        return
+    worst = ""
+    if gap.worst_pair is not None:
+        worst = (
+            f" (worst: {gap.worst_pair[0]}<->{gap.worst_pair[1]} at "
+            f"{gap.worst_delta_v:g}V -> {gap.max_required_mm:.3f}mm)"
+        )
+    flush_print(
+        f"    NOTE: {gap.pair_count} further pair(s) sit below the "
+        f"{hv_threshold:g}V --hv-threshold yet still require more than the "
+        f"{dru:.3f}mm DRU floor{worst}."
+    )
+    flush_print(
+        "    The router enforces only the DRU floor for those; 'kct creepage' "
+        "scores them against the standard.  Pass --hv-threshold 0 to widen "
+        "every mapped pair."
+    )
 
 
 def _pairwise_attach_zones(router: "Autorouter") -> "tuple[AttachZone, ...]":
@@ -11995,7 +12045,12 @@ def _main_impl(argv: list[str] | None = None) -> int:
             "Minimum net-pair |ΔV| (volts) that triggers a creepage widening "
             "for --voltage-map pairwise clearance; lower-difference pairs keep "
             "the scalar DRU floor to avoid over-segregating low-voltage nets "
-            "(default: 30.0). Mirrors optimize-placement / kct creepage."
+            "(default: 30.0). Mirrors optimize-placement. NOTE (#4507): "
+            "'kct creepage' has NO such threshold -- it scores every pair at "
+            "its actual |ΔV|, and IEC 60664-1's low-voltage rows (0.40-0.53mm "
+            "at PD2/IIIa) exceed a typical 0.2mm fab floor, so sub-threshold "
+            "pairs the router leaves at the DRU floor can still fail the "
+            "census.  The run reports how many; pass 0 to widen every pair."
         ),
     )
     parser.add_argument(

--- a/src/kicad_tools/router/cpp_backend.py
+++ b/src/kicad_tools/router/cpp_backend.py
@@ -1256,6 +1256,8 @@ class CppPathfinder:
         # Schema: {
         #   "failure_reason": int,           # FAILURE_* constant
         #   "blocking_via_net": int,         # 0 if not via-blocked
+        #   "blocking_net_name": str | None, # #4507: the id resolved through
+        #                                    # set_net_name_to_id, or None
         #   "failure_x": float,              # world-coord (mm)
         #   "failure_y": float,
         # } or ``None`` if no diagnostic was captured.
@@ -1272,6 +1274,10 @@ class CppPathfinder:
         # returns ``None`` and the C++ search uses the wider inter-pair
         # ``clearance`` for every other net (the pre-Phase-1C contract).
         self._net_name_to_id: dict[str, int] = {}
+        # Issue #4507: memoised inverse of the map above, built on demand by
+        # :meth:`_resolve_net_id` so a blocker-naming failure can report the
+        # board's net NAME rather than a raw id.  ``None`` = not built yet.
+        self._net_id_to_name_cache: dict[int, str] | None = None
         self._attach_zones = ()
 
         # Issue #4510 / Epic #4431 Phase 2a: lazily-built C++ payload for the
@@ -1484,6 +1490,9 @@ class CppPathfinder:
         ``clearance`` for every other net).
         """
         self._net_name_to_id = dict(mapping)
+        # Issue #4507: the id -> name inverse used by the blocker diagnostics
+        # is derived from this map -- drop it so the next lookup rebuilds.
+        self._net_id_to_name_cache = None
         # Issue #4510: the C++ domain matrix / attach zones are keyed by net
         # ID, translated through this map -- rebuild them on the next validate.
         self._pairwise_cpp_payload = None
@@ -2324,13 +2333,40 @@ class CppPathfinder:
         # see how close the search came to the memory cap.
         iterations = int(getattr(self._impl, "iterations", 0))
 
+        blocking_net = int(getattr(result, "blocking_via_net", 0))
         self._last_failure_info = {
             "failure_reason": int(reason),
-            "blocking_via_net": int(getattr(result, "blocking_via_net", 0)),
+            "blocking_via_net": blocking_net,
+            # Issue #4507 (T4 re-score): the id alone is not actionable in a
+            # router log or a caller's report -- ten softstart rev-C nets
+            # drained on cross-domain refusals and named only "net id 51".
+            # ``None`` when the id is 0 or absent from the reverse map.
+            "blocking_net_name": self._resolve_net_id(blocking_net),
             "failure_x": float(getattr(result, "failure_x", 0.0)),
             "failure_y": float(getattr(result, "failure_y", 0.0)),
             "iterations": iterations,
         }
+
+    def _resolve_net_id(self, net_id: int) -> str | None:
+        """Return the board net name for *net_id*, or ``None`` (Issue #4507).
+
+        The C++ kernels speak net **ids**; every operator-facing surface
+        (router log lines, failure-info dicts) wants the board's own net
+        name.  :meth:`set_net_name_to_id` already carries the forward map,
+        so the inverse is derivable -- built lazily and memoised, because a
+        blocker-naming failure is rare relative to the search itself.
+
+        Returns ``None`` for id ``0`` (the "no blocker named" sentinel) and
+        for any id the map does not cover (an un-threaded map, or a net the
+        Autorouter never registered), so callers can fall back to the id.
+        """
+        if not net_id:
+            return None
+        cache = self._net_id_to_name_cache
+        if cache is None:
+            cache = {nid: name for name, nid in self._net_name_to_id.items()}
+            self._net_id_to_name_cache = cache
+        return cache.get(net_id)
 
     def _describe_cpp_failure(self, result: router_cpp.RouteResult) -> str:
         """Return a human-readable description of a failed C++ route result.
@@ -2370,7 +2406,14 @@ class CppPathfinder:
             )
             and blocking_net
         ):
-            desc += f" (blocking net id {blocking_net})"
+            # Issue #4507: name the blocker when the reverse net map is
+            # threaded (it is on every ``Autorouter`` path).  "blocking net
+            # id 51" is not actionable on a real board -- the operator has to
+            # go look the id up before they can rip anything up.  The bare id
+            # remains the fallback for an un-threaded map so the diagnostic
+            # never gets *less* informative than it was.
+            name = self._resolve_net_id(blocking_net)
+            desc += f" (blocking net {name})" if name else f" (blocking net id {blocking_net})"
         return desc
 
     def get_last_failure_info(self) -> dict | None:
@@ -2383,9 +2426,12 @@ class CppPathfinder:
 
         Returns:
             Dict with keys ``failure_reason``, ``blocking_via_net``,
-            ``failure_x``, ``failure_y`` -- or ``None`` if no diagnostic
-            is available.  ``failure_reason`` matches the ``FAILURE_*``
-            constants in the ``router_cpp`` module (see ``types.hpp``).
+            ``blocking_net_name``, ``failure_x``, ``failure_y`` -- or
+            ``None`` if no diagnostic is available.  ``failure_reason``
+            matches the ``FAILURE_*`` constants in the ``router_cpp``
+            module (see ``types.hpp``).  ``blocking_net_name`` (#4507) is
+            the board net name for ``blocking_via_net``, or ``None`` when
+            no blocker was named / the reverse map does not cover the id.
         """
         return self._last_failure_info
 

--- a/src/kicad_tools/router/pairwise_clearance.py
+++ b/src/kicad_tools/router/pairwise_clearance.py
@@ -410,6 +410,98 @@ def build_pairwise_clearance_table(
     )
 
 
+class SubthresholdCoverage(NamedTuple):
+    """Pairs the ``--hv-threshold`` drops that the census still requires (#4507).
+
+    ``build_pairwise_clearance_table`` omits every pair whose ``|Delta V|`` is
+    below ``hv_threshold`` (default 30 V), so the router enforces only the
+    scalar DRU floor for them.  The creepage census (``kct creepage``) has no
+    such threshold: it looks the standard up at whatever ``|Delta V|`` the pair
+    actually has, and IEC 60664-1's low-voltage rows are **above** a typical
+    0.2 mm fab floor (0.40-0.53 mm for PD2 / material group IIIa).
+
+    Every such pair is therefore a requirement the router will not enforce and
+    the census will score -- structurally unreachable "0 board-level fails" on
+    any board with low-voltage pairs, no matter how good the search is.  This
+    is a *policy* gap, not a defect (the threshold exists so LV<->LV pairs are
+    not over-segregated), but it must be visible rather than silent.
+
+    Attributes:
+        pair_count: Number of sub-threshold pairs whose requirement exceeds the
+            DRU floor.  ``0`` when the threshold hides nothing.
+        max_required_mm: Largest such requirement (mm); ``0.0`` when none.
+        worst_pair: The ``(net_a, net_b)`` carrying :attr:`max_required_mm`
+            (``/``-stripped, sorted), or ``None`` when none.
+        worst_delta_v: That pair's ``|Delta V|`` in volts; ``0.0`` when none.
+    """
+
+    pair_count: int
+    max_required_mm: float
+    worst_pair: tuple[str, str] | None
+    worst_delta_v: float
+
+
+def subthreshold_coverage_gap(
+    net_voltages: Mapping[str, float],
+    *,
+    dru: float,
+    standard_id: str = "iec60664",
+    pollution_degree: int = 2,
+    material_group: str = "IIIa",
+    hv_threshold: float = 30.0,
+) -> SubthresholdCoverage:
+    """Measure what ``hv_threshold`` hides from the pairwise matrix (#4507).
+
+    Mirrors :func:`build_pairwise_clearance_table`'s inputs exactly -- same
+    signed differencing (#4867), same standard lookup -- but reports the pairs
+    that fall on the *other* side of the threshold and would still carry a
+    requirement above ``dru``.  See :class:`SubthresholdCoverage`.
+
+    Same-potential pairs (``|Delta V| == 0``) are excluded: the census gives
+    them a 0 mm requirement, so they are not a coverage gap.
+
+    The standard lookup is memoised per distinct ``|Delta V|``, so a large
+    voltage map costs O(N^2) float comparisons but only a handful of table
+    lookups.  An out-of-table ``|Delta V|`` is *swallowed* here (the pair is
+    skipped) rather than raised: this is a diagnostic, and the fail-loud
+    contract belongs to :func:`build_pairwise_clearance_table`, which sees the
+    same voltages.
+    """
+    from kicad_tools.creepage.standards import StandardLookupError, get_standard
+
+    std = get_standard(standard_id)
+    normalised = {_norm_net_key(name): float(v) for name, v in net_voltages.items()}
+    ids = sorted(normalised)
+    lookup_cache: dict[float, float | None] = {}
+
+    count = 0
+    worst_required = 0.0
+    worst_pair: tuple[str, str] | None = None
+    worst_dv = 0.0
+    for i in range(len(ids)):
+        for j in range(i + 1, len(ids)):
+            a, b = ids[i], ids[j]
+            dv = abs(normalised[a] - normalised[b])
+            if dv <= 0.0 or dv >= hv_threshold:
+                continue
+            if dv not in lookup_cache:
+                try:
+                    lookup_cache[dv] = std.required_creepage(dv, pollution_degree, material_group)[
+                        0
+                    ]
+                except StandardLookupError:
+                    lookup_cache[dv] = None
+            required = lookup_cache[dv]
+            if required is None or required <= dru:
+                continue
+            count += 1
+            if required > worst_required:
+                worst_required = required
+                worst_pair = (a, b)
+                worst_dv = dv
+    return SubthresholdCoverage(count, worst_required, worst_pair, worst_dv)
+
+
 class CppDomainMatrix(NamedTuple):
     """C++-consumable form of a :class:`PairwiseClearanceTable` (Issue #4510).
 

--- a/tests/router/test_pairwise_ripup_diagnostics_4507.py
+++ b/tests/router/test_pairwise_ripup_diagnostics_4507.py
@@ -336,6 +336,9 @@ def test_backend_surfaces_the_diagnostic_to_the_negotiated_strategy() -> None:
     assert info is not None
     assert info["failure_reason"] == int(router_cpp.FAILURE_PAIRWISE_BLOCKED)
     assert info["blocking_via_net"] == 2
+    # The structured diagnostic carries the blocker's board net NAME too, so a
+    # caller reporting the failure does not have to invert the id map itself.
+    assert info["blocking_net_name"] == "LV"
 
     # And the human-readable form names the blocker for the router log.
     class _Result:
@@ -344,7 +347,85 @@ def test_backend_surfaces_the_diagnostic_to_the_negotiated_strategy() -> None:
 
     desc = pf._describe_cpp_failure(_Result())
     assert "pairwise" in desc
-    assert "blocking net id 2" in desc
+    assert "blocking net LV" in desc
+
+
+def _bare_pathfinder() -> CppPathfinder:
+    """A minimal ``CppPathfinder`` for describe-only diagnostics assertions."""
+    rules = DesignRules(
+        trace_width=TRACE_WIDTH,
+        trace_clearance=DRU,
+        via_diameter=0.6,
+        via_clearance=DRU,
+        grid_resolution=RESOLUTION,
+    )
+    grid = RoutingGrid(width=4.0, height=4.0, rules=rules, layer_stack=LayerStack.two_layer())
+    return CppPathfinder(CppGrid.from_routing_grid(grid), rules)
+
+
+@requires_cpp
+def test_blocker_diagnostic_names_the_net_not_its_id() -> None:
+    """The blocker is reported by NAME once the reverse map is threaded (#4507).
+
+    The T4 softstart rev-C proof run observed ten nets drain the C++ open set
+    on cross-domain refusals and report only ``blocking net id 51`` -- a
+    number the operator has to look up before they can act on it.  Both
+    blocker-naming reasons (the #2476 stored-via one and the #4507 pairwise
+    one) resolve the id through ``set_net_name_to_id``.
+    """
+    from kicad_tools.router import router_cpp
+
+    pf = _bare_pathfinder()
+    pf.set_net_name_to_id(dict(NET_NAMES))
+
+    class _Pairwise:
+        failure_reason = int(router_cpp.FAILURE_PAIRWISE_BLOCKED)
+        blocking_via_net = LV_NET
+
+    class _ViaVia:
+        failure_reason = int(router_cpp.FAILURE_VIA_VIA_BLOCKED)
+        blocking_via_net = LV_NET
+
+    for result in (_Pairwise(), _ViaVia()):
+        desc = pf._describe_cpp_failure(result)
+        assert "(blocking net /GND)" in desc
+        assert "net id" not in desc
+
+
+@requires_cpp
+def test_blocker_diagnostic_falls_back_to_the_id_when_unresolvable() -> None:
+    """An un-threaded (or incomplete) map keeps the pre-#4507 bare-id wording."""
+    from kicad_tools.router import router_cpp
+
+    class _Result:
+        failure_reason = int(router_cpp.FAILURE_PAIRWISE_BLOCKED)
+        blocking_via_net = 51
+
+    # No reverse map at all -- e.g. a bare pathfinder outside the Autorouter.
+    assert "(blocking net id 51)" in _bare_pathfinder()._describe_cpp_failure(_Result())
+
+    # Map present but silent about this id (a net the Autorouter never
+    # registered): still the id, never a misleading name.
+    pf = _bare_pathfinder()
+    pf.set_net_name_to_id(dict(NET_NAMES))
+    assert "(blocking net id 51)" in pf._describe_cpp_failure(_Result())
+
+
+@requires_cpp
+def test_blocker_name_cache_follows_a_remapped_net_table() -> None:
+    """Re-threading the map invalidates the memoised id -> name inverse."""
+    from kicad_tools.router import router_cpp
+
+    class _Result:
+        failure_reason = int(router_cpp.FAILURE_PAIRWISE_BLOCKED)
+        blocking_via_net = LV_NET
+
+    pf = _bare_pathfinder()
+    pf.set_net_name_to_id(dict(NET_NAMES))
+    assert "(blocking net /GND)" in pf._describe_cpp_failure(_Result())
+
+    pf.set_net_name_to_id({"/AC_LINE": HV_NET, "/PGND": LV_NET})
+    assert "(blocking net /PGND)" in pf._describe_cpp_failure(_Result())
 
 
 def test_negotiated_records_the_pairwise_blocker_for_ripup() -> None:

--- a/tests/test_route_subthreshold_coverage_4507.py
+++ b/tests/test_route_subthreshold_coverage_4507.py
@@ -1,0 +1,233 @@
+"""``--hv-threshold`` coverage gap is reported, not silent (issue #4507).
+
+The #4507 T4 criterion asks softstart rev-C to route with **0 board-level
+``kct creepage`` fails**.  Re-scoring T4 on top of the #4867 signed-potential
+fix surfaced a second, independent reason that target is unreachable at
+default settings -- and this one is not a search problem at all:
+
+``build_pairwise_clearance_table`` drops every pair whose ``|ΔV|`` is below
+``--hv-threshold`` (30 V by default), leaving it at the scalar DRU floor.  The
+census has no threshold: it looks IEC 60664-1 up at the pair's actual ``|ΔV|``,
+and the standard's low-voltage rows (0.40-0.53 mm at PD2 / material group IIIa)
+are *above* a typical 0.2 mm fab floor.  On softstart rev-C that is 405 pairs
+the router will not widen and the census will score.
+
+The threshold itself is deliberate policy (it stops LV<->LV pairs being
+over-segregated), so this suite does not change the default.  It pins that the
+run *says so*, that the ``--hv-threshold 0`` escape hatch the message
+advertises actually enforces those pairs end to end, and that a map with
+nothing hidden stays quiet.
+
+Board fixture is a synthetic S-expression string, deliberately mirroring
+``test_route_signed_voltage_map_4867.py``: the softstart rev-C board is
+local-only and must never become a CI dependency.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from kicad_tools.cli.route_cmd import main as route_main
+from kicad_tools.router.pairwise_clearance import subthreshold_coverage_gap
+
+# A +/-10 V map is a real 20 V span -- below the 30 V threshold, so the router
+# holds it at the DRU floor, while IEC 60664-1 PD2/IIIa requires 0.48 mm at
+# 20 V.  The fixture's copper is 0.4 mm apart: inside the fab floor, outside
+# the standard.  That is the whole gap in one pair.
+SPAN_VOLTS = 10.0
+REQUIRED_AT_20V = 0.48
+
+
+def _pad(number: str, x: float, y: float, net: int, net_name: str) -> str:
+    return (
+        f'(pad "{number}" smd rect (at {x} {y}) (size 0.4 0.4) '
+        f'(layers "F.Cu" "F.Paste" "F.Mask") (net {net} "{net_name}"))'
+    )
+
+
+def _fp(ref: str, uid: int, x: float, y: float, pads: str) -> str:
+    return f"""  (footprint "Resistor_SMD:R_0603_1608Metric"
+    (layer "F.Cu")
+    (uuid "00000000-0000-0000-0000-0000000000{uid:02d}")
+    (at {x} {y})
+    (property "Reference" "{ref}" (at 0 -1.5 0) (layer "F.SilkS"))
+    (property "Value" "10k" (at 0 1.5 0) (layer "F.Fab"))
+    {pads}
+  )
+"""
+
+
+def _preserved_board() -> str:
+    """Preserved ``/BANK_POS`` / ``/BANK_NEG`` copper 0.4 mm edge-to-edge."""
+    parts = [
+        _fp("R1", 10, 103.0, 120.0, _pad("1", 0, 0, 3, "/SIG_A")),
+        _fp("R2", 11, 127.0, 120.0, _pad("1", 0, 0, 3, "/SIG_A")),
+    ]
+    return f"""(kicad_pcb
+  (version 20240108)
+  (generator "test")
+  (generator_version "8.0")
+  (general
+    (thickness 1.6)
+  )
+  (layers
+    (0 "F.Cu" signal)
+    (31 "B.Cu" signal)
+    (44 "Edge.Cuts" user)
+  )
+  (setup
+    (pad_to_mask_clearance 0)
+  )
+  (net 0 "")
+  (net 1 "/BANK_POS")
+  (net 2 "/BANK_NEG")
+  (net 3 "/SIG_A")
+  (gr_rect (start 100 100) (end 130 124)
+    (stroke (width 0.1) (type default))
+    (fill none)
+    (layer "Edge.Cuts")
+  )
+  (segment (start 105 105) (end 125 105) (width 0.2) (layer "F.Cu") (net 1))
+  (segment (start 105 105.6) (end 125 105.6) (width 0.2) (layer "F.Cu") (net 2))
+{"".join(parts)})
+"""
+
+
+def _write_map(tmp_path: Path, payload: dict, name: str = "vmap.json") -> Path:
+    vmap = tmp_path / name
+    vmap.write_text(json.dumps(payload))
+    return vmap
+
+
+def _route_args(pcb: Path, out: Path, vmap: Path | None, *extra: str) -> list[str]:
+    args = [
+        str(pcb),
+        "-o",
+        str(out),
+        "--route-engine",
+        "lattice",
+        "--strategy",
+        "basic",
+        "--skip-drc",
+        "--preserve-existing",
+    ]
+    if vmap is not None:
+        args += [
+            "--voltage-map",
+            str(vmap),
+            "--creepage-standard",
+            "iec60664",
+            "--pollution-degree",
+            "2",
+            "--material-group",
+            "IIIa",
+        ]
+    return args + list(extra)
+
+
+@pytest.fixture
+def board(tmp_path: Path) -> Path:
+    pcb = tmp_path / "subthreshold.kicad_pcb"
+    pcb.write_text(_preserved_board())
+    return pcb
+
+
+# ---------------------------------------------------------------------------
+# The measurement helper
+# ---------------------------------------------------------------------------
+
+
+def test_gap_counts_only_pairs_the_threshold_hides() -> None:
+    """A 20 V span needs 0.48 mm but sits below the 30 V threshold."""
+    gap = subthreshold_coverage_gap({"/BANK_POS": SPAN_VOLTS, "/BANK_NEG": -SPAN_VOLTS}, dru=0.2)
+    assert gap.pair_count == 1
+    assert gap.max_required_mm == pytest.approx(REQUIRED_AT_20V)
+    assert gap.worst_pair == ("BANK_NEG", "BANK_POS")
+    assert gap.worst_delta_v == pytest.approx(2 * SPAN_VOLTS)
+
+
+def test_gap_excludes_pairs_the_matrix_already_holds() -> None:
+    """Above the threshold the pair is enforced, so it is not a *gap*."""
+    gap = subthreshold_coverage_gap({"/HV": 150.0, "/GND": 0.0}, dru=0.2)
+    assert gap == (0, 0.0, None, 0.0)
+
+
+def test_gap_excludes_same_potential_pairs() -> None:
+    """The census requires 0 mm of a same-potential pair; so does the router."""
+    gap = subthreshold_coverage_gap({"/A": 12.0, "/B": 12.0}, dru=0.2)
+    assert gap.pair_count == 0
+
+
+def test_gap_respects_the_dru_floor() -> None:
+    """A fab floor wider than the standard's low-voltage row hides nothing."""
+    assert subthreshold_coverage_gap({"/A": 10.0, "/B": -10.0}, dru=0.6).pair_count == 0
+
+
+def test_gap_is_empty_when_the_threshold_is_disarmed() -> None:
+    """``--hv-threshold 0`` leaves nothing on the wrong side of the threshold."""
+    gap = subthreshold_coverage_gap(
+        {"/BANK_POS": SPAN_VOLTS, "/BANK_NEG": -SPAN_VOLTS}, dru=0.2, hv_threshold=0.0
+    )
+    assert gap.pair_count == 0
+
+
+# ---------------------------------------------------------------------------
+# The CLI surface
+# ---------------------------------------------------------------------------
+
+
+def test_run_reports_the_hidden_pairs(board: Path, tmp_path: Path, capsys) -> None:
+    """The banner's ``0 cross-pairs`` no longer stands alone and reassuring."""
+    vmap = _write_map(tmp_path, {"/BANK_POS": SPAN_VOLTS, "/BANK_NEG": -SPAN_VOLTS})
+
+    rc = route_main(_route_args(board, tmp_path / "note.kicad_pcb", vmap))
+    captured = capsys.readouterr().out
+
+    assert rc == 0, captured
+    assert "HV pairwise clearance: 2 mapped nets, 0 cross-pairs" in captured
+    assert "1 further pair(s) sit below the 30V --hv-threshold" in captured
+    assert "BANK_NEG<->BANK_POS at 20V -> 0.480mm" in captured
+    assert "--hv-threshold 0" in captured
+
+
+def test_disarming_the_threshold_enforces_the_hidden_pair(
+    board: Path, tmp_path: Path, capsys
+) -> None:
+    """The advertised escape hatch must actually work end to end.
+
+    With the threshold at 0 the 20 V pair enters the matrix, the note has
+    nothing left to report, and the 0.4 mm copper now fails the #4588 audit at
+    the standard's 0.48 mm -- i.e. the router and the census finally agree.
+    """
+    vmap = _write_map(tmp_path, {"/BANK_POS": SPAN_VOLTS, "/BANK_NEG": -SPAN_VOLTS})
+
+    rc = route_main(_route_args(board, tmp_path / "armed.kicad_pcb", vmap, "--hv-threshold", "0"))
+    captured = capsys.readouterr().out
+
+    assert "HV pairwise clearance: 2 mapped nets, 1 cross-pairs" in captured
+    assert "sit below the" not in captured
+    assert rc != 0, captured
+    assert "pairwise HV clearance violations" in captured
+
+
+def test_no_note_when_the_threshold_hides_nothing(board: Path, tmp_path: Path, capsys) -> None:
+    """A map whose only pair is already enforced prints no advisory."""
+    vmap = _write_map(tmp_path, {"/BANK_POS": 150.0, "/BANK_NEG": 0.0})
+
+    route_main(_route_args(board, tmp_path / "quiet.kicad_pcb", vmap))
+    captured = capsys.readouterr().out
+
+    assert "HV pairwise clearance: 2 mapped nets, 1 cross-pairs" in captured
+    assert "sit below the" not in captured
+
+
+def test_dormant_without_a_voltage_map(board: Path, tmp_path: Path, capsys) -> None:
+    """No ``--voltage-map`` -> no banner and no advisory (byte-identical path)."""
+    route_main(_route_args(board, tmp_path / "dormant.kicad_pcb", None))
+    captured = capsys.readouterr().out
+
+    assert "HV pairwise clearance:" not in captured
+    assert "sit below the" not in captured


### PR DESCRIPTION
## Summary

Seventh **partial increment** of #4507 (router Phase 2 of epic #4431). It does the
one thing the previous increment left undone: **re-runs T4** — the last open
acceptance criterion — on top of #4868's signed-potential fix, and ships the two
code changes the re-scored data identified as the actual next gaps.

PR #4866 ran T4 against the *pre-fix* table, root-caused its residual to the
`abs()` collapse of signed potentials, and left `docs/hv-pairwise-softstart-proof.md`
carrying a **"must be re-scored"** banner: the routing arms were never re-run after
the fix, and #4867's own acceptance criteria predicted the leak set would **grow**
(99 pairs re-enter the matrix). That prediction is now tested.

**It is refuted — every column improved.** Same fixture at `7800b046`, same four
inputs at the same md5s, same three commands, on `main` @ `090086b4` with the C++
backend at build 21:

| Measure | T4 requires | **post-fix (this run)** | pre-fix (#4866) | control: matrix off |
|---|---|---|---|---|
| Signal nets routed | 100 % | **50 / 82 (61 %)** | 49 / 82 | 50 / 82 |
| Cross-pairs in the matrix | = census | **1922** | 1823 | dormant |
| Board-level census fails, after step 2 | **0** | **25** | 57 | 107 |
| Board-level census fails, after step 3 (HV keepouts) | **0** | **35** | 42 | — |
| Router's own gate, finished board (same-layer track↔track, #4506 honoured) | 0 | **2** | 3 | 54 |
| Router's inline post-route audit | 0 | **1** | 5 | (dormant) |

T4 **still fails** (25, not 0) — hence `Part of`, not `Closes` — but it is no
longer blocked on a correctness defect. Nine of the 25 are plane-pour proximity
the trace-only gate cannot see, five are sub-`--hv-threshold` pairs (below), and
one net pair is the router's own remaining leak.

## Changes

**1. `feat(router)`: name the blocking net in C++ search-failure diagnostics.**
The grid arm drained 8 nets on `FAILURE_PAIRWISE_BLOCKED` and named its blocker
as `blocking net id 33` — a number the operator must look up before they can rip
anything up. `CppPathfinder` already holds the forward name→id map; the
diagnostic now inverts it (lazily, memoised, invalidated on re-threading) and
`get_last_failure_info()` carries a resolved `blocking_net_name`. An un-threaded
or incomplete map still prints the bare id, so the diagnostic never gets *less*
informative. Applies to the older `FAILURE_VIA_VIA_BLOCKED` phrasing too, which
shares the wording. **Confirmed on the real board**: the same refusal that
printed `blocking net id 33` now prints `blocking net /LED_A_NEG`.

**2. `feat(router)`: report the pairs `--hv-threshold` hides.** New finding, and
the one that reframes T4. `build_pairwise_clearance_table()` drops every pair
whose `|ΔV|` is below `--hv-threshold` (30 V default), leaving it at the scalar
DRU floor. `kct creepage` has **no** threshold — it scores each pair at its
actual `|ΔV|`, and IEC 60664-1's low-voltage rows (0.40–0.53 mm at PD2/IIIa) are
*above* a 0.2 mm fab floor. On softstart rev-C that is **811 mapped-net pairs,
405 of which the census actually scores**, and **5 of the 25 residual
board-level fails** are in that class (after step 1 alone it was 10 of 36). No
search can close them: the requirement never reaches the search.

The threshold is deliberate policy (LV↔LV pairs must not be over-segregated), so
**the default is unchanged and nothing new is gated**. What changes is that the
run says so — `subthreshold_coverage_gap()` measures the hidden pairs with the
same signed differencing and standard lookup the matrix uses (memoised per
distinct `|ΔV|`), and the banner follows up with the count, the worst pair, and
the `--hv-threshold 0` escape hatch. `--hv-threshold`'s own help no longer claims
to mirror `kct creepage`. This is the same failure mode #4588 / #4699 / #4867
each closed in turn: a reassuring banner over an under-constrained matrix.

**3. `docs(router)`: the re-scored proof.** `docs/hv-pairwise-softstart-proof.md`
gains a current-record re-score section (verdict table, residual breakdown, grid
arm, "what T4 needs now"); the pre-fix run is retained verbatim below it as the
record of the diagnosis, and the stale banner is gone.

## Acceptance Criteria Verification

| # | Criterion | Status | Evidence |
|---|---|---|---|
| 1 | C++ `validate_route` + search-time check consume a domain-id array + domain-pair matrix | MET (earlier) | #4510 via #4524/#4533 |
| 2 | Search-time avoidance: hard blocking + halo/pricing widening | MET (earlier) | #4511, #4791, #4849, #4859 |
| 2b | Failed avoidance must be *actionable*, not silent | **MET — completed here** | #4860 named the blocker by id; this PR names it by **net name**, verified live on softstart rev-C |
| 3 | #4506 attach-zone exemption threaded into the C++ check | MET (earlier); **re-confirmed live** | 6 of 8 track↔track shortfalls waived inside two optocouplers' pad bboxes |
| T1 | Parity: C++ and Python validators agree | MET | `tests/router/test_pairwise_cpp_parity.py` |
| T2 | Two-domain fixture converges | MET | `test_two_domain_board_converges_with_search_time_avoidance` |
| T3 | Backward compat: no `--voltage-map` → unchanged routes | MET | `test_dormant_without_a_voltage_map` (new) + prior dormancy suites |
| **T4** | **softstart rev-C: 0 board-level census fails** | **STILL FAILS (25)** | Re-scored above. Not a Phase 2 search defect any more — see "What remains" |

### What remains on T4 (why this is `Part of`, not `Closes`)

1. **`--hv-threshold` policy** (5 of 25) — a board that must pass `kct creepage`
   cleanly has to route with `--hv-threshold 0`. Now *reported*; whether the
   **default** should change is an owner call, not a Builder one.
2. **Pour-vs-trace scope** (9 of 25) — the router's gate audits trace copper, the
   census measures pours too (#3901 territory).
3. **2 genuine gate leaks** (`/I_SENSE_OUT`↔`/SCAP_NEG`, 0.600 mm against
   1.400 mm on B.Cu) — the only line item Phase 2's own machinery owns.
4. **32 unrouted nets** — `PLACEMENT_BOUND` / `CONGESTION_SATURATED` /
   `BUDGET_STARVED`, unchanged in character since 2026-07-21.

## Follow-up findings (recorded here, not filed, per the sweep's no-new-issues rule)

* **`kct zones hv-keepout` now makes this board worse: 25 → 35.** Pre-fix the
  pass retired 15 fails (57 → 42); post-fix it *adds* 15 and retires 5. All 15
  are the same defect — `--clearance 1.6` carves a void whose refilled pour edge
  lands at **1.5931–1.5942 mm**, 6–7 µm short of the clearance it was asked for,
  so pairs that were passing fail by 0.4 % of their requirement. Carving at
  exactly the required clearance leaves no margin for the void polygon's
  discretisation. `src/kicad_tools/zones/hv_keepout.py`; out of scope for a
  Phase 2 PR, numbers to reproduce are in the doc. **Until it is addressed, the
  best board this recipe produces is step 2, and step 3 should be run with a
  clearance margin or not at all.**
* **Attach-zone frame trap for anyone re-running the gate replay**: do NOT apply
  the `pcb.board_origin` shift `_pairwise_attach_zones` uses when your copper
  comes straight out of a board file. That shift exists because the CLI audit's
  `Route` objects live in the router's internal frame; applied to file-frame
  copper it moves every zone off the board, the #4506 exemption then waives
  nothing, and the replay over-reports 8 leaks instead of 2. Documented in the
  proof doc's "Reproducing" section.

## Test Plan

* `tests/test_route_subthreshold_coverage_4507.py` — **new**, 9 tests: the
  measurement helper (threshold boundary, same-potential exclusion, DRU floor,
  disarmed threshold) and the CLI surface (advisory fires with the count/worst
  pair; `--hv-threshold 0` silences it *and* makes the #4588 audit fail the same
  copper the census fails; a fully-covered map stays quiet; no `--voltage-map`
  prints nothing). Synthetic board string — softstart is never a CI dependency.
* `tests/router/test_pairwise_ripup_diagnostics_4507.py` — 3 new tests (name
  resolution for both blocker reasons, bare-id fallback for an un-threaded or
  incomplete map, cache invalidation on re-threading) + the existing
  end-to-end assertion updated to the named form. `17 passed`.
* Regression sweeps: `tests/router/ -k "pairwise or cpp_backend or diagnos"` →
  `277 passed, 1 skipped`; repo-wide `-k "pairwise or voltage_map or hv_"` →
  `447 passed, 1 skipped`; `test_router_cpp_fallback_warning_3456.py`,
  `test_cpp_resume_exhaustion_skip_3923.py`,
  `test_router_cpp_via_blocked_failure.py` → `54 passed`;
  `test_route_pairwise_gate_4588.py` + `test_route_signed_voltage_map_4867.py`
  → green.
* `ruff check src/ tests/` clean; `ruff format --check` clean on all touched
  files; `scripts/ci/check_mypy_baseline.py` → *"1464 error(s), all within the
  baseline (1472 allowed). No new type errors."*
* Manual (local-only, not CI): the full three-arm softstart rev-C re-score
  documented in `docs/hv-pairwise-softstart-proof.md`, plus a `--timeout 420`
  grid replay on the patched tree that confirms the named blocker on real
  geometry.

Part of #4507
