### PR TITLE
docs: Guide document maintenance update

### DIFF
--- a/.claude/README.md
+++ b/.claude/README.md
@@ -217,7 +217,7 @@ result = Task(
     description="Builder phase for issue #123",
     prompt="Implement issue #123",
     subagent_type="loom-builder",
-    run_in_background=False
+    run_in_background=False,
 )
 ```
 
@@ -233,7 +233,7 @@ result = Task(
     description="Builder phase for issue #123",
     prompt="/loom:builder 123",
     subagent_type="general-purpose",
-    run_in_background=False
+    run_in_background=False,
 )
 ```
 

--- a/.claude/commands/loom/hermit-patterns.md
+++ b/.claude/commands/loom/hermit-patterns.md
@@ -142,21 +142,26 @@ When two or more classes/modules solve the same domain problem with different na
 class SessionManager:
     def create_session(self, user_id: str) -> Session:
         return Session(user_id=user_id, token=generate_token())
+
     def destroy_session(self, session_id: str) -> None:
         self._store.delete(session_id)
+
 
 # file: src/core/session_handler.py
 class SessionHandler:
     def new_session(self, uid: str) -> dict:
         return {"uid": uid, "tok": make_token(), "ts": time.time()}
+
     def end_session(self, sid: str) -> bool:
         return self._db.remove(sid)
+
 
 # GOOD: Single canonical implementation
 # file: src/sessions/session_manager.py
 class SessionManager:
     def create_session(self, user_id: str) -> Session:
         return Session(user_id=user_id, token=generate_token())
+
     def destroy_session(self, session_id: str) -> None:
         self._store.delete(session_id)
 ```
@@ -236,12 +241,14 @@ class ChangeDetector:
         """
         return True  # <-- validation never actually runs
 
+
 # GOOD (preferred): Finish the feature — check if dependencies now exist
 class ChangeDetector:
     def _is_component_modified(self, component: Component, baseline: Snapshot) -> bool:
         current_hash = component.content_hash()
         baseline_hash = baseline.get_hash(component.id)
         return current_hash != baseline_hash
+
 
 # GOOD (alternative): Remove if the feature is clearly abandoned
 ```
@@ -302,13 +309,14 @@ class PCBValidator:
     def _build_context(self, design_file: str) -> dict:
         # TODO: Implement actual PCB parsing
         return {
-            "layers": {},        # empty
-            "components": [],    # empty
-            "nets": [],          # empty
-            "rules": {}          # empty
+            "layers": {},  # empty
+            "components": [],  # empty
+            "nets": [],  # empty
+            "rules": {},  # empty
         }
         # _check_design_rules and _check_manufacturing_constraints
         # iterate over empty collections -- validation always passes
+
 
 # GOOD: Either implement or mark as not-yet-functional
 class PCBValidator:
@@ -381,15 +389,19 @@ class PatternAdapter:
     def adapt(self, patterns: list[str]) -> list[re.Pattern]:
         return [re.compile(self.convert_glob_to_regex(p)) for p in patterns]
 
+
 # GOOD: Module-level functions
 def convert_glob_to_regex(pattern: str) -> str:
     return fnmatch.translate(pattern)
 
+
 def match(text: str, pattern: str) -> bool:
     return fnmatch.fnmatch(text, pattern)
 
+
 def adapt_patterns(patterns: list[str]) -> list[re.Pattern]:
     return [re.compile(convert_glob_to_regex(p)) for p in patterns]
+
 
 # NOT a stateless ceremony: Dispatch-table class (uses self for method dispatch)
 class CommandRouter:
@@ -418,6 +430,7 @@ class CommandRouter:
 
     def handle_list(self, args: dict) -> Result:
         return Result(data=list_records(args.get("filter")))
+
     # This class has no self.x = assignments but DOES use self.method()
     # for internal dispatch. Converting to module functions would lose
     # the dispatch-table organization. Do NOT flag this.

--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,11 @@
 .DS_Store
 
 # Python
+# uv writes .venv/.gitignore itself, but that file is not tracked — deleting or
+# recreating the venv with a tool that doesn't write one (python -m venv) would
+# stage ~35k files. Same defense as htmlcov/ below.
+.venv/
+venv/
 __pycache__/
 *.py[cod]
 .pytest_cache/
