### PR TITLE
fix(route): derive clearance from an imported board's own declared net_class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1091,6 +1091,41 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   unquoted) are unaffected — a one-branch parse fix, no geometry or transform
   behaviour touched.
 
+- **Imported boards were gated against our default manufacturer profile
+  instead of their own declared rules** (#4875) — `kct route` fed the #3911
+  grid-safety gate an `args.clearance` that was *always* either an explicit
+  `--clearance` or the flat 0.15 mm default: `--manufacturer` never touched
+  it, and a board's own design rules were not parsed anywhere. An externally
+  authored board that declares 0.254 mm clearance was therefore refused for
+  failing a 0.075 mm grid requirement it never claimed — the tool substituted
+  its house rules for the board's, which also biases any route-vs-human
+  benchmark (found during the #4830 corpus pilots, PR #4869). Three changes:
+  `schema/pcb.py` now parses the **legacy top-level `(net_class …)` blocks**
+  pre-KiCad-6 boards carry (siblings of `(setup …)`, so `_parse_setup` never
+  saw them) and exposes them as `PCB.net_classes`; `router/mfr_limits.py`
+  gains `resolve_clearance(manufacturer)` alongside #4568's
+  `resolve_edge_clearance` and #4700's `resolve_min_trace_width`; and
+  `route_cmd` resolves the clearance **before** the auto-grid block (rather
+  than beside the #4568/#4700 auto-fills, which run after grid selection and
+  would be too late for the gate) with the precedence *explicit `--clearance`
+  > explicit `--manufacturer` > board-declared `net_class` clearance >
+  0.15 mm*, printing one `rules: …` provenance banner naming the source. Two
+  decisions were resolved conservatively: only an **actually explicit**
+  `--manufacturer` counts as an operator override (a default `jlcpcb` does
+  not, so no existing invocation changes clearance), and a declared clearance
+  **below the active profile's `min_clearance`** is raised to that floor with
+  a stderr warning naming the `--clearance` opt-out, rather than routing
+  copper no configured fab can etch. Derivation is gated on the board
+  actually carrying a `net_class` block — a token this repo's writer never
+  emits — so the demo-board fleet is structurally unaffected
+  (`tests/test_grid_safety_gate_fleet.py` now enforces that directly). Only
+  pre-KiCad-6 boards benefit: KiCad 6+ keeps net classes in the companion
+  `.kicad_pro`, so a modern single-file import still falls back to the
+  profile exactly as before. Also fixes the outer `kct route` argv
+  forwarding, which dropped a deliberate `--clearance 0.15` /
+  `--manufacturer jlcpcb` because it forwarded flags only when their value
+  differed from the default.
+
 - **`route --voltage-map` collapsed signed net potentials with `abs()`, so
   +150 V vs −150 V differenced to 0 V** (#4867, blocker for #4507, epic #4431
   Phase 2) — the router normalised its voltage map to *magnitudes* before

--- a/src/kicad_tools/cli/commands/routing.py
+++ b/src/kicad_tools/cli/commands/routing.py
@@ -503,7 +503,17 @@ def run_route_auto_command(args) -> int:
 
 def run_route_command(args) -> int:
     """Handle route command."""
+    from ..route_cmd import _flag_passed_explicitly
     from ..route_cmd import main as route_main
+
+    # Issue #4875: the inner command now derives its clearance from a board's
+    # own declared ``(net_class …)`` rules when nothing explicit outranks
+    # them, so "the operator typed the default value" and "the operator typed
+    # nothing" are no longer equivalent.  The value-comparison forwarding
+    # below would drop a deliberate ``--clearance 0.15`` / ``--manufacturer
+    # jlcpcb``, silently handing the decision back to the board.
+    _explicit_clearance = _flag_passed_explicitly(None, ("--clearance",))
+    _explicit_manufacturer = _flag_passed_explicitly(None, ("--manufacturer", "--mfr"))
 
     sub_argv = [args.pcb]
     if args.output:
@@ -558,7 +568,7 @@ def run_route_command(args) -> int:
     # auto-fill.  Flag-off argv stays byte-identical.
     if getattr(args, "trace_width", None) is not None:
         sub_argv.extend(["--trace-width", str(args.trace_width)])
-    if args.clearance != 0.15:
+    if args.clearance != 0.15 or _explicit_clearance:
         sub_argv.extend(["--clearance", str(args.clearance)])
     if args.via_drill != 0.3:
         sub_argv.extend(["--via-drill", str(args.via_drill)])
@@ -708,7 +718,7 @@ def run_route_command(args) -> int:
         sub_argv.extend(["--min-trace", str(args.min_trace)])
     if getattr(args, "min_clearance_floor", None) is not None:
         sub_argv.extend(["--min-clearance-floor", str(args.min_clearance_floor)])
-    if getattr(args, "manufacturer", "jlcpcb") != "jlcpcb":
+    if getattr(args, "manufacturer", "jlcpcb") != "jlcpcb" or _explicit_manufacturer:
         sub_argv.extend(["--manufacturer", args.manufacturer])
     # Issue #4700: the copper weight selects the manufacturer design-rule row
     # (``<layers>layer_<oz>oz``) the trace-width floor is resolved from, so it

--- a/src/kicad_tools/cli/route_cmd.py
+++ b/src/kicad_tools/cli/route_cmd.py
@@ -5054,6 +5054,224 @@ def _mfr_rule_key(layers: int | None, copper_oz: float | None) -> str:
     return f"{layer_text} {copper_text}"
 
 
+# ---------------------------------------------------------------------------
+# Issue #4875: board-declared clearance derivation for imported boards
+# ---------------------------------------------------------------------------
+
+#: ``kct route``'s historical flat ``--clearance`` default in mm.  Kept as the
+#: argparse default (rather than a ``None`` sentinel) because ``args.clearance``
+#: is read as a plain float at dozens of sites; explicit-vs-default is detected
+#: from argv instead (see :func:`_flag_passed_explicitly`).
+DEFAULT_ROUTE_CLEARANCE_MM = 0.15
+
+_CLEARANCE_EPS = 1e-9
+
+
+def _flag_passed_explicitly(argv: list[str] | None, options: tuple[str, ...]) -> bool:
+    """Return True when the invocation explicitly carried one of ``options``.
+
+    Issue #4875.  ``--clearance`` (``default=0.15``) and ``--manufacturer``
+    (``default="jlcpcb"``) both have *value* defaults, so -- unlike #4700's
+    ``--trace-width`` sentinel -- ``args`` alone cannot tell "the operator
+    asked for jlcpcb" from "nobody passed anything".  This mirrors the
+    existing ``"--no-auto-layers" in _argv_for_q5`` argv-sniff, extended to
+    handle the ``--flag=value`` spelling and argparse's unambiguous
+    long-option abbreviations.
+
+    Chosen over converting both flags to ``None`` sentinels deliberately: the
+    sentinel refactor would make ``args.manufacturer`` optional at 15+ call
+    sites that all assume ``str`` today, a blast radius far larger than the
+    behavior this issue changes.
+    """
+    tokens = list(argv) if argv is not None else list(sys.argv[1:])
+    for token in tokens:
+        if not token.startswith("--"):
+            continue
+        head = token.split("=", 1)[0]
+        if any(option == head or option.startswith(head) for option in options):
+            return True
+    return False
+
+
+def _board_declared_net_classes(pcb_path) -> dict:
+    """Parse the board's legacy top-level ``(net_class …)`` blocks, if any.
+
+    Issue #4875.  Returns ``{}`` -- cheaply, without parsing the board -- for
+    the overwhelmingly common case of a file that carries no ``net_class``
+    token at all (every KiCad 6+ board, and every board this repo's own
+    writer produces).  That text pre-check is what makes the derivation path
+    a structural no-op for the demo-board fleet.
+
+    Never raises: an unreadable or malformed board yields ``{}`` and the
+    caller falls back to today's behavior.
+    """
+    try:
+        text = Path(pcb_path).read_text(errors="replace")
+    except OSError:
+        return {}
+    if "(net_class" not in text:
+        return {}
+    try:
+        from kicad_tools.schema import PCB
+
+        return dict(PCB.load(Path(pcb_path)).net_classes)
+    except Exception:
+        # Rule derivation is an enhancement, never a new failure mode: a
+        # board this parser chokes on still routes at today's default.
+        return {}
+
+
+def _board_base_clearance(net_classes: dict) -> tuple[str, float] | None:
+    """Pick the board's base clearance from its declared net classes.
+
+    KiCad's board-wide class is ``Default``, so it wins when present.  On a
+    board that declares only named classes, the strictest (smallest)
+    declared clearance is used as the base -- ``args.clearance`` is the
+    router's global spacing floor, and a base looser than a declared class
+    would route that class wider than the board asked for.
+
+    Returns ``(class_name, clearance_mm)`` or ``None`` when no class
+    declares a positive clearance.
+    """
+    candidates: list[tuple[str, float]] = []
+    for name, net_class in net_classes.items():
+        value = getattr(net_class, "clearance", None)
+        if value is None:
+            continue
+        try:
+            value = float(value)
+        except (TypeError, ValueError):
+            continue
+        if value > 0:
+            candidates.append((str(name), value))
+    if not candidates:
+        return None
+    for name, value in candidates:
+        if name == "Default":
+            return (name, value)
+    return min(candidates, key=lambda item: (item[1], item[0]))
+
+
+def _decide_route_clearance(
+    *,
+    clearance: float,
+    explicit_clearance: bool,
+    manufacturer: str | None,
+    explicit_manufacturer: bool,
+    board_clearance: tuple[str, float] | None,
+) -> tuple[float, str, str | None, str | None]:
+    """Pure precedence core for :func:`_resolve_route_clearance` (issue #4875).
+
+    Precedence, matching the ``resolve_edge_clearance`` / ``resolve_min_trace_width``
+    shape established by #4568 / #4700::
+
+        explicit --clearance
+          > explicit --manufacturer (the operator's profile overrides the
+            board's own declared rules)
+          > board-declared legacy ``net_class`` clearance, raised to the
+            active profile's ``min_clearance`` floor when it undercuts it
+          > today's flat default (unchanged)
+
+    Returns ``(value, source, banner, warning)``.  ``banner`` is ``None``
+    only in the untouched no-board-rules case, where printing one would add
+    a line to every existing invocation while naming nothing new.
+    """
+    if explicit_clearance:
+        return (
+            clearance,
+            "flag",
+            f"Clearance: {clearance:.4g}mm (rules: explicit --clearance flag)",
+            None,
+        )
+
+    if board_clearance is None:
+        # No board-declared rules (every modern-format import, and the whole
+        # demo-board fleet): behavior is byte-identical to before #4875.
+        return (clearance, "default", None, None)
+
+    class_name, declared = board_clearance
+
+    if explicit_manufacturer:
+        return (
+            clearance,
+            "manufacturer",
+            f"Clearance: {clearance:.4g}mm (rules: manufacturer profile "
+            f"{manufacturer}) -- explicit --manufacturer overrides the board's "
+            f'declared net_class "{class_name}" clearance ({declared:.4g}mm)',
+            None,
+        )
+
+    from kicad_tools.router.mfr_limits import resolve_clearance
+
+    floor = resolve_clearance(manufacturer)
+    if floor is not None and declared < floor - _CLEARANCE_EPS:
+        warning = (
+            f'WARNING: the board declares net_class "{class_name}" clearance '
+            f"{declared:.4g}mm, which is below the {manufacturer} minimum "
+            f"clearance {floor:.4g}mm -- no configured fab tier can produce it. "
+            f"Routing at the {floor:.4g}mm floor instead; pass --clearance "
+            f"{declared:.4g} to route at the board's declared value anyway."
+        )
+        banner = (
+            f"Clearance: {floor:.4g}mm (rules: board net_class "
+            f'"{class_name}" {declared:.4g}mm, raised to the {manufacturer} '
+            f"floor {floor:.4g}mm)"
+        )
+        return (floor, "board-clamped", banner, warning)
+
+    return (
+        declared,
+        "board",
+        f'Clearance: {declared:.4g}mm (rules: board net_class "{class_name}")',
+        None,
+    )
+
+
+def _resolve_route_clearance(args, pcb_path, argv=None, *, quiet: bool = False) -> float:
+    """Resolve ``args.clearance`` from the board's own declared rules.
+
+    Issue #4875.  ``kct route`` used to feed the grid-safety gate (#3911) a
+    clearance that was *always* either an explicit ``--clearance`` or the
+    flat 0.15mm default -- ``--manufacturer`` never touched it, and the
+    board's own declared design rules were not parsed at all.  Externally
+    authored boards were therefore gated against house rules they never
+    claimed.
+
+    This runs **before** the auto-grid selection block, because that block
+    reads ``args.clearance`` for both the grid search and the #3911 gate; a
+    resolution placed next to the #4568/#4700 auto-fills further down would
+    be too late to affect either.
+
+    Prints the rule-source banner (stdout, suppressed by ``--quiet``) at
+    most once, and the looser-than-floor clamp warning (stderr, never
+    suppressed).  Also stashes the source on ``args._clearance_rule_source``.
+
+    Returns the resolved clearance in mm.
+    """
+    explicit_clearance = _flag_passed_explicitly(argv, ("--clearance",))
+    explicit_manufacturer = _flag_passed_explicitly(argv, ("--manufacturer", "--mfr"))
+
+    board_clearance = None
+    if not explicit_clearance:
+        board_clearance = _board_base_clearance(_board_declared_net_classes(pcb_path))
+
+    value, source, banner, warning = _decide_route_clearance(
+        clearance=float(getattr(args, "clearance", DEFAULT_ROUTE_CLEARANCE_MM)),
+        explicit_clearance=explicit_clearance,
+        manufacturer=getattr(args, "manufacturer", None),
+        explicit_manufacturer=explicit_manufacturer,
+        board_clearance=board_clearance,
+    )
+
+    args.clearance = value
+    args._clearance_rule_source = source
+    if warning is not None:
+        print(warning, file=sys.stderr)
+    if banner is not None and not quiet:
+        print(banner)
+    return value
+
+
 def _warn_layer_selection_advisories(args, layer_stack, *, is_auto: bool) -> None:
     """Emit Issue #4314 route-time layer-selection advisories to stderr.
 
@@ -11539,7 +11757,16 @@ def _main_impl(argv: list[str] | None = None) -> int:
         "--clearance",
         type=float,
         default=0.15,
-        help="Trace clearance in mm (default: 0.15)",
+        help=(
+            "Trace clearance in mm (default: 0.15). Precedence (issue #4875): "
+            "explicit --clearance > explicit --manufacturer > the board's own "
+            "declared legacy top-level (net_class (clearance ...)) rules > "
+            "0.15. Board-declared rules are only available on pre-KiCad-6 "
+            "boards that carry them in the .kicad_pcb itself; a modern import "
+            "keeps the 0.15 default exactly as before. A declared value below "
+            "the active manufacturer's minimum clearance is raised to that "
+            "floor with a stderr WARNING."
+        ),
     )
     parser.add_argument(
         "--fine-pitch-clearance",
@@ -13520,6 +13747,16 @@ def _main_impl(argv: list[str] | None = None) -> int:
         output_path = Path(args.output)
     else:
         output_path = pcb_path.with_stem(pcb_path.stem + "_routed")
+
+    # Issue #4875: resolve the effective trace clearance from the board's OWN
+    # declared design rules before anything reads it.  Ordering is
+    # load-bearing: the auto-grid selector below feeds ``args.clearance``
+    # straight into both the grid search and the #3911 memory-forced-unsafe
+    # gate, so an imported board that declares tighter-but-self-consistent
+    # rules must have them resolved HERE -- resolving alongside the #4568 /
+    # #4700 manufacturer auto-fills (further down, after grid selection) would
+    # be too late for either.
+    _resolve_route_clearance(args, pcb_path, argv, quiet=args.quiet)
 
     # Resolve grid value: "auto" or numeric
     # We need to resolve this early, before sub-functions are called

--- a/src/kicad_tools/router/mfr_limits.py
+++ b/src/kicad_tools/router/mfr_limits.py
@@ -532,6 +532,43 @@ def resolve_edge_clearance(manufacturer: str | None) -> float | None:
     return None
 
 
+def resolve_clearance(manufacturer: str | None) -> float | None:
+    """Resolve the trace-to-trace clearance floor for a manufacturer.
+
+    Shared resolution helper (Issue #4875), the clearance analogue of
+    :func:`resolve_edge_clearance`.  ``kct route`` uses it as the **floor**
+    a board-declared ``(net_class (clearance …))`` value is raised to, and
+    as the value an explicit ``--manufacturer`` resolves to when it
+    overrides board-declared rules.
+
+    Note this reads :attr:`MfrLimits.min_clearance` (the fab's absolute
+    copper-to-copper capability minimum), which is deliberately *not* the
+    same thing as the routing clearance a design should target -- ``kct
+    route``'s own default (0.15mm) is looser than every current profile's
+    ``min_clearance`` on purpose.  Callers must therefore treat the result
+    as a lower bound, never as a recommended value.
+
+    Args:
+        manufacturer: Manufacturer name (case-insensitive, aliases OK),
+            or ``None``/empty when no manufacturer is configured.
+
+    Returns:
+        The manufacturer's ``min_clearance`` in mm, or ``None`` when
+        ``manufacturer`` is falsy, unknown (no raise -- manufacturer
+        validation belongs to the CLI layer), or its clearance floor is
+        not positive.
+    """
+    if not manufacturer:
+        return None
+    try:
+        limits = get_mfr_limits(manufacturer)
+    except ValueError:
+        return None
+    if limits.min_clearance > 0:
+        return limits.min_clearance
+    return None
+
+
 def resolve_min_trace_width(
     manufacturer: str | None,
     layers: int | None = None,

--- a/src/kicad_tools/schema/__init__.py
+++ b/src/kicad_tools/schema/__init__.py
@@ -23,6 +23,7 @@ from .label import GlobalLabel, HierarchicalLabel, Label
 from .library import LibraryManager, LibraryPin, LibrarySymbol, SymbolLibrary
 from .pcb import (
     PCB,
+    BoardNetClass,
     Footprint,
     Layer,
     Net,
@@ -74,4 +75,5 @@ __all__ = [
     "Zone",
     "Setup",
     "StackupLayer",
+    "BoardNetClass",
 ]

--- a/src/kicad_tools/schema/pcb.py
+++ b/src/kicad_tools/schema/pcb.py
@@ -1682,6 +1682,62 @@ class Setup:
     tenting_back: bool | None = None
 
 
+@dataclass
+class BoardNetClass:
+    """A board-declared legacy top-level ``(net_class …)`` design-rule block.
+
+    Issue #4875.  Pre-KiCad-6 ``.kicad_pcb`` files (and the transitional
+    files written around the format change) carry their trace-clearance /
+    track-width / via-size design rules **in the board file itself**, as
+    top-level ``(net_class …)`` nodes that are siblings of ``(setup …)``::
+
+        (net_class Default "This is the default net class."
+          (clearance 0.2)
+          (trace_width 0.25)
+          (via_dia 0.8)
+          (via_drill 0.4)
+          (uvia_dia 0.3)
+          (uvia_drill 0.1)
+          (add_net GND)
+        )
+
+    KiCad 6+ moved net classes into the companion ``.kicad_pro`` project
+    file, so a modern board carries none of these -- which is exactly why
+    :attr:`PCB.net_classes` is empty for every board this repo's own writer
+    produces (it never emits ``net_class`` nodes).  Consumers therefore use
+    a non-empty :attr:`PCB.net_classes` as the positive signal "this is an
+    imported board that declares its own rules".
+
+    Every dimension is ``None`` when the corresponding token is absent, so
+    callers can distinguish "declared as 0" from "not declared".
+
+    Attributes:
+        name: Class name (``Default`` for the board-wide class).
+        description: Free-text description, ``""`` when absent.
+        clearance: Trace-to-trace clearance in mm.
+        trace_width: Default track width in mm.
+        via_dia: Through-via pad diameter in mm.
+        via_drill: Through-via drill diameter in mm.
+        uvia_dia: Micro-via pad diameter in mm.
+        uvia_drill: Micro-via drill diameter in mm.
+        diff_pair_width: Differential-pair track width in mm.
+        diff_pair_gap: Differential-pair gap in mm.
+        nets: Net names assigned to this class (``add_net`` entries).
+    """
+
+    name: str = ""
+    description: str = ""
+    clearance: float | None = None
+    trace_width: float | None = None
+    via_dia: float | None = None
+    via_drill: float | None = None
+    uvia_dia: float | None = None
+    uvia_drill: float | None = None
+    diff_pair_width: float | None = None
+    diff_pair_gap: float | None = None
+    nets: list[str] = field(default_factory=list)
+
+
 # Paper sizes in mm (width, height) - KiCad uses landscape orientation
 PAPER_SIZES: dict[str, tuple[float, float]] = {
     "A4": (297.0, 210.0),
@@ -1744,6 +1800,12 @@ class PCB:
         self._texts: list[GraphicText] = []
         self._graphics: list[BoardGraphic] = []
         self._setup: Setup | None = None
+        # Issue #4875: board-declared legacy top-level ``(net_class …)``
+        # design rules, keyed by class name.  A dict (not a list) so a
+        # re-``_parse()`` -- which appends rather than replaces -- overwrites
+        # instead of duplicating.  Empty for every KiCad 6+ board and for
+        # every board this repo's writer produces.
+        self._net_classes: dict[str, BoardNetClass] = {}
         self._title_block: dict[str, str] = {}
         self._board_origin: tuple[float, float] = (0.0, 0.0)
         # Issue #4416: board-level net-reference dialect signal.  Set by
@@ -2137,6 +2199,11 @@ class PCB:
                 graphic_type = tag[3:]  # Remove "gr_" prefix
                 graphic = BoardGraphic.from_sexp(child, graphic_type)
                 self._graphics.append(graphic)
+            elif tag == "net_class":
+                # Issue #4875: legacy (pre-KiCad-6) board-declared design
+                # rules.  These are top-level siblings of ``(setup …)``, NOT
+                # nested inside it, so ``_parse_setup`` never sees them.
+                self._parse_net_class(child)
 
         # Post-parse fixup: recover net_number from name for KiCad 10 name-only
         # format.  KiCad 10 may emit inline (net "name") without a numeric ID,
@@ -2394,6 +2461,45 @@ class PCB:
                     setup.tenting_back = value == "yes"
 
         self._setup = setup
+
+    def _parse_net_class(self, sexp: SExp) -> None:
+        """Parse one legacy top-level ``(net_class …)`` block (issue #4875).
+
+        The legacy grammar is ``(net_class <name> <description> (clearance
+        …) (trace_width …) …)`` -- name and description are positional
+        strings, every rule is a child node.  Unknown child tokens are
+        ignored; absent tokens leave their field ``None`` so a caller can
+        tell "not declared" from "declared as 0".
+        """
+        name = sexp.get_string(0) or ""
+        net_class = BoardNetClass(
+            name=name,
+            description=sexp.get_string(1) or "",
+        )
+
+        for token in (
+            "clearance",
+            "trace_width",
+            "via_dia",
+            "via_drill",
+            "uvia_dia",
+            "uvia_drill",
+            "diff_pair_width",
+            "diff_pair_gap",
+        ):
+            node = sexp.find(token)
+            if node is None:
+                continue
+            value = node.get_float(0)
+            if value is not None:
+                setattr(net_class, token, float(value))
+
+        for add_net in sexp.find_all("add_net"):
+            net_name = add_net.get_string(0)
+            if net_name is not None:
+                net_class.nets.append(net_name)
+
+        self._net_classes[net_class.name] = net_class
 
     def _parse_stackup(self, sexp: SExp) -> list[StackupLayer]:
         """Parse stackup definition."""
@@ -2918,6 +3024,7 @@ class PCB:
         self._texts = []
         self._graphics = []
         self._setup = None
+        self._net_classes = {}
         self._title_block = {}
         self._parse()
         self._board_origin = (0.0, 0.0)
@@ -3845,6 +3952,19 @@ class PCB:
     def setup(self) -> Setup | None:
         """Board setup/design rules."""
         return self._setup
+
+    @property
+    def net_classes(self) -> dict[str, BoardNetClass]:
+        """Board-declared legacy top-level ``(net_class …)`` blocks by name.
+
+        Issue #4875.  Empty (``{}``) for every KiCad 6+ board -- modern
+        files keep net classes in the companion ``.kicad_pro`` -- and for
+        every board this repo writes, so a non-empty mapping is the
+        positive "imported board with its own declared design rules"
+        signal that :mod:`kicad_tools.cli.route_cmd` gates rule derivation
+        on.
+        """
+        return self._net_classes
 
     # Statistics
 

--- a/tests/test_grid_safety_gate_fleet.py
+++ b/tests/test_grid_safety_gate_fleet.py
@@ -158,3 +158,87 @@ def test_fleet_memory_cap_warning_matches_gate(
         f"it is at risk; a False on board 05 drops a genuine warning. "
         f"Warnings seen: {warning_texts}"
     )
+
+
+# ---------------------------------------------------------------------------
+# Issue #4875: the fleet must be structurally immune to board-derived rules
+# ---------------------------------------------------------------------------
+#
+# #4875 lets ``kct route`` derive ``args.clearance`` from a board's own legacy
+# top-level ``(net_class …)`` block.  The gate assertions above are all keyed
+# to ``ROUTE_DEFAULT_CLEARANCE`` (0.15mm), so they only stay meaningful while
+# no fleet board can reach that derivation path.  It cannot: this repo's PCB
+# writer emits no ``net_class`` node at all, and the derivation is gated on
+# one being present.  These cases enforce both halves of that argument.
+
+#: The ``--manufacturer`` each recipe's ``kct route`` invocation actually
+#: passes, or ``None`` where it passes none (boards 00 and 06 route through
+#: the library API rather than the CLI).  Verified against the recipe
+#: sources.  An explicit manufacturer is #4875's operator override, so these
+#: invocations must resolve to the unchanged 0.15mm default too.
+FLEET_MANUFACTURER: dict[str, str | None] = {
+    "00-simple-led": None,
+    "01-voltage-divider": None,
+    "02-charlieplex-led": "jlcpcb",
+    "03-usb-joystick": "jlcpcb-tier1",
+    "04-stm32-devboard": "jlcpcb-tier1",
+    "05-bldc-motor-controller": "jlcpcb-tier1",
+    "06-diffpair-test": None,
+    "07-matchgroup-test": "jlcpcb",
+}
+
+
+@pytest.mark.parametrize("board_dir,stem,_expected", FLEET)
+def test_fleet_board_declares_no_legacy_net_class(board_dir: str, stem: str, _expected: bool):
+    """No fleet input carries the token that unlocks board-derived rules."""
+    from kicad_tools.cli.route_cmd import _board_declared_net_classes
+
+    pcb = _input_pcb(board_dir, stem)
+    if not pcb.exists():
+        pytest.skip(f"input PCB not committed: {pcb}")
+
+    assert "(net_class" not in pcb.read_text(errors="replace"), (
+        f"{board_dir} now carries a legacy net_class block; the 0.15mm "
+        "clearance every assertion in this file assumes no longer holds."
+    )
+    assert _board_declared_net_classes(pcb) == {}
+
+
+@pytest.mark.parametrize("board_dir,stem,_expected", FLEET)
+def test_fleet_clearance_is_unchanged_by_rule_derivation(
+    board_dir: str, stem: str, _expected: bool
+):
+    """``args.clearance`` still resolves to 0.15mm for every fleet recipe.
+
+    Run both with no flags and with the recipe's real ``--manufacturer``, so
+    neither #4875 branch (board-derived, or manufacturer-as-override) can
+    silently move a fleet board off the default the gate map is keyed to.
+    """
+    from types import SimpleNamespace
+
+    from kicad_tools.cli.route_cmd import _resolve_route_clearance
+
+    pcb = _input_pcb(board_dir, stem)
+    if not pcb.exists():
+        pytest.skip(f"input PCB not committed: {pcb}")
+
+    mfr = FLEET_MANUFACTURER[board_dir] or "jlcpcb"
+    invocations: list[list[str]] = [
+        [str(pcb)],
+        [str(pcb), "--manufacturer", mfr],
+    ]
+
+    for argv in invocations:
+        args = SimpleNamespace(
+            clearance=ROUTE_DEFAULT_CLEARANCE,
+            manufacturer=mfr,
+            quiet=True,
+        )
+        resolved = _resolve_route_clearance(args, pcb, argv, quiet=True)
+        assert resolved == ROUTE_DEFAULT_CLEARANCE, (
+            f"{board_dir} @ {argv}: clearance moved to {resolved}mm. "
+            "Every gate expectation in this file (and the committed routed "
+            "artifacts) assumes the flat 0.15mm route default."
+        )
+        assert args.clearance == ROUTE_DEFAULT_CLEARANCE
+        assert args._clearance_rule_source == "default"

--- a/tests/test_mfr_limits.py
+++ b/tests/test_mfr_limits.py
@@ -15,6 +15,7 @@ from kicad_tools.router.mfr_limits import (
     get_mfr_limits,
     get_mfr_size_tier_ladder,
     get_relaxation_tiers,
+    resolve_clearance,
     resolve_min_trace_width,
 )
 
@@ -741,3 +742,52 @@ class TestRelaxationLadderRespectsCheckSideFloor:
                     min_trace_floor=floor,
                 )
                 assert all(t.trace_width >= floor - 1e-9 for t in tiers), (name, copper)
+
+
+class TestResolveClearance:
+    """Issue #4875: the shared clearance-floor resolution helper.
+
+    ``resolve_clearance`` is the clearance analogue of #4568's
+    ``resolve_edge_clearance``: ``kct route`` uses it as the floor a
+    board-declared ``(net_class (clearance …))`` value is raised to, so a
+    legacy import can never be routed below what any configured fab can
+    actually etch.
+    """
+
+    def test_resolves_each_known_manufacturer(self):
+        """Every configured profile resolves to its own min_clearance."""
+        for name, limits in MFR_LIMITS.items():
+            assert resolve_clearance(name) == pytest.approx(limits.min_clearance)
+
+    def test_case_insensitive_and_alias_tolerant(self):
+        """Names go through get_mfr_limits, so aliases/casing work."""
+        assert resolve_clearance("JLCPCB") == pytest.approx(MFR_JLCPCB.min_clearance)
+        assert resolve_clearance("oshpark") == pytest.approx(MFR_OSHPARK.min_clearance)
+
+    def test_none_and_empty_resolve_to_none(self):
+        """No manufacturer configured -> no floor (never raises)."""
+        assert resolve_clearance(None) is None
+        assert resolve_clearance("") is None
+
+    def test_unknown_manufacturer_resolves_to_none(self):
+        """Validation belongs to the CLI layer -- the helper never raises."""
+        assert resolve_clearance("not-a-fab") is None
+
+    def test_default_profile_floor_is_below_the_route_default(self):
+        """Pins the premise the #4875 clamp relies on.
+
+        The clamp only ever runs with the *default* ``--manufacturer``
+        (``jlcpcb``) -- an explicit ``--manufacturer`` takes the override
+        branch instead and never clamps -- and jlcpcb's 0.127mm capability
+        minimum is looser than ``kct route``'s own 0.15mm default.  So a
+        board declaring anything in 0.127..0.15mm (tighter than our house
+        default, but etchable) is honored verbatim; only a genuinely
+        un-manufacturable declaration is raised.
+
+        ``oshpark`` (0.152mm) is the one profile whose floor exceeds the
+        route default, which is exactly why it must stay on the
+        explicit-override branch rather than silently re-floor a board.
+        """
+        assert resolve_clearance("jlcpcb") == pytest.approx(0.127)
+        assert resolve_clearance("jlcpcb") < 0.15
+        assert resolve_clearance("oshpark") > 0.15

--- a/tests/test_pcb_net_class.py
+++ b/tests/test_pcb_net_class.py
@@ -1,0 +1,132 @@
+"""Issue #4875: legacy top-level ``(net_class …)`` parsing in ``schema.pcb``.
+
+Pre-KiCad-6 boards declare their design rules (clearance, track width, via
+sizes) in the ``.kicad_pcb`` itself, as top-level ``(net_class …)`` nodes that
+are **siblings** of ``(setup …)`` -- not children of it, so ``_parse_setup``
+never saw them and nothing in this repo parsed them at all before #4875.
+
+``kct route`` gates its board-derived clearance on
+:attr:`PCB.net_classes` being non-empty, so these tests pin both halves of
+that signal: legacy boards parse, and modern boards (including everything
+this repo's own writer emits) stay empty.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from kicad_tools.schema import PCB, BoardNetClass
+
+_LEGACY_HEADER = """(kicad_pcb (version 20171130) (host pcbnew 5.1.9)
+  (general (thickness 1.6))
+  (page A4)
+  (layers (0 F.Cu signal) (31 B.Cu signal) (44 Edge.Cuts user))
+  (setup (pad_to_mask_clearance 0.05) (aux_axis_origin 0 0))
+  (net 0 "")
+  (net 1 GND)
+"""
+
+_LEGACY_FOOTER = """  (gr_line (start 0 0) (end 50 0) (layer Edge.Cuts) (width 0.1))
+)
+"""
+
+
+def _write_board(tmp_path: Path, body: str, name: str = "legacy.kicad_pcb") -> Path:
+    pcb = tmp_path / name
+    pcb.write_text(_LEGACY_HEADER + body + _LEGACY_FOOTER)
+    return pcb
+
+
+def test_legacy_default_net_class_is_parsed(tmp_path):
+    """Every declared dimension lands on the dataclass."""
+    pcb_path = _write_board(
+        tmp_path,
+        """  (net_class Default "This is the default net class."
+    (clearance 0.2)
+    (trace_width 0.25)
+    (via_dia 0.8)
+    (via_drill 0.4)
+    (uvia_dia 0.3)
+    (uvia_drill 0.1)
+    (diff_pair_width 0.2)
+    (diff_pair_gap 0.25)
+    (add_net GND)
+    (add_net /SIG)
+  )
+""",
+    )
+
+    net_classes = PCB.load(pcb_path).net_classes
+    assert list(net_classes) == ["Default"]
+
+    default = net_classes["Default"]
+    assert isinstance(default, BoardNetClass)
+    assert default.name == "Default"
+    assert default.description == "This is the default net class."
+    assert default.clearance == 0.2
+    assert default.trace_width == 0.25
+    assert default.via_dia == 0.8
+    assert default.via_drill == 0.4
+    assert default.uvia_dia == 0.3
+    assert default.uvia_drill == 0.1
+    assert default.diff_pair_width == 0.2
+    assert default.diff_pair_gap == 0.25
+    assert default.nets == ["GND", "/SIG"]
+
+
+def test_multiple_net_classes_are_keyed_by_name(tmp_path):
+    """A board may declare several classes; all are surfaced."""
+    pcb_path = _write_board(
+        tmp_path,
+        """  (net_class Default "" (clearance 0.2) (trace_width 0.25))
+  (net_class "Power" "wide rails" (clearance 0.3) (trace_width 0.8) (add_net VBUS))
+""",
+    )
+
+    net_classes = PCB.load(pcb_path).net_classes
+    assert set(net_classes) == {"Default", "Power"}
+    assert net_classes["Power"].clearance == 0.3
+    assert net_classes["Power"].trace_width == 0.8
+    assert net_classes["Power"].nets == ["VBUS"]
+    # Absent tokens stay None so "not declared" is distinguishable from 0.
+    assert net_classes["Default"].via_dia is None
+    assert net_classes["Default"].description == ""
+
+
+def test_absent_net_class_block_yields_empty_mapping(tmp_path):
+    """A modern-format board (rules live in the .kicad_pro) declares nothing.
+
+    This is the pilot-board case from the corpus benchmark work: a stripped
+    single-file import whose ``(setup …)`` carries no rule tokens at all.
+    """
+    pcb_path = _write_board(tmp_path, "")
+    assert PCB.load(pcb_path).net_classes == {}
+
+
+def test_written_board_never_emits_net_class(tmp_path):
+    """This repo's own writer emits no ``net_class`` -- the fleet's guard.
+
+    ``kct route``'s board-derived clearance path is gated on a non-empty
+    ``net_classes``, so a writer that cannot produce the token is what makes
+    the demo-board fleet structurally immune to the #4875 behavior change.
+    """
+    pcb = PCB.create(width=50.0, height=40.0)
+    out = tmp_path / "written.kicad_pcb"
+    pcb.save(out)
+
+    assert "(net_class" not in out.read_text()
+    assert PCB.load(out).net_classes == {}
+
+
+def test_net_class_survives_reparse_without_duplicating(tmp_path):
+    """``_parse`` appends; the name-keyed mapping must not accumulate."""
+    pcb_path = _write_board(
+        tmp_path,
+        '  (net_class Default "" (clearance 0.2))\n',
+    )
+    pcb = PCB.load(pcb_path)
+    assert len(pcb.net_classes) == 1
+
+    pcb._parse()  # idempotent re-parse (resize() takes this path)
+    assert len(pcb.net_classes) == 1
+    assert pcb.net_classes["Default"].clearance == 0.2

--- a/tests/test_route_grid_safety_gate.py
+++ b/tests/test_route_grid_safety_gate.py
@@ -23,6 +23,7 @@ grid``.
 
 import logging
 import re
+import sys
 import warnings
 from pathlib import Path
 from types import SimpleNamespace
@@ -664,3 +665,338 @@ class TestResolveRouteEngine:
             'getattr(args, "route_engine", "grid")',
             'getattr(args, "route_engine", engine_default)',
         ], reads
+
+
+# ---------------------------------------------------------------------------
+# Issue #4875: imported boards are gated against THEIR OWN declared rules
+# ---------------------------------------------------------------------------
+#
+# Before #4875 the gate always evaluated ``args.clearance``, which was either
+# an explicit ``--clearance`` or the flat 0.15mm default -- ``--manufacturer``
+# never touched it and the board's own declared design rules were not parsed
+# at all.  An externally authored board that declares 0.254mm clearance was
+# therefore refused for failing a 0.075mm grid requirement it never claimed.
+#
+# These cases drive the REAL resolution path (no stub on the resolver) with a
+# clearance-aware selector stub that reproduces the selector's own arithmetic:
+# a memory-capped 0.1mm grid is "memory forced unsafe" exactly when it is
+# coarser than clearance/2.
+
+_LEGACY_BOARD_HEAD = """(kicad_pcb (version 20171130) (host pcbnew 5.1.9)
+  (general (thickness 1.6))
+  (page A4)
+  (layers (0 F.Cu signal) (31 B.Cu signal) (44 Edge.Cuts user))
+  (setup (pad_to_mask_clearance 0.05) (aux_axis_origin 0 0))
+  (net 0 "")
+  (net 1 GND)
+"""
+
+_LEGACY_BOARD_TAIL = """  (gr_line (start 0 0) (end 200 0) (layer Edge.Cuts) (width 0.1))
+)
+"""
+
+
+def _imported_board(tmp_path, net_class_block: str = "") -> Path:
+    """Write a legacy-format imported board, optionally declaring rules."""
+    pcb = tmp_path / "imported.kicad_pcb"
+    pcb.write_text(_LEGACY_BOARD_HEAD + net_class_block + _LEGACY_BOARD_TAIL)
+    return pcb
+
+
+def _declares(clearance: float, trace_width: float = 0.25) -> str:
+    return (
+        f'  (net_class Default "This is the default net class."\n'
+        f"    (clearance {clearance})\n"
+        f"    (trace_width {trace_width})\n"
+        f"    (via_dia 0.8) (via_drill 0.4)\n"
+        f"    (add_net GND)\n"
+        f"  )\n"
+    )
+
+
+def _memory_capped_selection(grid: float, clearance: float) -> GridAutoSelection:
+    """The selector's own verdict for a memory-capped ``grid`` at ``clearance``."""
+    safe = grid <= clearance / 2 + 1e-9
+    return GridAutoSelection(
+        resolution=grid,
+        off_grid_pads=0,
+        total_pads=2,
+        off_grid_percentage=0.0,
+        candidates_tried=[(grid, 0)],
+        memory_capped=True,
+        uncapped_resolution=0.065,
+        origin_offset=(0.0, 0.0),
+        clearance_compliant_at_clearance_over_2=safe,
+        memory_budget_used=4_000_000,
+        lattice_rescued=False,
+        memory_forced_unsafe_grid=not safe,
+    )
+
+
+def _run_imported_board(pcb: Path, extra_args, *, forced_grid: float = 0.1):
+    """Drive ``main()`` to the gate on a real board file.
+
+    Returns ``(exit_code, gate_reached, clearance_seen_by_selector)``.
+    """
+    pads = [PadPosition(x=10.0, y=10.0), PadPosition(x=20.0, y=10.0)]
+    observed = {"clearance": None}
+    gate_reached = {"value": False}
+
+    def _select(**kwargs):
+        observed["clearance"] = kwargs["clearance"]
+        return _memory_capped_selection(forced_grid, kwargs["clearance"])
+
+    def _sentinel(*_args, **_kwargs):
+        gate_reached["value"] = True
+        raise _GateReached
+
+    with (
+        patch("kicad_tools.router.io.extract_pad_positions", return_value=pads),
+        patch("kicad_tools.router.io.extract_board_dimensions", return_value=(200.0, 200.0)),
+        patch("kicad_tools.router.io.auto_select_grid_resolution", side_effect=_select),
+        patch("kicad_tools.router.io.compute_multi_resolution_plan", return_value=None),
+        patch("kicad_tools.router.io.load_pads_for_analysis", return_value=pads),
+        patch.object(route_cmd, "_resolve_starting_layers", side_effect=_sentinel),
+    ):
+        try:
+            code = route_cmd.main([str(pcb), *extra_args])
+        except _GateReached:
+            code = None
+    return code, gate_reached["value"], observed["clearance"]
+
+
+def test_imported_board_without_declared_rules_is_refused(tmp_path, capsys):
+    """Baseline: the pre-#4875 behavior the fixture must still reproduce.
+
+    Nothing declares a rule, so the gate evaluates the 0.15mm house default
+    (0.1mm grid > 0.075mm) and refuses -- exactly as before.
+    """
+    pcb = _imported_board(tmp_path)
+    code, gate_reached, clearance = _run_imported_board(pcb, [])
+
+    assert clearance == 0.15
+    assert code == 1
+    assert gate_reached is False
+    out = capsys.readouterr().out
+    assert "rules:" not in out, "no banner when nothing but the default resolved"
+
+
+def test_board_declared_clearance_clears_the_false_gate_refusal(tmp_path, capsys):
+    """The #4875 fix: the board's own 0.254mm rule admits the 0.1mm grid."""
+    pcb = _imported_board(tmp_path, _declares(0.254))
+    code, gate_reached, clearance = _run_imported_board(pcb, [])
+
+    assert clearance == 0.254, "the selector must see the board's own clearance"
+    assert gate_reached is True, "the board declares rules its own grid satisfies"
+    assert code is None
+
+    out = capsys.readouterr().out
+    assert 'Clearance: 0.254mm (rules: board net_class "Default")' in out
+    assert out.count("(rules:") == 1, "the rule-source banner prints exactly once"
+
+
+def test_explicit_clearance_overrides_board_declared_rules(tmp_path, capsys):
+    """An explicit ``--clearance`` wins over the board, unmodified."""
+    pcb = _imported_board(tmp_path, _declares(0.254))
+    code, gate_reached, clearance = _run_imported_board(pcb, ["--clearance", "0.15"])
+
+    assert clearance == 0.15, "explicit flag must not be replaced by board rules"
+    assert code == 1, "0.1mm grid > 0.075mm -- gated at the operator's value"
+    assert gate_reached is False
+
+    out = capsys.readouterr().out
+    assert "Clearance: 0.15mm (rules: explicit --clearance flag)" in out
+    assert out.count("(rules:") == 1
+
+
+def test_explicit_clearance_equals_spelling_is_detected(tmp_path, capsys):
+    """``--clearance=0.15`` is as explicit as ``--clearance 0.15``."""
+    pcb = _imported_board(tmp_path, _declares(0.254))
+    _code, _gate, clearance = _run_imported_board(pcb, ["--clearance=0.15"])
+    assert clearance == 0.15
+    assert "(rules: explicit --clearance flag)" in capsys.readouterr().out
+
+
+def test_explicit_manufacturer_overrides_board_declared_rules(tmp_path, capsys):
+    """An explicit ``--manufacturer`` is an operator override of board rules.
+
+    Decision (issue #4875 ambiguity #1): only an *actually explicit*
+    ``--manufacturer`` counts.  It restores today's behavior exactly (the
+    0.15mm default), so no invocation that names a manufacturer -- which is
+    every demo-board recipe -- changes its clearance because of this issue.
+    """
+    pcb = _imported_board(tmp_path, _declares(0.254))
+    code, gate_reached, clearance = _run_imported_board(pcb, ["--manufacturer", "jlcpcb"])
+
+    assert clearance == 0.15
+    assert code == 1
+    assert gate_reached is False
+
+    out = capsys.readouterr().out
+    assert "rules: manufacturer profile jlcpcb" in out
+    assert "overrides the board's declared net_class" in out
+    assert out.count("(rules:") == 1
+
+
+def test_explicit_mfr_alias_also_overrides(tmp_path, capsys):
+    """The ``--mfr`` alias is the same override."""
+    pcb = _imported_board(tmp_path, _declares(0.254))
+    _code, _gate, clearance = _run_imported_board(pcb, ["--mfr", "oshpark"])
+    assert clearance == 0.15
+    assert "rules: manufacturer profile oshpark" in capsys.readouterr().out
+
+
+def test_sub_floor_board_clearance_is_raised_to_the_fab_floor(tmp_path, capsys):
+    """A declared clearance no fab can etch is clamped UP, never silently.
+
+    Decision (issue #4875 ambiguity #2): the conservative resolution.  A
+    board declaring 0.05mm is below every configured tier's capability
+    minimum; honoring it verbatim would route copper no fab can produce, so
+    it is raised to the active profile's floor and the substitution is
+    named on stdout AND warned about on stderr.
+    """
+    pcb = _imported_board(tmp_path, _declares(0.05))
+    _code, _gate, clearance = _run_imported_board(pcb, [])
+
+    assert clearance == pytest.approx(0.127), "raised to the jlcpcb floor"
+
+    captured = capsys.readouterr()
+    assert 'board net_class "Default" 0.05mm, raised to the jlcpcb floor' in captured.out
+    assert "below the jlcpcb minimum clearance" in captured.err
+    assert "--clearance 0.05" in captured.err, "names the opt-out"
+    assert captured.out.count("(rules:") == 1
+
+
+def test_board_clearance_between_floor_and_default_is_honored(tmp_path, capsys):
+    """0.13mm is tighter than our house default but etchable -- keep it."""
+    pcb = _imported_board(tmp_path, _declares(0.13))
+    _code, _gate, clearance = _run_imported_board(pcb, [])
+
+    assert clearance == 0.13
+    captured = capsys.readouterr()
+    assert 'Clearance: 0.13mm (rules: board net_class "Default")' in captured.out
+    assert "below the jlcpcb minimum clearance" not in captured.err
+
+
+def test_quiet_suppresses_the_banner_but_not_the_clamp_warning(tmp_path, capsys):
+    """``--quiet`` hides provenance chatter; the un-manufacturable warning stays."""
+    pcb = _imported_board(tmp_path, _declares(0.05))
+    _code, _gate, clearance = _run_imported_board(pcb, ["--quiet"])
+
+    assert clearance == pytest.approx(0.127)
+    captured = capsys.readouterr()
+    assert "(rules:" not in captured.out
+    assert "below the jlcpcb minimum clearance" in captured.err
+
+
+class TestClearanceRuleSourceHelpers:
+    """Unit coverage for the #4875 resolution helpers."""
+
+    @pytest.mark.parametrize(
+        "argv,expected",
+        [
+            (["board.kicad_pcb"], False),
+            (["board.kicad_pcb", "--clearance", "0.2"], True),
+            (["board.kicad_pcb", "--clearance=0.2"], True),
+            (["board.kicad_pcb", "--clear-cache"], False),
+            (["board.kicad_pcb", "--edge-clearance", "0.3"], False),
+            (["board.kicad_pcb", "--fine-pitch-clearance", "0.1"], False),
+        ],
+    )
+    def test_clearance_flag_detection(self, argv, expected):
+        assert route_cmd._flag_passed_explicitly(argv, ("--clearance",)) is expected
+
+    @pytest.mark.parametrize(
+        "argv,expected",
+        [
+            (["board.kicad_pcb"], False),
+            (["board.kicad_pcb", "--manufacturer", "oshpark"], True),
+            (["board.kicad_pcb", "--manufacturer=oshpark"], True),
+            (["board.kicad_pcb", "--mfr", "oshpark"], True),
+            (["board.kicad_pcb", "--mfr=oshpark"], True),
+            (["board.kicad_pcb", "--max-layers", "6"], False),
+        ],
+    )
+    def test_manufacturer_flag_detection(self, argv, expected):
+        options = ("--manufacturer", "--mfr")
+        assert route_cmd._flag_passed_explicitly(argv, options) is expected
+
+    def test_default_class_wins_over_named_classes(self):
+        classes = {
+            "Power": SimpleNamespace(clearance=0.4),
+            "Default": SimpleNamespace(clearance=0.2),
+        }
+        assert route_cmd._board_base_clearance(classes) == ("Default", 0.2)
+
+    def test_strictest_named_class_is_the_base_without_a_default(self):
+        classes = {
+            "Power": SimpleNamespace(clearance=0.4),
+            "Signal": SimpleNamespace(clearance=0.18),
+        }
+        assert route_cmd._board_base_clearance(classes) == ("Signal", 0.18)
+
+    def test_classes_without_a_clearance_declare_nothing(self):
+        classes = {"Default": SimpleNamespace(clearance=None)}
+        assert route_cmd._board_base_clearance(classes) is None
+        assert route_cmd._board_base_clearance({}) is None
+
+    def test_unreadable_board_falls_back_to_no_declared_rules(self, tmp_path):
+        """Rule derivation is an enhancement, never a new failure mode."""
+        missing = tmp_path / "nope.kicad_pcb"
+        assert route_cmd._board_declared_net_classes(missing) == {}
+
+    def test_malformed_board_falls_back_to_no_declared_rules(self, tmp_path):
+        broken = tmp_path / "broken.kicad_pcb"
+        broken.write_text("(kicad_pcb (net_class Default (clearance 0.2)")  # unbalanced
+        assert route_cmd._board_declared_net_classes(broken) == {}
+
+    def test_modern_board_skips_the_parse_entirely(self, tmp_path):
+        """The text pre-check is what keeps the fleet path free of new cost."""
+        modern = tmp_path / "modern.kicad_pcb"
+        modern.write_text("(kicad_pcb (version 20221018) (setup))\n")
+        with patch("kicad_tools.schema.PCB.load", side_effect=AssertionError("parsed!")):
+            assert route_cmd._board_declared_net_classes(modern) == {}
+
+
+class TestOuterCliForwardsExplicitDefaults:
+    """Issue #4875: ``kct route`` must forward a deliberately-default flag.
+
+    ``run_route_command`` builds the inner ``route_cmd`` argv by comparing
+    each outer flag against its default and forwarding only the differences
+    (so a flag-off invocation stays byte-identical).  That is exactly wrong
+    for the two flags whose *presence* now carries meaning: ``kct route
+    --clearance 0.15`` and ``--manufacturer jlcpcb`` were dropped, so the
+    board's declared rules silently outranked an explicit operator choice.
+    """
+
+    def _sub_argv(self, argv: list[str]) -> list[str]:
+        from kicad_tools.cli.commands import routing
+        from kicad_tools.cli.parser import create_parser
+
+        cli_argv = ["route", "board.kicad_pcb", *argv]
+        args = create_parser().parse_args(cli_argv)
+
+        captured: dict[str, list[str]] = {}
+
+        def _capture(sub_argv):
+            captured["argv"] = list(sub_argv)
+            return 0
+
+        with (
+            patch.object(sys, "argv", ["kct", *cli_argv]),
+            patch("kicad_tools.cli.route_cmd.main", side_effect=_capture),
+        ):
+            routing.run_route_command(args)
+        return captured["argv"]
+
+    def test_flag_off_argv_stays_byte_identical(self):
+        assert self._sub_argv([]) == ["board.kicad_pcb"]
+
+    def test_explicit_default_clearance_is_forwarded(self):
+        assert "--clearance" in self._sub_argv(["--clearance", "0.15"])
+
+    def test_explicit_default_manufacturer_is_forwarded(self):
+        assert "--manufacturer" in self._sub_argv(["--manufacturer", "jlcpcb"])
+
+    def test_explicit_default_mfr_alias_is_forwarded(self):
+        assert "--manufacturer" in self._sub_argv(["--mfr", "jlcpcb"])


### PR DESCRIPTION
## Summary

`kct route` gated externally-authored boards against **our** default manufacturer profile rather than the design rules the board itself declares. The grid-safety gate (#3911) reads `args.clearance`, and that value was *always* either an explicit `--clearance` or the flat 0.15 mm CLI default — `--manufacturer` never touched it, and a board's own declared rules were not parsed anywhere in the repo. So a board authored at 0.254 mm clearance was refused for failing a 0.075 mm grid requirement it never claimed, and any future route-vs-human benchmark (#4830, PR #4869) would be handicapping the router with rules the human never had to satisfy.

This adds the missing parser, a shared resolution helper in the #4568/#4700 shape, and the precedence + ordering fix — confined by construction to boards that actually declare rules.

## Changes

**`src/kicad_tools/schema/pcb.py`** — parse legacy top-level `(net_class …)` blocks into a new `BoardNetClass` dataclass, exposed as `PCB.net_classes` (name-keyed, so a re-`_parse()` overwrites instead of duplicating). These are **siblings** of `(setup …)`, not children, so `_parse_setup` never saw them; a new branch at the end of the top-level dispatch chain handles them. Every dimension defaults to `None` so "not declared" is distinguishable from "declared as 0".

**`src/kicad_tools/router/mfr_limits.py`** — `resolve_clearance(manufacturer) -> float | None`, the clearance analogue of #4568's `resolve_edge_clearance`: same pure-function shape, returns `None` rather than raising on an unknown name.

**`src/kicad_tools/cli/route_cmd.py`** — `_resolve_route_clearance()` runs **before** the auto-grid block (`_main_impl`), not beside the #4568/#4700 auto-fills, which run *after* grid selection and would be too late for both the gate and the grid search. Precedence:

```
explicit --clearance
  > explicit --manufacturer  (operator's profile overrides the board)
  > board-declared legacy net_class clearance, raised to the active
    profile's min_clearance floor when it undercuts it
  > 0.15 mm  (today's default, unchanged)
```

One provenance banner per invocation naming the source, e.g.
`Clearance: 0.254mm (rules: board net_class "Default")`.

**`src/kicad_tools/cli/commands/routing.py`** — the outer `kct route` built the inner argv by forwarding each flag only when its *value* differed from the default, which silently dropped a deliberate `--clearance 0.15` / `--manufacturer jlcpcb`, handing the decision back to the board. Now forwarded whenever actually passed. Flag-off argv stays byte-identical (pinned by a test).

## Decisions taken (the issue's two flagged ambiguities)

**(i) Only an *actually explicit* `--manufacturer` counts as an operator override.** Detection is **argv-sniffing** (`_flag_passed_explicitly`, handling `--flag=value` and argparse's unambiguous abbreviations), extending the existing `"--no-auto-layers" in _argv_for_q5` pattern — *not* the sentinel-default refactor, which would make `args.manufacturer` optional at 15+ call sites that all assume `str`.

Crucially, the manufacturer profile is **not** used to *derive* a clearance value. Deriving `args.clearance` from `MfrLimits(...).min_clearance` would move every `--manufacturer`-bearing invocation off 0.15 mm (jlcpcb → 0.127) and change the fleet's routed output — the "deliberately reviewed, separate decision" the curation warned against. Instead an explicit `--manufacturer` **suppresses board-derived rules**, restoring today's behavior exactly. The manufacturer's only new role is as the clamp floor below.

**(ii) A declared clearance below the active profile's floor is raised to the floor, loudly** — not honored verbatim. This is a deliberate deviation from the curated AC #2's "honored (not silently tightened)" recommendation, made on operator direction: never trust a looser-than-fab rule silently. It is *not* silent — stdout names the substitution and stderr warns, naming the `--clearance <declared>` opt-out that restores the board's exact value:

```
WARNING: the board declares net_class "Default" clearance 0.05mm, which is below the
jlcpcb minimum clearance 0.127mm -- no configured fab tier can produce it. Routing at
the 0.127mm floor instead; pass --clearance 0.05 to route at the board's declared value anyway.
Clearance: 0.127mm (rules: board net_class "Default" 0.05mm, raised to the jlcpcb floor 0.127mm)
```

The clamp can only ever fire with the *default* profile (an explicit `--manufacturer` takes the override branch), and jlcpcb's 0.127 mm floor is looser than route's own 0.15 mm default — so a board declaring anything etchable in 0.127–0.15 mm is honored verbatim. Only a genuinely un-manufacturable declaration is raised. Pinned as `test_default_profile_floor_is_below_the_route_default`.

**(iii) The banner is suppressed in the bare-default case** (no flags, no board rules) — printing it would add a line to every existing invocation while naming nothing new, and would diverge from the #4568/#4700 "print only when it changed something" convention. It prints in all three cases where something actually resolved.

**Scope held**: no geometric rule induction from reference copper, no `.kicad_pro` reading, no `--dru` input flag — all named out-of-scope by curation and untouched here.

**Known limit, stated honestly**: only pre-KiCad-6 boards carry rules in the `.kicad_pcb`. KiCad 6+ moved net classes to the companion `.kicad_pro`, so a modern single-file import (including the `os-0009947-pcb1` pilot board that motivated the issue) still falls back to the manufacturer profile exactly as before. That is expected, not a bug.

## Acceptance Criteria Verification

- [x] **Tight, self-consistent board rules route without the false gate refusal** — `test_board_declared_clearance_clears_the_false_gate_refusal`: same fixture + same memory-capped 0.1 mm grid is *refused* with no declared rules (`test_imported_board_without_declared_rules_is_refused`, 0.1 > 0.15/2) and *allowed* once the board's own 0.254 mm rule is honored (0.1 ≤ 0.254/2). The selector stub reproduces the real selector's own arithmetic rather than hard-coding a verdict.
- [x] **Looser-than-floor board is not silently trusted** — `test_sub_floor_board_clearance_is_raised_to_the_fab_floor` (see deviation above). `test_board_clearance_between_floor_and_default_is_honored` proves the clamp does not over-fire on merely-tight boards.
- [x] **Explicit `--clearance` always wins, banner names the flag** — `test_explicit_clearance_overrides_board_declared_rules` (+ `--clearance=0.15` spelling). Also fixed the outer-CLI hole that dropped the flag at its default value.
- [x] **Banner prints exactly once, naming one of the three sources** — asserted via `out.count("(rules:") == 1` in every case; `test_quiet_suppresses_the_banner_but_not_the_clamp_warning` keeps the un-manufacturable warning under `--quiet`.
- [x] **`tests/test_grid_safety_gate_fleet.py` green, existing assertions unmodified, extended** — two new cases: no fleet input carries a `(net_class` token (`_board_declared_net_classes` returns `{}`), and `args.clearance` still resolves to 0.15 mm for every board both bare and with its recipe's real `--manufacturer`.
- [x] **Modern-format board with no rules falls back exactly as before** — `test_imported_board_without_declared_rules_is_refused` asserts clearance 0.15, the same refuse verdict, and **no** banner line. `test_modern_board_skips_the_parse_entirely` proves the text pre-check short-circuits before `PCB.load` (so the fleet path takes on no new parse cost).

## Test Plan

```
uv run pytest tests/test_route_grid_safety_gate.py tests/test_grid_safety_gate_fleet.py \
  tests/test_grid_auto_selection.py tests/test_mfr_limits.py tests/test_pcb.py \
  tests/test_pcb_net_class.py tests/test_cli_parser_drift.py -q
# 572 passed
```

Plus the CLI-forwarding neighbours (`test_route_offboard_gate`, `test_cli_route_match_groups`, `test_layer_escalation`, `test_route_max_cells_flag`, `test_route_cmd_params`, `test_route_deterministic_budget`, `test_cli_order_method`, `test_partial_routing_features`, `test_route_cmd_placement_feedback`): **339 passed**. `test_route_cmd_help_string` / `test_cli_route_net_class_map` / `test_route_cmd_global_state_isolation`: **87 passed**.

`ruff check` + `ruff format` clean. `scripts/ci/check_mypy_baseline.py`: `OK: mypy reports 1464 error(s), all within the baseline (1472 allowed). No new type errors.` (baseline left untouched).

**Manual, through the real `kct route` entry point** (board 00's PCB with a `(net_class Default (clearance 0.254) …)` block injected):

| Invocation | Result |
|---|---|
| no flags, no declared rules | *no banner*, grid selection identical to `main` |
| no flags, declares 0.254 | `Clearance: 0.254mm (rules: board net_class "Default")`, selector picks the coarser rule-consistent grid |
| declares 0.05 | clamped to 0.127 + stderr warning |
| `--clearance 0.15` | `(rules: explicit --clearance flag)` |
| `--manufacturer jlcpcb` | `(rules: manufacturer profile jlcpcb) -- explicit --manufacturer overrides …` |

**Fleet regression, measured not asserted**: full `kct route` of board 00 and board **02** (the board whose recipe passes the explicit `--manufacturer jlcpcb` that this PR newly forwards to the inner command), with and without the flag, at `--seed 42` — routed output **byte-identical** modulo uuid/date. Combined with the structural gate (no fleet input contains `(net_class`) this covers the mandatory byte-identity guard without a multi-hour full-fleet regeneration.

Closes #4875
