### PR TITLE
feat(build-native): MSVC/Windows support for kct build-native

### DIFF
--- a/src/kicad_tools/cli/build_native_cmd.py
+++ b/src/kicad_tools/cli/build_native_cmd.py
@@ -76,9 +76,7 @@ def _find_msvc() -> str | None:
         return cl
 
     # vswhere canonical location (unchanged since VS 2017)
-    vswhere_default = Path(
-        "C:/Program Files (x86)/Microsoft Visual Studio/Installer/vswhere.exe"
-    )
+    vswhere_default = Path("C:/Program Files (x86)/Microsoft Visual Studio/Installer/vswhere.exe")
     vswhere = shutil.which("vswhere") or (
         str(vswhere_default) if vswhere_default.exists() else None
     )

--- a/src/kicad_tools/cli/build_native_cmd.py
+++ b/src/kicad_tools/cli/build_native_cmd.py
@@ -56,14 +56,66 @@ def _check_cmake() -> tuple[bool, str | None]:
     if not cmake_path:
         return (
             False,
-            "cmake not found. Install with: brew install cmake (macOS) or apt install cmake (Linux)",
+            "cmake not found. Install with: brew install cmake (macOS),"
+            " apt install cmake (Linux), or winget install cmake (Windows).",
         )
     return True, cmake_path
 
 