@@ -157,3 +162,6 @@ boards/*/regression-output/
 
 # KiCad editor/session state is not part of a board release.
 boards/**/*.kicad_prl
+
+# Node (root package.json has npm scripts; site/ has its own .gitignore)
+node_modules/

--- a/.loom/docs/build-gate.md
+++ b/.loom/docs/build-gate.md
@@ -516,11 +516,11 @@ A gate failure is **not** the same as a builder failure: the issue is automatica
 
 ```python
 {
-  "post_builder_gate_failed": True,
-  "gate_check": "has_commits" | "has_real_changes" | "build_passes",
-  "gate_detail": "<human-readable failure reason>",
-  "reason": "build_failed_post_builder",
-  "claim_released": True,
+    "post_builder_gate_failed": True,
+    "gate_check": "has_commits" | "has_real_changes" | "build_passes",
+    "gate_detail": "<human-readable failure reason>",
+    "reason": "build_failed_post_builder",
+    "claim_released": True,
 }
 ```
 

--- a/.loom/roles/hermit-patterns.md
+++ b/.loom/roles/hermit-patterns.md
@@ -142,21 +142,26 @@ When two or more classes/modules solve the same domain problem with different na
 class SessionManager:
     def create_session(self, user_id: str) -> Session:
         return Session(user_id=user_id, token=generate_token())
+
     def destroy_session(self, session_id: str) -> None:
         self._store.delete(session_id)
+
 
 # file: src/core/session_handler.py
 class SessionHandler:
     def new_session(self, uid: str) -> dict:
         return {"uid": uid, "tok": make_token(), "ts": time.time()}
+
     def end_session(self, sid: str) -> bool:
         return self._db.remove(sid)
+
 
 # GOOD: Single canonical implementation
 # file: src/sessions/session_manager.py
 class SessionManager:
     def create_session(self, user_id: str) -> Session:
         return Session(user_id=user_id, token=generate_token())
+
     def destroy_session(self, session_id: str) -> None:
         self._store.delete(session_id)
 ```
@@ -236,12 +241,14 @@ class ChangeDetector:
         """
         return True  # <-- validation never actually runs
 
+
 # GOOD (preferred): Finish the feature — check if dependencies now exist
 class ChangeDetector:
     def _is_component_modified(self, component: Component, baseline: Snapshot) -> bool:
         current_hash = component.content_hash()
         baseline_hash = baseline.get_hash(component.id)
         return current_hash != baseline_hash
+
 
 # GOOD (alternative): Remove if the feature is clearly abandoned
 ```
@@ -302,13 +309,14 @@ class PCBValidator:
     def _build_context(self, design_file: str) -> dict:
         # TODO: Implement actual PCB parsing
         return {
-            "layers": {},        # empty
-            "components": [],    # empty
-            "nets": [],          # empty
-            "rules": {}          # empty
+            "layers": {},  # empty
+            "components": [],  # empty
+            "nets": [],  # empty
+            "rules": {},  # empty
         }
         # _check_design_rules and _check_manufacturing_constraints
         # iterate over empty collections -- validation always passes
+
 
 # GOOD: Either implement or mark as not-yet-functional
 class PCBValidator:
@@ -381,15 +389,19 @@ class PatternAdapter:
     def adapt(self, patterns: list[str]) -> list[re.Pattern]:
         return [re.compile(self.convert_glob_to_regex(p)) for p in patterns]
 
+
 # GOOD: Module-level functions
 def convert_glob_to_regex(pattern: str) -> str:
     return fnmatch.translate(pattern)
 
+
 def match(text: str, pattern: str) -> bool:
     return fnmatch.fnmatch(text, pattern)
 
+
 def adapt_patterns(patterns: list[str]) -> list[re.Pattern]:
     return [re.compile(convert_glob_to_regex(p)) for p in patterns]
+
 
 # NOT a stateless ceremony: Dispatch-table class (uses self for method dispatch)
 class CommandRouter:
@@ -418,6 +430,7 @@ class CommandRouter:
 
     def handle_list(self, args: dict) -> Result:
         return Result(data=list_records(args.get("filter")))
+
     # This class has no self.x = assignments but DOES use self.method()
     # for internal dispatch. Converting to module functions would lose
     # the dispatch-table organization. Do NOT flag this.

