### PR TITLE
fix(router): read footprint refs from (property "Reference") in load_pads_for_analysis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1066,6 +1066,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`load_pads_for_analysis` returned anonymous pads on every KiCad 7+ board,
+  silently disabling fine-pitch escape planning** (#4872) — the grid-analysis
+  pad loader (`router/io.py`) read the footprint reference only from the legacy
+  `(fp_text reference U1 …)` spelling. KiCad 7 and later write it exclusively as
+  `(property "Reference" "U1" …)`, so on any modern board — including this
+  repo's own pcbnew-resaved fixtures — every returned pad carried `ref=""`.
+  Positions and sizes were correct, so nothing crashed and nothing warned; the
+  pads were simply anonymous. That is the worst failure shape for the consumers
+  that group by reference: `identify_fine_pitch_components` skips ref-less pads
+  outright, so `compute_multi_resolution_plan` found **zero** fine-pitch
+  components and adaptive/multi-resolution **fine-pitch escape routing never
+  fired** on a modern-format board, degrading to plain coarse-grid routing with
+  no diagnostic. Both routing engines reach this loader through their primary
+  construction entry points (`LatticePathfinder.from_board`,
+  `MeshPathfinder.from_board`). The reference is now read with the same
+  two-step precedence `load_pcb_for_routing` has always used elsewhere in the
+  same file — `property "Reference"` first, `fp_text reference` as the legacy
+  fallback — so a transitional file carrying both resolves to the property
+  value. Measured on the committed
+  `boards/02-charlieplex-led/output/charlieplex_3x3_routed.kicad_pcb`: 34 pads
+  collapsed into a single `""` bucket before, now 14 distinct references
+  matching `kicad_tools.schema.PCB` exactly. Legacy `fp_text` boards (quoted and
+  unquoted) are unaffected — a one-branch parse fix, no geometry or transform
+  behaviour touched.
+
 - **`route --voltage-map` collapsed signed net potentials with `abs()`, so
   +150 V vs −150 V differenced to 0 V** (#4867, blocker for #4507, epic #4431
   Phase 2) — the router normalised its voltage map to *magnitudes* before

--- a/src/kicad_tools/router/io.py
+++ b/src/kicad_tools/router/io.py
@@ -2122,8 +2122,13 @@ def load_pads_for_analysis(pcb_path_or_text: str | Path) -> list[Pad]:
         footprint_name_match = re.search(r'\(footprint\s+"([^"]*)"', section)
         footprint_name = footprint_name_match.group(1) if footprint_name_match else ""
 
-        # Get footprint reference
-        ref_match = re.search(r'\(fp_text\s+reference\s+"?([^"\s)]+)"?', section)
+        # Get footprint reference. KiCad 7+ writes it as
+        # (property "Reference" "U1" ...); the (fp_text reference U1 ...)
+        # spelling is legacy (pre-KiCad-7). Try the modern property form
+        # first, then fall back -- same precedence load_pcb_for_routing uses.
+        ref_match = re.search(r'\(property\s+"Reference"\s+"([^"]+)"', section)
+        if not ref_match:
+            ref_match = re.search(r'\(fp_text\s+reference\s+"?([^"\s)]+)"?', section)
         ref = ref_match.group(1) if ref_match else ""
 
         # Get footprint position and rotation

--- a/tests/router/test_load_pads_modern_format_4872.py
+++ b/tests/router/test_load_pads_modern_format_4872.py
@@ -1,0 +1,245 @@
+"""Regression tests for footprint references on modern-format boards (#4872).
+
+``load_pads_for_analysis`` used to read the footprint reference only from the
+legacy ``(fp_text reference U1 ...)`` spelling.  KiCad 7+ writes the reference
+as ``(property "Reference" "U1" ...)``, so on any modern board every pad came
+back with ``ref=""`` — the pads were positionally correct but anonymous, and
+every per-component consumer (``identify_fine_pitch_components`` and therefore
+multi-resolution / adaptive-grid escape planning) silently no-opped.
+
+These tests pin both spellings, their precedence, and the downstream
+per-component bucketing.
+"""
+
+from pathlib import Path
+
+import pytest
+
+from kicad_tools.router.adaptive_grid import identify_fine_pitch_components
+from kicad_tools.router.io import load_pads_for_analysis
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+MODERN_BOARD = (
+    REPO_ROOT / "boards" / "02-charlieplex-led" / "output" / "charlieplex_3x3_routed.kicad_pcb"
+)
+
+
+def _modern_pcb_text() -> str:
+    """Two footprints in the KiCad 7+ ``(property "Reference" ...)`` spelling.
+
+    ``U1`` is a 0.5 mm-pitch (fine-pitch) 4-pad part; ``R1`` is a 2 mm-pitch
+    0805 that must NOT be classified fine-pitch.  Structure mirrors a real
+    pcbnew-resaved file: the footprint ``(at ...)`` precedes the properties,
+    and each property carries its own nested ``(at ...)``.
+    """
+    return """(kicad_pcb
+	(version 20241229)
+	(generator "pcbnew")
+	(footprint "Package_SO:TSSOP-4"
+		(layer "F.Cu")
+		(uuid "aaaaaaaa-0000-0000-0000-000000000001")
+		(at 100 100)
+		(property "Reference" "U1"
+			(at 0 -2 0)
+			(layer "F.SilkS")
+			(effects (font (size 1 1) (thickness 0.15)))
+		)
+		(property "Value" "TSSOP-4"
+			(at 0 2 0)
+			(layer "F.Fab")
+			(effects (font (size 1 1) (thickness 0.15)))
+		)
+		(pad "1" smd rect
+			(at -0.75 0)
+			(size 0.3 1.0)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(net 1 "NET_A")
+		)
+		(pad "2" smd rect
+			(at -0.25 0)
+			(size 0.3 1.0)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(net 2 "NET_B")
+		)
+		(pad "3" smd rect
+			(at 0.25 0)
+			(size 0.3 1.0)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(net 3 "NET_C")
+		)
+		(pad "4" smd rect
+			(at 0.75 0)
+			(size 0.3 1.0)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(net 4 "NET_D")
+		)
+	)
+	(footprint "Resistor_SMD:R_0805_2012Metric"
+		(layer "F.Cu")
+		(uuid "aaaaaaaa-0000-0000-0000-000000000002")
+		(at 110 100)
+		(property "Reference" "R1"
+			(at 0 -1.5 0)
+			(layer "F.SilkS")
+			(effects (font (size 1 1) (thickness 0.15)))
+		)
+		(property "Value" "330R"
+			(at 0 1.5 0)
+			(layer "F.Fab")
+			(effects (font (size 1 1) (thickness 0.15)))
+		)
+		(pad "1" smd roundrect
+			(at -1 0)
+			(size 1 1.3)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(net 4 "NET_D")
+		)
+		(pad "2" smd roundrect
+			(at 1 0)
+			(size 1 1.3)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(net 5 "NET_E")
+		)
+	)
+)"""
+
+
+def _legacy_pcb_text() -> str:
+    """The same two parts in the pre-KiCad-7 ``(fp_text reference ...)`` spelling."""
+    return """(kicad_pcb (version 20221018)
+	(footprint "Package_SO:TSSOP-4" (at 100 100)
+		(fp_text reference "U1" (at 0 -2))
+		(fp_text value "TSSOP-4" (at 0 2))
+		(pad "1" smd rect (at -0.75 0) (size 0.3 1.0) (layers "F.Cu") (net 1 "NET_A"))
+		(pad "2" smd rect (at -0.25 0) (size 0.3 1.0) (layers "F.Cu") (net 2 "NET_B"))
+		(pad "3" smd rect (at 0.25 0) (size 0.3 1.0) (layers "F.Cu") (net 3 "NET_C"))
+		(pad "4" smd rect (at 0.75 0) (size 0.3 1.0) (layers "F.Cu") (net 4 "NET_D"))
+	)
+	(footprint "Resistor_SMD:R_0805_2012Metric" (at 110 100)
+		(fp_text reference "R1" (at 0 -1.5))
+		(pad "1" smd roundrect (at -1 0) (size 1 1.3) (layers "F.Cu") (net 4 "NET_D"))
+		(pad "2" smd roundrect (at 1 0) (size 1 1.3) (layers "F.Cu") (net 5 "NET_E"))
+	)
+)"""
+
+
+class TestModernReferenceSpelling:
+    """``(property "Reference" ...)`` must yield real refs, not empty strings."""
+
+    def test_modern_property_reference_is_parsed(self):
+        pads = load_pads_for_analysis(_modern_pcb_text())
+
+        assert len(pads) == 6
+        assert sorted({p.ref for p in pads}) == ["R1", "U1"]
+        assert all(p.ref for p in pads), "no pad may carry an empty ref"
+
+    def test_modern_refs_map_to_the_right_pads(self):
+        pads = load_pads_for_analysis(_modern_pcb_text())
+        by_ref: dict[str, list] = {}
+        for pad in pads:
+            by_ref.setdefault(pad.ref, []).append(pad)
+
+        assert sorted(p.pin for p in by_ref["U1"]) == ["1", "2", "3", "4"]
+        assert sorted(p.pin for p in by_ref["R1"]) == ["1", "2"]
+        # U1 sits at (100, 100); R1 at (110, 100) — refs are not shuffled.
+        assert all(99.0 < p.x < 101.0 for p in by_ref["U1"])
+        assert all(108.0 < p.x < 112.0 for p in by_ref["R1"])
+
+    def test_legacy_fp_text_reference_still_parsed(self):
+        """The legacy spelling must keep working unchanged."""
+        pads = load_pads_for_analysis(_legacy_pcb_text())
+
+        assert len(pads) == 6
+        assert sorted({p.ref for p in pads}) == ["R1", "U1"]
+
+    def test_unquoted_legacy_fp_text_reference_still_parsed(self):
+        """KiCad 5-era files wrote the reference unquoted."""
+        text = (
+            "(kicad_pcb (version 20171130)\n"
+            '  (module "Package_SO:TSSOP-4" (at 100 100)\n'
+            "    (fp_text reference U1 (at 0 -2))\n"
+            '    (pad "1" smd rect (at 0 0) (size 0.3 1.0) (layers "F.Cu") (net 1 "NET_A"))\n'
+            "  )\n"
+            ")"
+        )
+        # Rewritten as (footprint ...) — this loader only splits on (footprint.
+        pads = load_pads_for_analysis(text.replace("(module ", "(footprint "))
+
+        assert len(pads) == 1
+        assert pads[0].ref == "U1"
+
+    def test_property_takes_precedence_over_fp_text(self):
+        """A transitional file may carry both; the property spelling wins.
+
+        Matches ``load_pcb_for_routing``'s existing precedence order.
+        """
+        text = """(kicad_pcb (version 20241229)
+	(footprint "Package_SO:TSSOP-4"
+		(layer "F.Cu")
+		(at 100 100)
+		(property "Reference" "U7"
+			(at 0 -2 0)
+			(layer "F.SilkS")
+		)
+		(fp_text reference "U1" (at 0 -2) (layer "F.SilkS"))
+		(pad "1" smd rect (at 0 0) (size 0.3 1.0) (layers "F.Cu") (net 1 "NET_A"))
+	)
+)"""
+        pads = load_pads_for_analysis(text)
+
+        assert len(pads) == 1
+        assert pads[0].ref == "U7"
+
+
+class TestFinePitchBucketingOnModernBoards:
+    """The concrete downstream consumer that silently no-opped before #4872."""
+
+    def test_fine_pitch_components_keyed_by_real_ref(self):
+        pads = load_pads_for_analysis(_modern_pcb_text())
+
+        fine = identify_fine_pitch_components(pads, coarse_resolution=0.2)
+
+        # U1's 0.5mm pitch trips the 0.8mm default threshold; R1's 2mm does not.
+        assert "U1" in fine, "fine-pitch escape never fires when refs are empty"
+        assert "R1" not in fine
+        assert "" not in fine
+        assert fine["U1"] > 0.0
+
+    def test_fine_pitch_bucketing_matches_legacy_spelling(self):
+        """Modern and legacy spellings of the same board classify identically."""
+        modern = identify_fine_pitch_components(
+            load_pads_for_analysis(_modern_pcb_text()), coarse_resolution=0.2
+        )
+        legacy = identify_fine_pitch_components(
+            load_pads_for_analysis(_legacy_pcb_text()), coarse_resolution=0.2
+        )
+
+        assert modern == legacy
+
+
+class TestCommittedModernBoardFixture:
+    """Ground truth from a real pcbnew-resaved board committed to this repo."""
+
+    def test_charlieplex_routed_board_yields_real_refs(self):
+        if not MODERN_BOARD.exists():  # pragma: no cover - fixture is committed
+            pytest.skip(f"fixture not present: {MODERN_BOARD}")
+
+        pads = load_pads_for_analysis(MODERN_BOARD)
+        refs = {p.ref for p in pads}
+
+        # 14 footprints / 34 pads, cross-checked against kicad_tools.schema.PCB.
+        assert len(pads) == 34
+        assert len(refs) == 14
+        assert "" not in refs
+
+    def test_charlieplex_refs_agree_with_schema_loader(self):
+        if not MODERN_BOARD.exists():  # pragma: no cover - fixture is committed
+            pytest.skip(f"fixture not present: {MODERN_BOARD}")
+
+        from kicad_tools.schema import PCB
+
+        pcb = PCB.load(MODERN_BOARD)
+        schema_refs = {fp.reference for fp in pcb.footprints}
+        io_refs = {p.ref for p in load_pads_for_analysis(MODERN_BOARD)}
+
+        assert io_refs == schema_refs


### PR DESCRIPTION
## Summary

`load_pads_for_analysis` (`src/kicad_tools/router/io.py`) extracted the footprint
reference with a single regex against the **legacy** `(fp_text reference U1 …)`
spelling. KiCad 7+ writes the reference exclusively as
`(property "Reference" "U1" …)`, so on any modern-format board every returned
`Pad` carried `ref=""`.

Nothing crashed and nothing warned — positions, sizes and nets were all correct,
the pads were just anonymous. That is the worst failure shape for the consumers
that group by reference: `identify_fine_pitch_components` skips ref-less pads
outright, so `compute_multi_resolution_plan` found **zero** fine-pitch
components and **adaptive/multi-resolution fine-pitch escape routing never fired**
on a modern board, silently degrading to plain coarse-grid routing. Both routing
engines reach this loader through their primary construction entry points
(`LatticePathfinder.from_board`, `MeshPathfinder.from_board`).

Fix shape (a) from the issue: replicate the two-step fallback that
`load_pcb_for_routing` already uses **in this same file** (io.py:3655-3661) —
`property "Reference"` first, `fp_text reference` as the legacy fallback. No
migration to `schema.PCB`, so the hand-verified #3739 / #3902 geometry-transform
logic in this loader is untouched.

## Changes

- `src/kicad_tools/router/io.py` — `load_pads_for_analysis` now tries
  `(property "Reference" "X")` before falling back to
  `(fp_text reference X)` (quoted or unquoted). +7/-2 lines, parse-only.
- `tests/router/test_load_pads_modern_format_4872.py` (new, 9 tests) — modern
  spelling, legacy spelling (quoted + unquoted), mixed-format precedence,
  fine-pitch bucketing by real ref, and the committed real-board fixture
  cross-checked against `schema.PCB`.
- `CHANGELOG.md` — Unreleased / Fixed entry.

Out of scope by design: `schema/pcb.py` (owned by the concurrent #4873/#4874
work), and the issue's "value regex" suggestion — `load_pads_for_analysis`
never extracts a value field and `Pad` has none.

## Acceptance Criteria Verification

- [x] **Matches `(property "Reference" "X" …)` with `load_pcb_for_routing`'s
  precedence** — property first, `fp_text` fallback; verified by
  `test_property_takes_precedence_over_fp_text` (a footprint carrying both
  `property "Reference" "U7"` and `fp_text reference "U1"` resolves to `U7`).
- [x] **Modern-format regression fixture asserts real footprint/pad counts** —
  both an inline fixture (6 pads / refs `{U1, R1}`) and the committed
  `boards/02-charlieplex-led/output/charlieplex_3x3_routed.kicad_pcb`:
  **34 pads across 14 distinct non-empty refs** (was 34 pads in one `""`
  bucket), and `test_charlieplex_refs_agree_with_schema_loader` asserts the ref
  set equals `kicad_tools.schema.PCB`'s footprint set exactly.
- [x] **No regression on legacy `fp_text` boards** — `tests/router/` (1426
  passed), `tests/test_footprint_rotation.py`, `tests/test_adaptive_grid.py`,
  `tests/test_route_max_cells_flag.py`, `tests/test_route_grid_safety_gate.py`,
  `tests/test_drc_location_absolute.py` all pass **unmodified**; the new suite
  additionally pins the quoted and unquoted legacy spellings directly.
- [x] **`identify_fine_pitch_components()` buckets by real ref on a
  modern-format board** — `test_fine_pitch_components_keyed_by_real_ref`:
  `"U1" in fine` (0.5 mm pitch), `"R1" not in fine` (2 mm), `"" not in fine`.
  `test_fine_pitch_bucketing_matches_legacy_spelling` asserts the modern and
  legacy spellings of the same board classify **identically**.
- [x] **`mypy` / `ruff` clean on the touched files** — `ruff check` and
  `ruff format --check` pass; mypy baseline check: `all within the baseline
  (1464 of 1472 allowed), no new type errors`.

## Test Plan

- **Vacuity-checked**: with the one-hunk `io.py` fix reverted, **7 of the 9 new
  tests fail** (the 2 that pass are the legacy-spelling ones, exactly as
  intended). Restored, 9/9 pass.
- **Manual reproduction from the issue** (after the fix):
  ```
  io.py:  34 pads 14 refs ['D1'…'D9', 'R1'…'R4', 'U1']
  schema: 14 footprints 34 pads ['D1'…'D9', 'R1'…'R4', 'U1']
  ```
  (before: `34 1`, single `""` bucket)
- `uv run pytest tests/router/` → **1426 passed, 5 skipped** (9m10s, C++ backend
  built and active, build version 21).
- `uv run pytest tests/test_footprint_rotation.py tests/test_adaptive_grid.py
  tests/test_route_max_cells_flag.py tests/test_route_grid_safety_gate.py
  tests/test_drc_location_absolute.py` → **133 passed**.

Closes #4872

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014jM7psrLav9YQ8fqzzsa23