### PR TITLE
test(cli): remove obsolete auto-pour parser drift exemptions

### DIFF
--- a/tests/test_cli_parser_drift.py
+++ b/tests/test_cli_parser_drift.py
@@ -100,8 +100,6 @@ INNER_ONLY_ALLOWLIST: frozenset[str] = frozenset(
         # Internal routing-algorithm toggles exposed through the
         # ``route_cmd.py`` parser for development experimentation.
         # Promote to the outer parser when ready to support officially.
-        "--auto-pour",
-        "--no-auto-pour",
         "--batch-routing",
         "--bus-min-width",
         "--bus-mode",


### PR DESCRIPTION
The main CLI now accepts and forwards both auto-pour flags, but the parser-drift test still lists them as inner-only. This makes test_allowlist_entries_are_actually_inner_only fail on current main.

Remove the two obsolete allowlist entries so parser parity remains enforced.

The functional fix and forwarding regression landed concurrently in d95b6eff; this PR contains the remaining test cleanup after rebasing onto dcfca09c.

Validation: the forwarding and parser-drift suites reproduced one failure on main and pass all 40 tests with this cleanup. Ruff passes.

Closes #4988