+def _find_msvc() -> str | None:
+    """Return the path to cl.exe if MSVC is available, otherwise None.
+
+    Detection order:
+    1. ``cl.exe`` already on PATH (vcvars activated or installed in PATH).
+    2. ``vswhere.exe`` (ships with every VS 2017+ and Build Tools install) to
+       locate the latest VS that ships the C++ desktop workload, then resolve
+       cl.exe from that installation root.
+    """
+    cl = shutil.which("cl")
+    if cl:
+        return cl
+
+    # vswhere canonical location (unchanged since VS 2017)
+    vswhere_default = Path(
+        "C:/Program Files (x86)/Microsoft Visual Studio/Installer/vswhere.exe"
+    )
+    vswhere = shutil.which("vswhere") or (
+        str(vswhere_default) if vswhere_default.exists() else None
+    )
+    if not vswhere:
+        return None
+
+    try:
+        # ``-products *`` is required so vswhere also searches Build Tools
+        # installations (not just VS IDE products).
+        result = subprocess.run(
+            [
+                vswhere,
+                "-latest",
+                "-products",
+                "*",
+                "-requires",
+                "Microsoft.VisualStudio.Component.VC.Tools.x86.x64",
+                "-find",
+                "VC/Tools/MSVC/*/bin/Hostx64/x64/cl.exe",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        if result.returncode == 0:
+            lines = [l.strip() for l in result.stdout.splitlines() if l.strip()]
+            if lines:
+                return lines[0]
+    except (subprocess.TimeoutExpired, FileNotFoundError, OSError):
+        pass
+
+    return None
+
+
 def _check_compiler() -> tuple[bool, str | None]:
     """Check if a C++20 compiler is available."""
-    # Check for clang++ or g++
+    # Check for clang++ or g++ (macOS / Linux)
     for compiler in ["clang++", "g++"]:
         path = shutil.which(compiler)
         if path:
@@ -79,9 +131,17 @@ def _check_compiler() -> tuple[bool, str | None]:
                 return True, path
             except (subprocess.TimeoutExpired, FileNotFoundError, subprocess.CalledProcessError):
                 continue
+
+    # Check for MSVC cl.exe (Windows)
+    msvc = _find_msvc()
+    if msvc:
+        return True, msvc
+
     return (
         False,
-        "C++20 compiler not found. Install Xcode Command Line Tools (macOS) or build-essential (Linux)",
+        "C++20 compiler not found. Install Xcode Command Line Tools (macOS),"
+        " build-essential (Linux), or Visual Studio Build Tools with the"
+        " 'Desktop development with C++' workload (Windows).",
     )
 
 
@@ -472,6 +532,12 @@ def build_native(
             f"-Dnanobind_DIR={nanobind_cmake}",
             "-DCMAKE_BUILD_TYPE=Release",
         ]
+
+        # On Windows with MSVC the Visual Studio generator is selected
+        # automatically; request x64 explicitly so the output .pyd matches the
+        # (almost certainly 64-bit) Python interpreter.
+        if sys.platform == "win32" and _find_msvc():
+            cmake_args.extend(["-A", "x64"])
 
         configure_result = subprocess.run(
             cmake_args,

--- a/src/kicad_tools/placement/cpp/CMakeLists.txt
+++ b/src/kicad_tools/placement/cpp/CMakeLists.txt
@@ -37,7 +37,8 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 # Compiler flags
 if(MSVC)
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /std:c++20 /Zc:__cplusplus /O2")
+    # /D_USE_MATH_DEFINES: expose M_PI and friends from <cmath> on MSVC.
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /std:c++20 /Zc:__cplusplus /O2 /D_USE_MATH_DEFINES")
 else()
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O2")
 endif()

--- a/tests/test_build_native_msvc.py
+++ b/tests/test_build_native_msvc.py
@@ -7,10 +7,7 @@ with mocks -- no real compiler or vswhere is invoked.
 from __future__ import annotations
 
 import subprocess
-from pathlib import Path
 from unittest import mock
-
-import pytest
 
 import kicad_tools.cli.build_native_cmd as bnc
 
@@ -18,12 +15,8 @@ import kicad_tools.cli.build_native_cmd as bnc
 class TestFindMsvc:
     def test_returns_none_when_no_cl_and_no_vswhere(self, monkeypatch):
         monkeypatch.setattr(bnc.shutil, "which", lambda name: None)
-        # Patch the default vswhere path so it looks non-existent.
-        monkeypatch.setattr(
-            bnc,
-            "_find_msvc",
-            lambda: None,  # bypass filesystem check in Path.exists
-        )
+        # Default vswhere path looks non-existent -> no vswhere anywhere.
+        monkeypatch.setattr(bnc.Path, "exists", lambda self: False)
         assert bnc._find_msvc() is None
 
     def test_cl_on_path_takes_priority(self, monkeypatch):
@@ -35,12 +28,13 @@ class TestFindMsvc:
         )
         assert bnc._find_msvc() == fake_cl
 
-    def test_vswhere_fallback_returns_cl_path(self, monkeypatch, tmp_path):
-        # cl is not on PATH.
-        monkeypatch.setattr(bnc.shutil, "which", lambda name: None)
-
-        # Create a fake vswhere that prints a cl.exe path.
+    def test_vswhere_fallback_returns_cl_path(self, monkeypatch):
+        # cl is not on PATH and vswhere isn't on PATH either, so _find_msvc
+        # must fall back to the well-known default vswhere.exe location.
         fake_cl = r"C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\VC\Tools\MSVC\14.43.0\bin\Hostx64\x64\cl.exe"
+
+        monkeypatch.setattr(bnc.shutil, "which", lambda name: None)
+        monkeypatch.setattr(bnc.Path, "exists", lambda self: True)
 
         def fake_run(args, **kwargs):
             m = mock.MagicMock()
@@ -48,47 +42,13 @@ class TestFindMsvc:
             m.stdout = fake_cl + "\n"
             return m
 
-        # Make _find_msvc believe vswhere exists at the well-known path.
-        fake_vswhere = tmp_path / "vswhere.exe"
-        fake_vswhere.touch()
-        monkeypatch.setattr(
-            bnc,
-            "_find_msvc",
-            # Real implementation; patch only the external calls.
-            bnc._find_msvc.__wrapped__ if hasattr(bnc._find_msvc, "__wrapped__") else bnc._find_msvc,
-        )
-
-        original_find_msvc = bnc._find_msvc
-
-        def patched_find_msvc():
-            # Simulate: cl not on PATH, but vswhere is present.
-            import subprocess as _sp
-            import shutil as _sh
-
-            if _sh.which("cl"):
-                return _sh.which("cl")
-
-            vswhere = str(fake_vswhere)
-            result = _sp.run(
-                [vswhere, "-latest", "-products", "*",
-                 "-requires", "Microsoft.VisualStudio.Component.VC.Tools.x86.x64",
-                 "-find", "VC/Tools/MSVC/*/bin/Hostx64/x64/cl.exe"],
-                capture_output=True, text=True, timeout=10,
-            )
-            if result.returncode == 0:
-                lines = [l.strip() for l in result.stdout.splitlines() if l.strip()]
-                if lines:
-                    return lines[0]
-            return None
-
         monkeypatch.setattr(bnc.subprocess, "run", fake_run)
-        monkeypatch.setattr(bnc, "_find_msvc", patched_find_msvc)
 
-        result = bnc._find_msvc()
-        assert result == fake_cl
+        assert bnc._find_msvc() == fake_cl
 
-    def test_vswhere_failure_returns_none(self, monkeypatch, tmp_path):
+    def test_vswhere_failure_returns_none(self, monkeypatch):
         monkeypatch.setattr(bnc.shutil, "which", lambda name: None)
+        monkeypatch.setattr(bnc.Path, "exists", lambda self: True)
 
         def failing_run(args, **kwargs):
             m = mock.MagicMock()
@@ -96,42 +56,18 @@ class TestFindMsvc:
             m.stdout = ""
             return m
 
-        fake_vswhere = tmp_path / "vswhere.exe"
-        fake_vswhere.touch()
-
-        def patched_find_msvc():
-            import subprocess as _sp
-            result = _sp.run(
-                [str(fake_vswhere)], capture_output=True, text=True, timeout=10,
-            )
-            if result.returncode == 0 and result.stdout.strip():
-                return result.stdout.strip().splitlines()[0]
-            return None
-
         monkeypatch.setattr(bnc.subprocess, "run", failing_run)
-        monkeypatch.setattr(bnc, "_find_msvc", patched_find_msvc)
 
         assert bnc._find_msvc() is None
 
-    def test_vswhere_timeout_returns_none(self, monkeypatch, tmp_path):
+    def test_vswhere_timeout_returns_none(self, monkeypatch):
         monkeypatch.setattr(bnc.shutil, "which", lambda name: None)
+        monkeypatch.setattr(bnc.Path, "exists", lambda self: True)
 
         def timeout_run(args, **kwargs):
             raise subprocess.TimeoutExpired(args, 10)
 
-        fake_vswhere = tmp_path / "vswhere.exe"
-        fake_vswhere.touch()
-
-        def patched_find_msvc():
-            import subprocess as _sp
-            try:
-                _sp.run([str(fake_vswhere)], capture_output=True, text=True, timeout=10)
-            except _sp.TimeoutExpired:
-                return None
-            return None
-
         monkeypatch.setattr(bnc.subprocess, "run", timeout_run)
-        monkeypatch.setattr(bnc, "_find_msvc", patched_find_msvc)
 
         assert bnc._find_msvc() is None
 

--- a/tests/test_build_native_msvc.py
+++ b/tests/test_build_native_msvc.py
@@ -1,0 +1,179 @@
+"""Tests for MSVC cl.exe detection in ``kct build-native`` (Windows support).
+
+These tests exercise ``_find_msvc`` and the MSVC branch of ``_check_compiler``
+with mocks -- no real compiler or vswhere is invoked.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+import kicad_tools.cli.build_native_cmd as bnc
+
+
+class TestFindMsvc:
+    def test_returns_none_when_no_cl_and_no_vswhere(self, monkeypatch):
+        monkeypatch.setattr(bnc.shutil, "which", lambda name: None)
+        # Patch the default vswhere path so it looks non-existent.
+        monkeypatch.setattr(
+            bnc,
+            "_find_msvc",
+            lambda: None,  # bypass filesystem check in Path.exists
+        )
+        assert bnc._find_msvc() is None
+
+    def test_cl_on_path_takes_priority(self, monkeypatch):
+        fake_cl = r"C:\vctools\bin\cl.exe"
+        monkeypatch.setattr(
+            bnc.shutil,
+            "which",
+            lambda name: fake_cl if name == "cl" else None,
+        )
+        assert bnc._find_msvc() == fake_cl
+
+    def test_vswhere_fallback_returns_cl_path(self, monkeypatch, tmp_path):
+        # cl is not on PATH.
+        monkeypatch.setattr(bnc.shutil, "which", lambda name: None)
+
+        # Create a fake vswhere that prints a cl.exe path.
+        fake_cl = r"C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\VC\Tools\MSVC\14.43.0\bin\Hostx64\x64\cl.exe"
+
+        def fake_run(args, **kwargs):
+            m = mock.MagicMock()
+            m.returncode = 0
+            m.stdout = fake_cl + "\n"
+            return m
+
+        # Make _find_msvc believe vswhere exists at the well-known path.
+        fake_vswhere = tmp_path / "vswhere.exe"
+        fake_vswhere.touch()
+        monkeypatch.setattr(
+            bnc,
+            "_find_msvc",
+            # Real implementation; patch only the external calls.
+            bnc._find_msvc.__wrapped__ if hasattr(bnc._find_msvc, "__wrapped__") else bnc._find_msvc,
+        )
+
+        original_find_msvc = bnc._find_msvc
+
+        def patched_find_msvc():
+            # Simulate: cl not on PATH, but vswhere is present.
+            import subprocess as _sp
+            import shutil as _sh
+
+            if _sh.which("cl"):
+                return _sh.which("cl")
+
+            vswhere = str(fake_vswhere)
+            result = _sp.run(
+                [vswhere, "-latest", "-products", "*",
+                 "-requires", "Microsoft.VisualStudio.Component.VC.Tools.x86.x64",
+                 "-find", "VC/Tools/MSVC/*/bin/Hostx64/x64/cl.exe"],
+                capture_output=True, text=True, timeout=10,
+            )
+            if result.returncode == 0:
+                lines = [l.strip() for l in result.stdout.splitlines() if l.strip()]
+                if lines:
+                    return lines[0]
+            return None
+
+        monkeypatch.setattr(bnc.subprocess, "run", fake_run)
+        monkeypatch.setattr(bnc, "_find_msvc", patched_find_msvc)
+
+        result = bnc._find_msvc()
+        assert result == fake_cl
+
+    def test_vswhere_failure_returns_none(self, monkeypatch, tmp_path):
+        monkeypatch.setattr(bnc.shutil, "which", lambda name: None)
+
+        def failing_run(args, **kwargs):
+            m = mock.MagicMock()
+            m.returncode = 1
+            m.stdout = ""
+            return m
+
+        fake_vswhere = tmp_path / "vswhere.exe"
+        fake_vswhere.touch()
+
+        def patched_find_msvc():
+            import subprocess as _sp
+            result = _sp.run(
+                [str(fake_vswhere)], capture_output=True, text=True, timeout=10,
+            )
+            if result.returncode == 0 and result.stdout.strip():
+                return result.stdout.strip().splitlines()[0]
+            return None
+
+        monkeypatch.setattr(bnc.subprocess, "run", failing_run)
+        monkeypatch.setattr(bnc, "_find_msvc", patched_find_msvc)
+
+        assert bnc._find_msvc() is None
+
+    def test_vswhere_timeout_returns_none(self, monkeypatch, tmp_path):
+        monkeypatch.setattr(bnc.shutil, "which", lambda name: None)
+
+        def timeout_run(args, **kwargs):
+            raise subprocess.TimeoutExpired(args, 10)
+
+        fake_vswhere = tmp_path / "vswhere.exe"
+        fake_vswhere.touch()
+
+        def patched_find_msvc():
+            import subprocess as _sp
+            try:
+                _sp.run([str(fake_vswhere)], capture_output=True, text=True, timeout=10)
+            except _sp.TimeoutExpired:
+                return None
+            return None
+
+        monkeypatch.setattr(bnc.subprocess, "run", timeout_run)
+        monkeypatch.setattr(bnc, "_find_msvc", patched_find_msvc)
+
+        assert bnc._find_msvc() is None
+
+
+class TestCheckCompilerMsvc:
+    def test_msvc_accepted_when_unix_compilers_absent(self, monkeypatch):
+        fake_cl = r"C:\BuildTools\cl.exe"
+        # No clang++ / g++ on PATH; MSVC found via _find_msvc.
+        monkeypatch.setattr(bnc.shutil, "which", lambda name: None)
+        monkeypatch.setattr(bnc, "_find_msvc", lambda: fake_cl)
+
+        ok, path = bnc._check_compiler()
+
+        assert ok is True
+        assert path == fake_cl
+
+    def test_unix_compiler_preferred_over_msvc(self, monkeypatch):
+        fake_cl = r"C:\BuildTools\cl.exe"
+        fake_clangpp = "/usr/bin/clang++"
+
+        def which(name):
+            return fake_clangpp if name == "clang++" else None
+
+        monkeypatch.setattr(bnc.shutil, "which", which)
+        monkeypatch.setattr(bnc, "_find_msvc", lambda: fake_cl)
+        monkeypatch.setattr(
+            bnc.subprocess,
+            "run",
+            lambda *a, **k: mock.MagicMock(returncode=0),
+        )
+
+        ok, path = bnc._check_compiler()
+
+        assert ok is True
+        assert path == fake_clangpp
+
+    def test_error_message_mentions_windows_when_all_absent(self, monkeypatch):
+        monkeypatch.setattr(bnc.shutil, "which", lambda name: None)
+        monkeypatch.setattr(bnc, "_find_msvc", lambda: None)
+
+        ok, msg = bnc._check_compiler()
+
+        assert ok is False
+        assert msg is not None
+        assert "Windows" in msg or "Visual Studio" in msg


### PR DESCRIPTION
## Summary

`kct build-native` fails on Windows with _"C++20 compiler not found"_ even
when VS 2022 Build Tools are installed, because `_check_compiler()` only
looks for `clang++` and `g++`.  Both `CMakeLists.txt` files already had
working `if(MSVC)` blocks; the missing piece was detection and one missing
define.

- **`build_native_cmd.py`**: add `_find_msvc()` — finds `cl.exe` via
  `shutil.which("cl")` (vcvars on PATH) or `vswhere.exe -products *`
  (covers Build Tools, not just VS IDE).  `_check_compiler()` falls through
  to it on Windows.  When MSVC is detected, cmake gets `-A x64` so the
  `.pyd` matches the 64-bit Python interpreter.
- **`placement/cpp/CMakeLists.txt`**: add `/D_USE_MATH_DEFINES` to the
  existing `if(MSVC)` block — required for `M_PI` from `<cmath>` on MSVC.
- **`tests/test_build_native_msvc.py`**: 8 new unit tests covering
  `_find_msvc` (PATH hit, vswhere fallback, vswhere failure, timeout) and
  `_check_compiler` MSVC branch (accepted when Unix absent, Unix preferred
  when both present, error message mentions Windows).

## Test plan

- [x] All 8 new tests pass (`pytest tests/test_build_native_msvc.py`)
- [x] All 32 existing staleness tests pass unchanged
- [x] End-to-end: `kct build-native --verbose --force` on Windows 11,
  VS 2022 Build Tools 14.43.34808, cmake 3.31 → both
  `router_cpp.cp312-win_amd64.pyd` and `placement_cpp.cp312-win_amd64.pyd`
  build and load correctly; `kct build-native --check` reports
  `C++ backend: available (version 1.0.0)`

## Platform

Windows 11 · VS 2022 Build Tools 14.43.34808 · cmake 3.31 · Python 3.12

🤖 Generated with [Claude Code](https://claude.com/claude-code)