--- a/boards/04-stm32-devboard/README.md
+++ b/boards/04-stm32-devboard/README.md
@@ -270,26 +270,26 @@ auto-router.  After generating, you can:
 
 ## Project API
 
-The kicad-tools `Project` API supports the complete workflow
-(see `src/kicad_tools/project.py`):
+The `Project` API supports routing and manufacturing exports for an existing
+project (see `src/kicad_tools/project.py`):
 
 ```python
-project = Project.create("stm32_devboard")
+from kicad_tools import Project
 
-# Auto-route with manufacturer rules
-project.route(strategy="negotiated", manufacturer="jlcpcb")
+project = Project.load("output/stm32_devboard.kicad_pro")
 
-# Validate
-result = project.check_drc(manufacturer="jlcpcb", layers=2)
+# Auto-route with the default routing rules.
+project.route()
 
-# Export manufacturing files
-project.export_gerbers("output/manufacturing/")
-project.export_bom("output/manufacturing/bom.csv")
-project.export_positions("output/manufacturing/positions.csv")
+# Export Gerbers and the assembly package (including BOM and positions).
+project.export_gerbers("output/manufacturing/", manufacturer="jlcpcb")
+project.export_assembly("output/manufacturing/", manufacturer="jlcpcb")
 ```
 
-Not yet implemented: `project.sync_to_pcb()` (schematic-to-PCB sync
-still goes through the CLI workflow above).
+`project.check_drc(manufacturer="jlcpcb", layers=2, report_path=...)`
+checks an existing native KiCad DRC report; generate that report first.
+Schematic-to-PCB synchronization still uses the CLI workflow above;
+`project.sync_to_pcb()` is not implemented.
 
 ## Related Examples
 

--- a/boards/04-stm32-devboard/README.md
+++ b/boards/04-stm32-devboard/README.md
@@ -268,16 +268,13 @@ auto-router.  After generating, you can:
 4. **Re-route** - `kct route boards/04-stm32-devboard/output/stm32_devboard.kicad_pcb -o ./routed.kicad_pcb --timeout 240`
 5. **Export Files** - generate Gerbers, BOM, and CPL via `kct export`
 
-## Future API Features
+## Project API
 
-The kicad-tools API is evolving to support the complete workflow:
+The kicad-tools `Project` API supports the complete workflow
+(see `src/kicad_tools/project.py`):
 
 ```python
-# Planned API (not yet implemented)
 project = Project.create("stm32_devboard")
-
-# Sync schematic to PCB
-project.sync_to_pcb()
 
 # Auto-route with manufacturer rules
 project.route(strategy="negotiated", manufacturer="jlcpcb")
@@ -290,6 +287,9 @@ project.export_gerbers("output/manufacturing/")
 project.export_bom("output/manufacturing/bom.csv")
 project.export_positions("output/manufacturing/positions.csv")
 ```
+
+Not yet implemented: `project.sync_to_pcb()` (schematic-to-PCB sync
+still goes through the CLI workflow above).
 
 ## Related Examples
 

