### PR TITLE
fix(parser): read legacy `(module …)` boards as footprints — 9→0 corpus blockers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1126,6 +1126,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `--manufacturer jlcpcb` because it forwarded flags only when their value
   differed from the default.
 
+- **Legacy `(module …)` boards parsed to zero footprints and zero pads —
+  silently** (#4873) — KiCad 6 renamed the component block from `(module …)` to
+  `(footprint …)`, and `PCB._parse()`'s dispatch chain matched the modern
+  spelling only, with no `else` arm. A pre-KiCad-6 board therefore parsed its
+  nets, segments, vias and zones fine while its **entire component graph
+  vanished**, with no error, no warning and no version signal — a data-shaped
+  wrong answer that every downstream consumer (routing, DRC, LVS, BOM) would
+  read as "this board has no parts." `module` is now accepted as the legacy
+  spelling of `footprint` throughout `schema/pcb.py`: not just the parse
+  dispatch, but every tree walk that keys on the tag
+  (`_link_footprint_sexp_nodes`, `_translate_footprint_sexp`,
+  `_find_footprint_sexp`, reference/value updates, silkscreen text edits, net
+  insertion), so a module-sourced board is **editable**, not merely readable —
+  position sync, rename, remove, translate and save/reload all round-trip. No
+  sub-form translation was needed: `pad` / `at` / `layer` / `fp_text` / `attr`
+  are spelled identically on both sides of the rename. Measured on the pinned
+  22-board open-schematics corpus census
+  (`scripts/corpus/benchmark_readiness.py`): the `legacy-module-schema` and
+  `no-pad-graph` blockers drop **9 → 0**, featurizable boards rise **10 → 18**
+  and route-vs-human benchmark cases **8 → 16** — the token rename alone was
+  costing 41% of the sample. The class of failure is now loud in general: a
+  board that carries `(pad …)` nodes but yields no footprint logs a warning
+  naming the declared version and the unreadable container tag, and records it
+  in the new `PCB.parse_warnings`, so a *future* unknown component container
+  cannot silently return an empty component graph either. The sibling legacy
+  `gr_arc` centre+angle defect (#4874) is deliberately not in this change.
+
 - **`route --voltage-map` collapsed signed net potentials with `abs()`, so
   +150 V vs −150 V differenced to 0 V** (#4867, blocker for #4507, epic #4431
   Phase 2) — the router normalised its voltage map to *magnitudes* before

--- a/docs/research/corpus-benchmark-feasibility.md
+++ b/docs/research/corpus-benchmark-feasibility.md
@@ -5,6 +5,28 @@ slice 4 of 4. Measured on 2026-08-16 against the 22 PCB entries of
 `scripts/corpus/manifests/open-schematics-sample.json` (revision-pinned
 `bshada/open-schematics` payloads) plus this repo's own 8 routed boards.*
 
+> **Update — the biggest lever has landed.**
+> [#4873](https://github.com/rjwalters/kicad-tools/issues/4873) taught
+> `PCB._parse()` to read the pre-KiCad-6 `(module …)` spelling as a footprint.
+> Re-running the census below on the same pinned payload cache:
+>
+> | Census figure | Before #4873 | After #4873 |
+> |---|---|---|
+> | `legacy-module-schema` blockers | 9 | **0** |
+> | `no-pad-graph` blockers | 9 | **0** |
+> | featurizable boards (#4799) | 10 / 22 (45.5%) | **18 / 22 (81.8%)** |
+> | labeled calibration examples | 8 (36.4%) | **16 (72.7%)** |
+> | route-vs-human cases | 8 (36.4%) | **16 (72.7%)** |
+> | `unusable` label | 12 | **4** |
+>
+> Everything below is the **pre-fix** measurement and is kept as the record of
+> why the fix was worth making. The residual blockers are unchanged in kind:
+> `no-net-binding` ×2 and `no-reference-copper` ×2 are properties of those
+> designs, `no-outline` ×1 and `outline-not-polygonal` ×1 (the legacy
+> centre+angle `gr_arc` form, tracked as
+> [#4874](https://github.com/rjwalters/kicad-tools/issues/4874)) are the
+> remaining parser work.
+
 Slices 1–3 answered *"can our parsers read real-world KiCad files?"* (yes:
 30/30 manifest entries parse). This slice answers the question the two proposed
 follow-on capabilities actually depend on: **is the corpus usable as benchmark

--- a/scripts/corpus/benchmark_readiness.py
+++ b/scripts/corpus/benchmark_readiness.py
@@ -87,9 +87,13 @@ COMPLETE_REFERENCE_FRACTION = 0.95
 
 #: Parsed, but no footprints/pads came out: no component graph to featurize.
 BLOCK_NO_PAD_GRAPH = "no-pad-graph"
-#: The specific, fixable cause of most ``no-pad-graph`` boards: the file uses
-#: the pre-KiCad-6 ``(module ...)`` token, which this repo's parser silently
-#: ignores (it reads ``(footprint ...)`` only). Actionable as parser work.
+#: The specific, fixable cause a ``no-pad-graph`` board *used* to have: the file
+#: uses the pre-KiCad-6 ``(module ...)`` token, which the parser silently
+#: ignored (it read ``(footprint ...)`` only). Issue #4873 taught
+#: ``PCB._parse()`` the alias, so this blocker should now be empty on the
+#: pinned corpus; it is kept as a live diagnostic in case some other legacy
+#: dialect still yields no footprints at all -- naming the dialect keeps that
+#: case actionable as parser work instead of hiding it in the generic bucket.
 BLOCK_LEGACY_MODULE_SCHEMA = "legacy-module-schema"
 #: Pads exist but the board has fewer than ``MIN_MULTI_PAD_NETS`` routable
 #: nets -- usually none carry a net at all (a panel or a mechanical board), but
@@ -375,9 +379,14 @@ def evaluate(features: BoardFeatures) -> Readiness:
 
     if features.footprints == 0 or features.pads == 0:
         blockers.append(BLOCK_NO_PAD_GRAPH)
-        if features.legacy_module_tokens > 0:
-            # Name the cause, not just the symptom: this one is fixable in the
-            # parser and would recover the whole bucket at once.
+        if features.footprints == 0 and features.legacy_module_tokens > 0:
+            # Name the cause, not just the symptom: a legacy-dialect board that
+            # yields *no footprints at all* is parser work, not corpus noise.
+            # Since #4873 the plain ``(module ...)`` rename is understood, so
+            # this fires only for a dialect we still cannot read -- keyed on
+            # zero footprints (not zero pads), because a legacy board whose
+            # modules simply carry no pads is a mechanical board, not a parse
+            # gap.
             blockers.append(BLOCK_LEGACY_MODULE_SCHEMA)
     elif features.multi_pad_nets < MIN_MULTI_PAD_NETS:
         blockers.append(BLOCK_NO_NET_BINDING)

--- a/src/kicad_tools/schema/pcb.py
+++ b/src/kicad_tools/schema/pcb.py
@@ -32,6 +32,29 @@ if TYPE_CHECKING:
     from ..manufacturers import DesignRules
     from ..query.footprints import FootprintList
 
+# S-expression tags that introduce a component (footprint) block.
+#
+# KiCad 6 renamed ``(module ...)`` to ``(footprint ...)``; boards written by
+# pre-KiCad-6 tools -- still a large share of the public corpus -- use the
+# legacy spelling.  Every sub-form we read inside the block (``pad``, ``at``,
+# ``layer``, ``fp_text reference`` / ``fp_text value``, ``attr``) is spelled
+# identically on both sides of the rename, so accepting ``module`` as an alias
+# recovers the whole component graph without any per-sub-form translation
+# (issue #4873).  ``core.sexp_file.load_footprint`` already accepts the same
+# alias for standalone ``.kicad_mod`` library files.
+FOOTPRINT_TAGS: tuple[str, ...] = ("footprint", "module")
+
+
+def _is_footprint_tag(tag: str | None) -> bool:
+    """Return True if *tag* names a footprint block (modern or legacy).
+
+    Use this instead of a bare ``tag == "footprint"`` comparison anywhere the
+    board S-expression tree is walked, so legacy ``(module ...)`` boards stay
+    editable (position sync, rename, remove, translate) and not just readable.
+    """
+    return tag in FOOTPRINT_TAGS
+
+
 # Default regex for detecting power/ground net names.
 # Matches names like GND, +3V3, +5V, VCC, VDD, VBUS, or names starting with '+'.
 _DEFAULT_POWER_NET_PATTERN = re.compile(
@@ -1848,6 +1871,10 @@ class PCB:
         # (add_trace/add_via) emits name-based refs when this is True so a
         # name-based board stays name-based on save.
         self._net_name_only_dialect: bool = False
+        #: Loud, human-readable signals raised while parsing this board -- used
+        #: today for the "file has a component graph we could not read" guard
+        #: (issue #4873).  Empty on a board the parser fully understands.
+        self.parse_warnings: list[str] = []
         self._parse()
         self._detect_board_origin()
         self._link_footprint_sexp_nodes()
@@ -2196,7 +2223,10 @@ class PCB:
                 self._parse_layers(child)
             elif tag == "net":
                 self._parse_net(child)
-            elif tag == "footprint":
+            elif tag in FOOTPRINT_TAGS:
+                # ``module`` is the pre-KiCad-6 spelling of ``footprint``;
+                # the block's contents are unchanged by the rename, so the
+                # same parser handles both (issue #4873).
                 fp = Footprint.from_sexp(child)
                 self._footprints.append(fp)
             elif tag == "segment":
@@ -2243,6 +2273,52 @@ class PCB:
         # but the header declarations (net N "name") are always present, so we
         # can rebuild the number from the name.
         self._fixup_net_numbers()
+
+        self._warn_on_unparsed_component_graph()
+
+    def _warn_on_unparsed_component_graph(self) -> None:
+        """Refuse to return an empty component graph *silently*.
+
+        The ``(module ...)`` defect (issue #4873) was invisible precisely
+        because ``_parse()``'s dispatch chain has no fallback: a component
+        block spelled with an unrecognised tag simply fell through the loop
+        and the board reported zero footprints and zero pads with no error,
+        no warning, and no version signal.
+
+        This guard makes that class of failure loud rather than data-shaped:
+        if the file plainly carries a component graph (it has ``(pad ...)``
+        nodes somewhere in the tree) but no footprint was parsed, log a
+        warning naming the declared board version and the container tags we
+        could not read, and record it in :attr:`parse_warnings` so callers
+        can surface it too.  Genuinely component-free boards (panel frames,
+        outline-only fixtures) have no pads and stay quiet.
+        """
+        if self._footprints:
+            return
+
+        pad_nodes = self._sexp.find_all("pad")
+        if not pad_nodes:
+            return  # No component graph in the file at all -- nothing lost.
+
+        unreadable_tags = sorted(
+            {
+                child.tag
+                for child in self._sexp.iter_children()
+                if child.tag is not None and not _is_footprint_tag(child.tag) and child.find("pad")
+            }
+        )
+        version_node = self._sexp.find_child("version")
+        declared_version = (version_node.get_string(0) if version_node else None) or "unknown"
+        message = (
+            f"Board declares version {declared_version} and contains "
+            f"{len(pad_nodes)} pad node(s), but no footprint could be parsed: "
+            f"the component graph is unreadable. Unrecognised container tag(s): "
+            f"{', '.join(unreadable_tags) if unreadable_tags else 'none at top level'}. "
+            "Pad-level results (routing, DRC, LVS, BOM) from this board would be "
+            "wrong, not merely incomplete."
+        )
+        logger.warning("%s", message)
+        self.parse_warnings.append(message)
 
     def _parse_layers(self, sexp: SExp):
         """Parse layer definitions."""
@@ -2678,7 +2754,7 @@ class PCB:
         # iteration order (fallback for legacy files without UUIDs).
         order_idx = 0
         for child in self._sexp.iter_children():
-            if child.tag != "footprint":
+            if not _is_footprint_tag(child.tag):
                 continue
 
             # Direct child only: pads/properties carry their own (uuid)
@@ -3008,7 +3084,7 @@ class PCB:
         # Translate every positioned top-level item in the tree.
         for child in self._sexp.iter_children():
             tag = child.tag
-            if tag == "footprint":
+            if _is_footprint_tag(tag):
                 self._translate_footprint_sexp(child, dx_nm, dy_nm)
             elif tag in (
                 "segment",
@@ -3115,6 +3191,20 @@ class PCB:
                 return fp
         return None
 
+    def _iter_footprint_sexps(self) -> Iterator[SExp]:
+        """Yield every footprint node in the tree, in document order.
+
+        Matches both the modern ``(footprint ...)`` spelling and the legacy
+        pre-KiCad-6 ``(module ...)`` spelling (issue #4873).  Search semantics
+        match :meth:`SExp.find_all` -- descendants of the root, not the root
+        itself -- so this is a drop-in replacement for the
+        ``self._sexp.find_all("footprint")`` calls it supersedes.
+        """
+        for child in self._sexp.children:
+            for node in child.iter_all():
+                if _is_footprint_tag(node.tag):
+                    yield node
+
     def _find_footprint_sexp(self, reference: str) -> SExp | None:
         """Find a footprint S-expression node by reference designator.
 
@@ -3126,7 +3216,7 @@ class PCB:
         Returns:
             The footprint SExp node if found, None otherwise.
         """
-        for fp_sexp in self._sexp.find_all("footprint"):
+        for fp_sexp in self._iter_footprint_sexps():
             ref_value = None
 
             # KiCad 7 format: fp_text with type "reference"
@@ -4144,7 +4234,7 @@ class PCB:
         abs_y = y + self._board_origin[1]
 
         for child in self._sexp.iter_children():
-            if child.tag != "footprint":
+            if not _is_footprint_tag(child.tag):
                 continue
 
             # Check if this is the right footprint by looking at reference
@@ -4214,7 +4304,7 @@ class PCB:
 
         # Update the S-expression tree
         for child in self._sexp.iter_children():
-            if child.tag != "footprint":
+            if not _is_footprint_tag(child.tag):
                 continue
 
             fp_ref = self._get_footprint_reference(child)
@@ -4268,7 +4358,7 @@ class PCB:
 
         # Update the S-expression tree
         for child in self._sexp.iter_children():
-            if child.tag != "footprint":
+            if not _is_footprint_tag(child.tag):
                 continue
 
             fp_ref = self._get_footprint_reference(child)
@@ -4348,7 +4438,7 @@ class PCB:
 
         # Update S-expression tree
         for child in self._sexp.iter_children():
-            if child.tag != "footprint":
+            if not _is_footprint_tag(child.tag):
                 continue
 
             # Get reference from this footprint
@@ -4449,7 +4539,7 @@ class PCB:
         """
         # Find footprint in S-expression tree
         for child in self._sexp.iter_children():
-            if child.tag != "footprint":
+            if not _is_footprint_tag(child.tag):
                 continue
 
             fp_ref = self._get_footprint_reference(child)
@@ -4576,7 +4666,7 @@ class PCB:
 
         # Update S-expression tree
         for child in self._sexp.iter_children():
-            if child.tag != "footprint":
+            if not _is_footprint_tag(child.tag):
                 continue
 
             fp_ref = self._get_footprint_reference(child)
@@ -4683,7 +4773,7 @@ class PCB:
 
         # Update S-expression tree
         for child in self._sexp.iter_children():
-            if child.tag != "footprint":
+            if not _is_footprint_tag(child.tag):
                 continue
 
             fp_ref = self._get_footprint_reference(child)
@@ -5132,7 +5222,7 @@ class PCB:
             # Find the first footprint and insert before it
             first_footprint_index = -1
             for i, child in enumerate(self._sexp.children):
-                if child.name == "footprint":
+                if _is_footprint_tag(child.name):
                     first_footprint_index = i
                     break
 
@@ -5746,7 +5836,7 @@ class PCB:
             return False
 
         # Update the S-expression tree
-        for fp_sexp in self._sexp.find_all("footprint"):
+        for fp_sexp in self._iter_footprint_sexps():
             # Find the matching footprint by reference
             ref_value = None
 

--- a/tests/test_corpus_readiness.py
+++ b/tests/test_corpus_readiness.py
@@ -16,9 +16,11 @@ a benchmark verdict rather than crash:
 * a **pour** counts as copper (a ground net served only by a filled zone is
   routed; scoring it unrouted mis-grades every board that has a plane), while a
   **keepout rule area** does not (it is a constraint, not a conductor);
-* an empty component graph is attributed to the legacy ``(module ...)`` schema
-  when that is the cause, because that blocker is fixable in the parser and the
-  generic "no pads" bucket hides how much of the corpus it would unlock;
+* a pre-KiCad-6 ``(module ...)`` board keeps its component graph (issue #4873
+  taught the parser the alias; this file used to pin the opposite), and an
+  empty component graph is still attributed to a legacy schema when *that* is
+  the cause, because the generic "no pads" bucket hides how much of the corpus
+  a parser fix would unlock;
 * a partially-routed board is disqualified as a *reference*, not silently scored
   against;
 * an outline whose corner arcs use the pre-KiCad-6 centre+angle form now
@@ -243,6 +245,37 @@ LEGACY_MODULE_BOARD = """(kicad_pcb (version 4) (host pcbnew "(2017-11-30)")
 )
 """
 
+# The same pre-KiCad-6 dialect, but a *complete* two-part board: two multi-pad
+# nets, both fully routed. Before #4873 this was worth zero to the benchmark
+# line (no component graph at all); it is now a labelled route-vs-human
+# reference, which is the whole payoff the census measured (9/22 pinned boards
+# were losing their component graph to the token rename alone).
+LEGACY_MODULE_ROUTED_BOARD = """(kicad_pcb (version 4) (host pcbnew "(2017-11-30)")
+  (general (thickness 1.6))
+  (page A4)
+  (layers (0 F.Cu signal) (31 B.Cu signal) (44 Edge.Cuts user))
+  (net 0 "")
+  (net 1 GND)
+  (net 2 SIG)
+  (gr_line (start 0 0) (end 20 0) (layer Edge.Cuts) (width 0.05))
+  (gr_line (start 20 0) (end 20 10) (layer Edge.Cuts) (width 0.05))
+  (gr_line (start 20 10) (end 0 10) (layer Edge.Cuts) (width 0.05))
+  (gr_line (start 0 10) (end 0 0) (layer Edge.Cuts) (width 0.05))
+  (module R_0603 (layer F.Cu) (tedit 0) (at 5 5)
+    (fp_text reference R1 (at 0 0) (layer F.SilkS))
+    (pad 1 smd rect (at -0.8 0) (size 0.9 0.8) (layers F.Cu F.Paste F.Mask) (net 1 GND))
+    (pad 2 smd rect (at 0.8 0) (size 0.9 0.8) (layers F.Cu F.Paste F.Mask) (net 2 SIG))
+  )
+  (module R_0603 (layer F.Cu) (tedit 0) (at 12 5)
+    (fp_text reference R2 (at 0 0) (layer F.SilkS))
+    (pad 2 smd rect (at -0.8 0) (size 0.9 0.8) (layers F.Cu F.Paste F.Mask) (net 2 SIG))
+    (pad 1 smd rect (at 0.8 0) (size 0.9 0.8) (layers F.Cu F.Paste F.Mask) (net 1 GND))
+  )
+  (segment (start 5.8 5) (end 11.2 5) (width 0.25) (layer F.Cu) (net 2))
+  (segment (start 4.2 5) (end 12.8 5) (width 0.25) (layer B.Cu) (net 1))
+)
+"""
+
 
 def write_board(tmp_path: Path, name: str, text: str) -> Path:
     path = tmp_path / f"{name}.kicad_pcb"
@@ -280,11 +313,29 @@ class TestFeatureExtraction:
         assert keepout.multi_pad_nets_with_copper == 1
         assert keepout.routed_net_fraction == pytest.approx(0.5)
 
-    def test_legacy_module_board_parses_but_yields_no_pads(self, tmp_path: Path) -> None:
+    def test_legacy_module_board_yields_its_component_graph(self, tmp_path: Path) -> None:
+        """Pre-KiCad-6 ``(module ...)`` boards keep their pads (issue #4873).
+
+        This test used to pin the *defect* (``footprints == 0 and pads == 0``):
+        the parser read ``(footprint ...)`` only, so 9 of the 22 pinned corpus
+        boards silently lost their entire component graph. The parser now
+        treats ``module`` as the legacy spelling of ``footprint``, so the graph
+        survives -- while ``legacy_module_tokens`` keeps counting the dialect,
+        which is still worth reporting as a provenance signal.
+        """
         f = features(tmp_path, "legacy", LEGACY_MODULE_BOARD)
-        assert f.footprints == 0 and f.pads == 0
-        assert f.legacy_module_tokens == 1, "the (module ...) token is the diagnosable cause"
-        assert f.segments == 1, "copper still parses -- only the component graph is missing"
+        assert f.footprints == 1 and f.pads == 1
+        assert f.netted_pads == 1, "the pad's (net 1 GND) binding survives the alias"
+        assert f.legacy_module_tokens == 1, "the dialect is still counted, just no longer fatal"
+        assert f.segments == 1
+
+    def test_legacy_module_board_can_be_a_full_benchmark_case(self, tmp_path: Path) -> None:
+        """The census payoff: a routed legacy board is now fully featurizable."""
+        f = features(tmp_path, "legacy-routed", LEGACY_MODULE_ROUTED_BOARD)
+        assert (f.footprints, f.pads, f.netted_pads) == (2, 4, 4)
+        assert f.multi_pad_nets == 2
+        assert f.multi_pad_nets_with_trace_copper == 2
+        assert f.routed_net_fraction == pytest.approx(1.0)
 
     def test_missing_outline_yields_zero_area_without_raising(self, tmp_path: Path) -> None:
         f = features(tmp_path, "no-outline", board_text(outline="none", copper=SIG_TRACE))
@@ -373,11 +424,41 @@ class TestVerdicts:
         assert verdict.capacity_features and not verdict.capacity_labeled
         assert verdict.harness_blockers == [BLOCK_NO_REFERENCE_COPPER]
 
-    def test_legacy_module_board_names_the_fixable_cause(self, tmp_path: Path) -> None:
+    def test_legacy_module_board_is_no_longer_schema_blocked(self, tmp_path: Path) -> None:
+        """#4873: the dialect no longer costs the board its component graph.
+
+        The one-pad fixture still fails the *net-binding* gate (nothing to
+        route), but that is a property of the board, not of the parser -- the
+        two parser blockers must be gone.
+        """
         verdict = evaluate(features(tmp_path, "legacy", LEGACY_MODULE_BOARD))
+        assert verdict.capacity_blockers == [BLOCK_NO_NET_BINDING]
+        assert BLOCK_NO_PAD_GRAPH not in verdict.capacity_blockers
+        assert BLOCK_LEGACY_MODULE_SCHEMA not in verdict.capacity_blockers
+
+    def test_routed_legacy_module_board_is_a_harness_candidate(self, tmp_path: Path) -> None:
+        verdict = evaluate(features(tmp_path, "legacy-routed", LEGACY_MODULE_ROUTED_BOARD))
+        assert verdict.capacity_blockers == []
+        assert verdict.label == LABEL_COMPLETE
+        assert verdict.capacity_features and verdict.capacity_labeled
+        assert verdict.harness_candidate
+
+    def test_a_dialect_that_still_parses_to_nothing_names_itself(self) -> None:
+        """The legacy-schema diagnostic stays live for the *next* dialect.
+
+        Keyed on zero footprints (not zero pads) since #4873: a board whose
+        modules parse but carry no pads is a mechanical board, while a board
+        that yields no footprints at all while the raw text is full of
+        ``(module ...)`` tokens is still parser work, and saying so keeps it
+        out of the generic ``no-pad-graph`` bucket.
+        """
+        verdict = evaluate(
+            BoardFeatures(board_id="future-dialect", footprints=0, pads=0, legacy_module_tokens=7)
+        )
         assert verdict.label == LABEL_NONE
         assert not verdict.capacity_features
-        assert verdict.capacity_blockers == [BLOCK_NO_PAD_GRAPH, BLOCK_LEGACY_MODULE_SCHEMA]
+        assert BLOCK_NO_PAD_GRAPH in verdict.capacity_blockers
+        assert BLOCK_LEGACY_MODULE_SCHEMA in verdict.capacity_blockers
 
     def test_pads_without_nets_are_a_distinct_blocker(self, tmp_path: Path) -> None:
         verdict = evaluate(features(tmp_path, "mech", board_text(nets=False)))
@@ -541,7 +622,7 @@ class TestCensus:
         assert totals["pour_dependent_candidates"] == 1
 
         assert report["by_label"] == {LABEL_COMPLETE: 2, LABEL_PARTIAL: 1, LABEL_NONE: 1}
-        assert report["blockers"][BLOCK_LEGACY_MODULE_SCHEMA] == 1
+        assert report["blockers"][BLOCK_NO_NET_BINDING] == 1
         assert report["blockers"][BLOCK_PARTIAL_REFERENCE_ROUTING] == 1
         assert report["candidate_profile"]["count"] == 2
         assert [b["board_id"] for b in report["boards"]] == sorted(
@@ -558,7 +639,7 @@ class TestCensus:
     def test_render_names_every_blocker_and_board(self, tmp_path: Path) -> None:
         boards, verdicts = self._mixed(tmp_path)
         text = render_census(census(boards, verdicts))
-        assert BLOCK_LEGACY_MODULE_SCHEMA in text
+        assert BLOCK_NO_NET_BINDING in text
         assert BLOCK_PARTIAL_REFERENCE_ROUTING in text
         for board in boards:
             assert board.board_id in text

--- a/tests/test_pcb.py
+++ b/tests/test_pcb.py
@@ -4710,3 +4710,185 @@ class TestGraphicArcLegacyCenterAngle:
         issue fixes)."""
         arc = self._parse_arc('(gr_arc (start 2 0) (end 0 2) (layer "Edge.Cuts") (width 0.05))')
         assert arc.mid == (0.0, 0.0)
+
+
+LEGACY_MODULE_BOARD = """(kicad_pcb (version 4) (host pcbnew "(2017-11-30)")
+  (general (thickness 1.6))
+  (page A4)
+  (layers (0 F.Cu signal) (31 B.Cu signal) (44 Edge.Cuts user))
+  (net 0 "")
+  (net 1 GND)
+  (net 2 SIG)
+  (gr_line (start 0 0) (end 20 0) (layer Edge.Cuts) (width 0.05))
+  (gr_line (start 20 0) (end 20 10) (layer Edge.Cuts) (width 0.05))
+  (gr_line (start 20 10) (end 0 10) (layer Edge.Cuts) (width 0.05))
+  (gr_line (start 0 10) (end 0 0) (layer Edge.Cuts) (width 0.05))
+  (module R_0603 (layer F.Cu) (tedit 5A1F2B3C) (at 5 5)
+    (attr smd)
+    (fp_text reference R1 (at 0 1.5) (layer F.SilkS))
+    (fp_text value 10K (at 0 -1.5) (layer F.Fab))
+    (pad 1 smd rect (at -0.8 0) (size 0.9 0.8) (layers F.Cu F.Paste F.Mask) (net 1 GND))
+    (pad 2 smd rect (at 0.8 0) (size 0.9 0.8) (layers F.Cu F.Paste F.Mask) (net 2 SIG))
+  )
+  (module C_0402 (layer B.Cu) (tedit 5A1F2B3D) (at 12 5 90)
+    (fp_text reference C1 (at 0 1.5) (layer B.SilkS))
+    (pad 1 smd rect (at -0.5 0) (size 0.6 0.6) (layers B.Cu B.Paste B.Mask) (net 2 SIG))
+  )
+  (segment (start 4.2 5) (end 12.8 5) (width 0.25) (layer F.Cu) (net 1))
+)
+"""
+
+
+class TestLegacyModuleBoards:
+    """Pre-KiCad-6 ``(module ...)`` boards are footprints too (issue #4873).
+
+    KiCad 6 renamed the block; boards written by the pcbnew 5.x line (still a
+    large share of the public corpus) use the old spelling.  Before the fix
+    these boards parsed their nets/segments fine and reported **zero
+    footprints and zero pads** with no error -- a data-shaped wrong answer.
+    """
+
+    def _write(self, tmp_path: Path, text: str, name: str = "legacy") -> Path:
+        path = tmp_path / f"{name}.kicad_pcb"
+        path.write_text(text, encoding="utf-8")
+        return path
+
+    def test_module_blocks_parse_as_footprints(self, tmp_path: Path):
+        pcb = PCB.load(self._write(tmp_path, LEGACY_MODULE_BOARD))
+
+        assert pcb.footprint_count == 2
+        assert [fp.reference for fp in pcb.footprints] == ["R1", "C1"]
+
+        r1 = pcb.get_footprint("R1")
+        assert r1 is not None
+        assert r1.name == "R_0603"
+        assert r1.value == "10K"
+        assert r1.layer == "F.Cu"
+        assert r1.position == (5.0, 5.0)
+        assert r1.attr == "smd"
+
+        c1 = pcb.get_footprint("C1")
+        assert c1 is not None
+        assert c1.layer == "B.Cu"
+        assert c1.rotation == 90.0
+
+    def test_module_pads_carry_position_net_and_layer(self, tmp_path: Path):
+        pcb = PCB.load(self._write(tmp_path, LEGACY_MODULE_BOARD))
+
+        r1 = pcb.get_footprint("R1")
+        assert r1 is not None
+        assert len(r1.pads) == 2
+
+        pad1, pad2 = r1.pads
+        assert (pad1.number, pad2.number) == ("1", "2")
+        assert pad1.position == (-0.8, 0.0)
+        assert (pad1.net_number, pad1.net_name) == (1, "GND")
+        assert (pad2.net_number, pad2.net_name) == (2, "SIG")
+        assert pad1.layers == ["F.Cu", "F.Paste", "F.Mask"]
+
+        # Absolute board position resolves through the footprint origin.
+        assert pcb.get_pad_position("R1", "1") == pytest.approx((4.2, 5.0))
+
+    def test_no_parse_warning_when_the_graph_is_readable(self, tmp_path: Path):
+        pcb = PCB.load(self._write(tmp_path, LEGACY_MODULE_BOARD))
+        assert pcb.parse_warnings == []
+
+    def test_position_sync_writes_back_into_the_module_node(self, tmp_path: Path):
+        """Editing a module-sourced footprint persists across save/reload."""
+        path = self._write(tmp_path, LEGACY_MODULE_BOARD)
+        pcb = PCB.load(path)
+
+        r1 = pcb.get_footprint("R1")
+        assert r1 is not None
+        r1.position = (7.5, 6.25)
+
+        out = tmp_path / "moved.kicad_pcb"
+        pcb.save(out)
+
+        reloaded = PCB.load(out)
+        moved = reloaded.get_footprint("R1")
+        assert moved is not None
+        assert moved.position == (7.5, 6.25)
+        assert len(moved.pads) == 2, "pads survive the round-trip"
+        assert reloaded.footprint_count == 2
+
+    def test_update_reference_and_value_find_the_module_node(self, tmp_path: Path):
+        path = self._write(tmp_path, LEGACY_MODULE_BOARD)
+        pcb = PCB.load(path)
+
+        assert pcb.update_footprint_reference("R1", "R99") is True
+        assert pcb.update_footprint_value("R99", "22K") is True
+
+        out = tmp_path / "renamed.kicad_pcb"
+        pcb.save(out)
+
+        reloaded = PCB.load(out)
+        assert reloaded.get_footprint("R1") is None
+        renamed = reloaded.get_footprint("R99")
+        assert renamed is not None
+        assert renamed.value == "22K"
+
+    def test_remove_footprint_deletes_the_module_node(self, tmp_path: Path):
+        path = self._write(tmp_path, LEGACY_MODULE_BOARD)
+        pcb = PCB.load(path)
+
+        assert pcb.remove_footprint("R1") is True
+        assert pcb.footprint_count == 1
+
+        out = tmp_path / "removed.kicad_pcb"
+        pcb.save(out)
+
+        text = out.read_text(encoding="utf-8")
+        assert "R_0603" not in text, "the (module ...) node itself must be gone"
+
+        reloaded = PCB.load(out)
+        assert reloaded.footprint_count == 1
+        assert reloaded.get_footprint("R1") is None
+        assert reloaded.get_footprint("C1") is not None
+
+    def test_modern_footprint_boards_are_unaffected(self, minimal_pcb: Path):
+        """The alias must not perturb the modern ``(footprint ...)`` path."""
+        pcb = PCB.load(minimal_pcb)
+        assert pcb.footprint_count > 0
+        assert pcb.parse_warnings == []
+
+
+class TestUnreadableComponentGraphIsLoud:
+    """No silent zero: a pad graph we cannot read must announce itself (#4873).
+
+    The ``(module ...)`` defect was invisible because the parse dispatch has
+    no fallback -- an unrecognised container tag fell through and the board
+    reported zero footprints with no signal at all.  The guard is generic, so
+    a *future* unknown container is loud instead of data-shaped.
+    """
+
+    UNKNOWN_CONTAINER_BOARD = """(kicad_pcb (version 3)
+  (layers (0 F.Cu signal) (31 B.Cu signal))
+  (net 0 "")
+  (net 1 GND)
+  (component_v0 R_0603 (layer F.Cu) (at 5 5)
+    (fp_text reference R1 (at 0 0) (layer F.SilkS))
+    (pad 1 smd rect (at -0.8 0) (size 0.9 0.8) (layers F.Cu) (net 1 GND))
+  )
+)
+"""
+
+    def test_unknown_container_with_pads_warns(self, tmp_path: Path, caplog):
+        path = tmp_path / "unknown.kicad_pcb"
+        path.write_text(self.UNKNOWN_CONTAINER_BOARD, encoding="utf-8")
+
+        with caplog.at_level("WARNING", logger="kicad_tools.schema.pcb"):
+            pcb = PCB.load(path)
+
+        assert pcb.footprint_count == 0
+        assert len(pcb.parse_warnings) == 1
+        message = pcb.parse_warnings[0]
+        assert "component_v0" in message, "name the container tag we could not read"
+        assert "version 3" in message, "name the declared board version"
+        assert message in caplog.text, "the warning must also reach the log"
+
+    def test_component_free_board_stays_quiet(self):
+        """A genuinely padless board (panel frame, outline fixture) is fine."""
+        pcb = PCB.create(width=50.0, height=50.0)
+        assert pcb.footprint_count == 0
+        assert pcb.parse_warnings == []


### PR DESCRIPTION
Closes #4873

## The defect

KiCad 6 renamed the component block from `(module …)` to `(footprint …)`.
`PCB._parse()` dispatches on `child.tag` through an `elif` chain that matched
the modern spelling only — and has **no `else` arm**. A pre-KiCad-6 board
therefore parsed its nets, segments, vias, zones and graphics fine while its
**entire component graph vanished**: `footprint_count() == 0`, zero pads, no
error, no warning, no version signal. A data-shaped wrong answer, not a crash —
every downstream consumer (routing, DRC, LVS, BOM) reads it as "this board has
no parts."

## The fix — option (a), the alias

`module` is accepted as the legacy spelling of `footprint` throughout
`src/kicad_tools/schema/pcb.py`, behind a single `FOOTPRINT_TAGS` constant and
an `_is_footprint_tag()` helper. As the issue's sub-form audit predicted, **no
sub-form translation was needed**: `pad` / `at` / `layer` / `fp_text reference`
/ `fp_text value` / `attr` are spelled identically on both sides of the rename,
and `Footprint.from_sexp()` is unchanged.

Crucially this is not just the parse dispatch. Every tree walk that keys on the
tag was updated, so a module-sourced board is **editable**, not merely
readable — a grep for `== "footprint"` / `!= "footprint"` / `find_all("footprint")`
in the module now returns nothing but the constant itself:

- `_parse()` dispatch
- `_link_footprint_sexp_nodes()` (position sync back-reference)
- `_translate_footprint_sexp()` call site (board-origin translation)
- `_find_footprint_sexp()` → new `_iter_footprint_sexps()` helper, which
  preserves `find_all` semantics (descendants, document order) across both tags
  — this is what `remove_footprint()` and pad-position updates use
- `update_footprint_reference` / `update_footprint_value` /
  reference-visibility / `move_reference` / text-font / text-layer walks
- the "insert a net before the first footprint" fallback

The save path deliberately leaves the `(module …)` token in place: we recover
the graph without silently rewriting the caller's file format.

## No silent-zero path remains

The `(module …)` bug was invisible *because* the dispatch had no fallback, so
the guard is generic rather than module-specific: after parsing, a board that
plainly carries `(pad …)` nodes but produced **no footprint at all** now logs a
`logger.warning` naming the declared version and the unreadable container tag,
and records it in the new public `PCB.parse_warnings` list. A *future* unknown
component container is therefore loud, not data-shaped. Genuinely padless
boards (panel frames, outline fixtures) stay quiet, and the check early-returns
before any tree walk on the normal path, so it costs nothing on a healthy load.
Pinned by `TestUnreadableComponentGraphIsLoud`; verified silent on all 22
cached corpus boards.

`kct check` was left alone — a new sub-check is disproportionate here, and the
`logger.warning` already reaches stderr for every `kct` command (the CLI
installs no logging handler, so Python's last-resort handler prints WARNING+).

## Corpus census validation (AC option (a) — actually run)

Ran `scripts/corpus/benchmark_readiness.py` in this worktree against the pinned
payload cache (copied in read-only from the issue-4830 worktree; nothing was
written outside this worktree, and `scripts/corpus/.cache/` is gitignored).
Before-numbers are the pre-fix report from that same cache
(`benchmark-readiness-20260816T030953Z.json`), i.e. the same 22 boards:

| Census figure | Before | After |
|---|---|---|
| `legacy-module-schema` blockers | 9 | **0** |
| `no-pad-graph` blockers | 9 | **0** |
| featurizable boards (#4799) | 10 / 22 (45.5%) | **18 / 22 (81.8%)** |
| labeled calibration examples | 8 (36.4%) | **16 (72.7%)** |
| route-vs-human cases | 8 (36.4%) | **16 (72.7%)** |
| `human-routed` label | 8 | **16** |
| `unusable` label | 12 | **4** |

The recovered boards are substantial, not toys — e.g. `os-0070757-pcb1`
(version `4`, 869 pads, 150 multi-pad nets, 280 cm², fully human-routed) and
`os-0064015-pcb0` (version `20170901`, 835 pads, 6 layers). The four remaining
`unusable` boards fail for causes the issue already separates out:
`no-net-binding` ×2 and `no-reference-copper` ×2 are properties of those
designs; `no-outline` ×1; `outline-not-polygonal` ×1 is the legacy centre+angle
`gr_arc` defect, **#4874**, deliberately out of scope here.

Two small companion changes fall out of that measurement:

- `scripts/corpus/benchmark_readiness.py` — the `legacy-module-schema`
  diagnostic is re-keyed from "zero **pads**" to "zero **footprints** + legacy
  tokens". Post-fix, a legacy board whose modules simply carry no pads is a
  mechanical board, not a parse gap; the blocker stays live so the *next*
  unreadable dialect still names itself instead of hiding in `no-pad-graph`.
- `docs/research/corpus-benchmark-feasibility.md` — an update banner with the
  before/after table. The body is left as the pre-fix record of why the fix was
  worth making.

## Tests

- `tests/test_pcb.py` — new `TestLegacyModuleBoards` (7 tests): module blocks
  parse to real `Footprint`s with reference/value/layer/position/rotation/attr;
  pads carry position, net number+name and layers, and resolve through
  `get_pad_position`; position edit → `save()` → reload round-trips with pads
  intact; `update_footprint_reference` / `update_footprint_value` find the
  module node; `remove_footprint()` actually deletes it from the file; modern
  boards unaffected. Plus `TestUnreadableComponentGraphIsLoud` (2 tests).
- `tests/test_corpus_readiness.py` — `test_legacy_module_board_parses_but_yields_no_pads`
  **pinned the bug as expected behaviour** and is replaced by
  `test_legacy_module_board_yields_its_component_graph` (asserts
  `footprints == 1, pads == 1, netted_pads == 1`, and that
  `legacy_module_tokens` still counts the dialect as a provenance signal).
  Added a routed two-module fixture that is now a full harness candidate, a
  test that the legacy-schema *verdict* is gone, and a direct-`BoardFeatures`
  test keeping the diagnostic covered for a future dialect.

Results in this worktree: `tests/test_pcb.py` + `tests/test_corpus_readiness.py`
328 passed; the parser-adjacent slice (`-k "pcb or parse or sexp or schema or
footprint or corpus"`) 5481 passed / 13 skipped; ruff clean; mypy baseline OK
(1464 errors, all within the 1472 floor — no new type errors); `kct build-native`
built in the worktree.

## Noted, not fixed (out of scope)

Other modules still walk the tree with a bare `find_all("footprint")` —
`zones/fill_clearance.py`, `lvs/board_lvs.py`, `drc/repair_clearance.py`,
`drc/repair_silkscreen.py`, `panel/panel.py`, `cli/runner.py`. They were
already blind to these boards before this PR (nothing regresses), but a legacy
board now reaches them with a populated `pcb.footprints` while their own
S-expression walks still see none. Worth a follow-up issue in the same family
as #4872; not folded in here.
