### PR TITLE
fix: tolerate rounding at the PTH annular ring minimum

### DIFF
--- a/src/kicad_tools/validate/rules/solder_mask.py
+++ b/src/kicad_tools/validate/rules/solder_mask.py
@@ -13,7 +13,7 @@ from typing import TYPE_CHECKING
 from kicad_tools.core.geometry import rotate_pad_offset
 
 from ..violations import DRCResults, DRCViolation
-from .base import DRCRule
+from .base import DRC_TOLERANCE, DRCRule
 
 if TYPE_CHECKING:
     from kicad_tools.manufacturers import DesignRules
@@ -209,7 +209,7 @@ class SolderMaskPadRules(DRCRule):
                 # Annular ring = (pad dimension - drill) / 2
                 annular_ring = (min_pad_dim - pad.drill) / 2
 
-                if annular_ring < min_annular:
+                if annular_ring + DRC_TOLERANCE < min_annular:
                     # Rotate footprint-local pad offset into board frame
                     # before translating (KiCad negated-angle convention;
                     # see core.geometry.rotate_pad_offset, issue #3739;

--- a/tests/test_validate_solder_mask.py
+++ b/tests/test_validate_solder_mask.py
@@ -457,6 +457,38 @@ class TestRotatedViolationLocation:
 class TestPTHAnnularRing:
     """Tests for PTH pad annular ring validation."""
 
+    @pytest.mark.parametrize(
+        ("pad_size", "expected_violations"),
+        [(0.70, 0), (0.68, 1)],
+        ids=["exact-minimum-rounding", "undersized-ring"],
+    )
+    def test_annular_ring_minimum_boundary(self, pad_size, expected_violations):
+        """Accept the USB4085's exact minimum but reject a real shortfall."""
+        pcb = MockPCB(
+            footprints=[
+                MockFootprint(
+                    pads=[
+                        MockPad(
+                            type="thru_hole",
+                            size=(pad_size, pad_size),
+                            drill=0.40,
+                            layers=["*.Cu", "*.Mask"],
+                        ),
+                    ]
+                ),
+            ],
+        )
+        rules = MockDesignRules(min_annular_ring_mm=0.15)
+
+        results = SolderMaskPadRules().check(pcb, rules)
+
+        violations = [v for v in results.violations if v.rule_id == "pth_annular_ring"]
+        assert len(violations) == expected_violations
+        if expected_violations:
+            assert violations[0].severity == "error"
+            assert violations[0].actual_value == pytest.approx(0.14)
+            assert violations[0].required_value == pytest.approx(0.15)
+
     def test_adequate_annular_ring_passes(self):
         """Through-hole pad with adequate ring should pass."""
         pcb = MockPCB(


### PR DESCRIPTION
## Summary
PTH pads with 0.70 mm copper lands and 0.40 mm drills now pass the 0.15 mm annular-ring minimum. Floating-point rounding previously reported the contradictory error `0.150mm < minimum 0.150mm`.

## Changes
- Apply shared `DRC_TOLERANCE` to the PTH comparison, matching the existing via annular-ring rule.
- Cover the exact minimum and a genuinely undersized 0.14 mm ring.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Exact 0.15 mm PTH ring passes | Pass | 0.70 mm land / 0.40 mm drill regression |
| Genuine shortfall remains an error | Pass | 0.68 mm land / 0.40 mm drill negative control asserts error severity and 0.14 mm actual value |
| Manufacturer floor unchanged | Pass | Negative control asserts required value remains 0.15 mm; no manufacturer configuration changes |
| Match via tolerance | Pass | Both comparisons use `.base.DRC_TOLERANCE` |

## Test Plan
- `uv run pytest tests/test_validate_solder_mask.py tests/test_validate_dimensions.py --no-cov -q`: 63 passed.
- `uv run ruff format . --check`: 1993 files already formatted.
- `uv run ruff check .`: passed.
- `git diff --check`: passed.

TDD: yes — wrote the parameterized boundary regression first; exact-minimum case failed with the reported false-positive error and undersized control passed. Both pass after the fix.

Closes #4996