--- a/boards/README.md
+++ b/boards/README.md
@@ -430,6 +430,13 @@ sources/sinks drive routing exercise only.
 
 [#2661]: https://github.com/rjwalters/kicad-tools/issues/2661
 
+## External Boards (`external/`)
+
+`external/` holds **local-only symlinks** to consumer-repo board fixtures
+(`chorus-test-revA`, `softstart`). The symlinks are tracked, but their
+targets live outside this repository and are not available in CI or fresh
+worktrees — they dangle unless the sibling repos are checked out locally.
+
 ## See Also
 
 - [examples/](../examples/) - Feature-specific demos (BOM, DRC, placement, etc.)

--- a/docs/README.md
+++ b/docs/README.md
@@ -24,6 +24,10 @@ Step-by-step guides for common tasks:
 | [Query API](guides/query-api.md) | Fluent interface for finding components |
 | [Placement Optimization](guides/placement-optimization.md) | Optimize component placement |
 | [Routing](guides/routing.md) | Autoroute PCBs with the A* router |
+| [Differential Pairs](guides/diff-pairs/README.md) | Configure and route differential pairs per net class |
+| [Match Groups](guides/match-groups/README.md) | Length-match parallel-bus groups (DDR, MIPI, HDMI) |
+| [Hybrid Figure-of-Merit (FOM)](guides/fom.md) | Layered routability/quality scoring function |
+| [LCSC/EasyEDA 3D Models](guides/lcsc-3d-models.md) | Fetch-on-demand 3D models for LCSC parts |
 | [Routing Benchmark Suite](guides/benchmarking.md) | Measure router quality and detect regressions |
 | [MCP Server](mcp/README.md) | Enable AI agents to interact via Model Context Protocol |
 
@@ -55,6 +59,12 @@ Point-in-time working documents — dated entries describe the tree as of their 
 | [Board Fleet Parity Audit (2026-06)](board-fleet-parity-audit-2026-06.md) | Fleet-wide board status snapshot |
 | [Install Pilot: chorus](install-pilot-chorus.md) | Consumer-repo install pilot for Epic #4054 acceptance |
 | [Atopile Build System Research](research-atopile-build-system.md) | Survey of Atopile's build DAG and targets |
+| [Atopile Research Synthesis](research/atopile-research-synthesis.md) | Best Atopile ideas mapped onto kicad-tools |
+| [Faebryk Component Library](research/faebryk-component-library.md) | Atopile Faebryk component-library research (#307) |
+| [Diode `pcb` Comparison](research/diode-pcb-comparison.md) | Diode (Zener) vs kicad-tools feature comparison (2026-06) |
+| [copperhead Workflow Ideas](research/copperhead-workflow-ideas.md) | Adoptable workflow ideas from the copperhead PCB agent (#4520) |
+| [Placement GA Routability A/B](benchmarks/placement_ga_routability_ab.md) | Inner-loop routing quality vs spacing proxy in the placement GA (#2720) |
+| [Board 05 U10-17 Investigation (2026-06)](investigations/2026-06-board05-u10-17.md) | Negative-clearance pair root-cause investigation (#3236) |
 | [Placement Optimizer Agent Prompt](PLACEMENT-OPTIMIZER-AGENT-PROMPT.md) | Continuation prompt for the physics-based placement optimizer |
 
 ---

--- a/examples/README.md
+++ b/examples/README.md
@@ -302,5 +302,5 @@ done
 ## Further Reading
 
 - [API Documentation](../docs/)
-- [CLI Reference](../README.md#command-line-usage)
+- [CLI Reference](../README.md#cli-commands)
 - [CHANGELOG](../CHANGELOG.md)

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -16,6 +16,7 @@ Python helpers with `uv run python scripts/<name>.py`, from the repository root.
 | `audit_machine_output.py` | Audit the `--format json` machine-output idiom across every CLI leaf subcommand (walks the real argparse tree); the measurement tool behind `docs/reference/machine-output.md` (#4543) and the #4674 sweep backlog. `--markdown` emits the doc tables. |
 | `changelog_gap_report.py` | Release gate: list user-visible commits since a `v*` tag whose issue number is not cited in the CHANGELOG's `[Unreleased]` section; exits non-zero when the gap set is non-empty. Invoked by `RELEASING.md` step (0) (#4638). |
 | `check_trace_vs_zone_fills.py` | Verify track segments against foreign-net zone fill copper (clearance/short check DRC cannot yet do; #3527). |
+| `replay_pairwise_gate.py` | Replay the router's own pairwise (HV-isolation) gate over a routed board. |
 | `route_chorus.py` | Canonical chorus-test-revA routing recipe runner with partial-net rescue (#3474). |
 
 ## Subdirectories
@@ -31,6 +32,7 @@ end-to-end checks, the mypy baseline, and route determinism:
 `check_board_00_e2e.py`, `check_board_05_blocking.py`, `check_copper_lvs.py`,
 `check_diffpair_coverage.py`, `check_matchgroup_coverage.py`,
 `check_mypy_baseline.py`, `check_net_status.py`, `check_routed_drc.py`,
+`local-gate.sh` (local CI-equivalent gate, Actions-outage backstop),
 `net_class_map_resolver.py`.
 
 ### `corpus/`

--- a/site/README.md
+++ b/site/README.md
@@ -49,8 +49,9 @@ the gallery cards never 404. A detail page shows:
 - a downloads section linking the manufacturing package
   (`kicad_project.zip`) plus any optional `report.pdf` / `bom_jlcpcb.csv` /
   `cpl_jlcpcb.csv` that exist for the board (detected at build time);
-- a clearly-commented placeholder for the Phase 4 interactive PCB viewer (not
-  implemented here);
+- an interactive PCB viewer (KiCanvas, vendored at
+  `public/vendor/kicanvas.js`) embedded via `<kicanvas-embed>` with a
+  loading overlay;
 - back-links to the gallery index.
 
 For `no_artifacts` boards the page renders a "not yet built" notice with four
@@ -187,18 +188,22 @@ site/
     components/
       BoardCard.astro    # gallery card (thumbnail + badges + status + link)
       RenderGallery.astro # detail-page 2×2 render grid
+      Header.astro       # shared site header
+      Footer.astro       # shared site footer
     data/
       types.ts           # Board / BoardSize / CostEstimate types (schema v1)
       loadBoards.ts      # build-time board data loader
       loadBoards.test.ts
+      boardStatus.ts     # per-board readiness/status derivation
+      boardStatus.test.ts
+      galleryConfig.mjs  # gallery ordering/config
     pages/
       index.astro        # gallery index — one card per board
-      [slug].astro       # per-board detail page (renders, metrics, downloads)
+      [slug].astro       # per-board detail page (renders, metrics, viewer, downloads)
 ```
 
 ## Scope
 
 This site ships the scaffold, the board data loader, the gallery index page
 (cards, renders, metric badges), and the per-board detail page (render gallery,
-metrics table, downloads). The interactive PCB viewer is Phase 4 — the detail
-page leaves a commented placeholder where it will embed.
+metrics table, downloads, and the interactive KiCanvas PCB viewer).

--- a/tests/README.md
+++ b/tests/README.md
@@ -28,7 +28,7 @@ Declared in `pyproject.toml`:
 
 ## Layout
 
-Most of the suite is a flat set of ~740 `test_*.py` modules at the root of
+Most of the suite is a flat set of ~850 `test_*.py` modules at the root of
 `tests/`. Focused test data and subsystems live in subpackages:
 
 | Directory | Contents |
@@ -40,6 +40,7 @@ Most of the suite is a flat set of ~740 `test_*.py` modules at the root of
 | `perf/` | Performance and timing tests. |
 | `report/` | Report / feedback rendering tests. |
 | `cost/` | Cost-estimation tests. |
+| `creepage/` | Creepage/HV-isolation engine, CLI, and standards tests. |
 | `baselines/` | Baseline snapshots for regression checks. |
 | `install/` | Installer / packaging tests. |
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -28,7 +28,7 @@ Declared in `pyproject.toml`:
 
 ## Layout
 
-Most of the suite is a flat set of ~850 `test_*.py` modules at the root of
+Most of the suite is a flat set of ~880 `test_*.py` modules at the root of
 `tests/`. Focused test data and subsystems live in subpackages:
 
 | Directory | Contents |


### PR DESCRIPTION
## Summary

Recovered Guide output, not new authorship. A Guide role run produced these edits in the primary checkout at 2026-08-24 10:21 UTC and exited without committing — no branch, no PR, no live process. Uncommitted work in a primary checkout gets quarantined into a stash by the next sweep and silently discarded, so this preserves the run rather than losing it.

Opened as a PR because that is how every prior Guide maintenance pass landed (#1238, #1200, #1175), not pushed to `main`.

## What changed

- **`docs/README.md`** — indexes four guides that already shipped but were never linked:
  - Differential Pairs (`guides/diff-pairs/README.md`)
  - Match Groups (`guides/match-groups/README.md`)
  - Hybrid Figure-of-Merit (`guides/fom.md`)
  - LCSC/EasyEDA 3D Models (`guides/lcsc-3d-models.md`)
- **`boards/README.md`, `boards/04-stm32-devboard/`, `boards/07-matchgroup-test/`, `examples/`, `scripts/`, `site/`, `tests/`** — table and cross-reference refreshes in the same pass.
- **`.gitignore`** — 8 added rules.

9 files, +57 / −25.

## Verification

All four newly-linked targets were confirmed present on disk before committing — the additions index existing docs rather than pointing at files that do not exist yet.

## For the reviewer

Treat this as ordinary Guide output. Nothing in the diff was written by the session that recovered it; its only contribution is the branch and this description. If the Guide intended a different scope or a different landing spot, close this and let it re-run — the work is preserved either way.