### PR TITLE
fix(cli): handle suppressed format defaults in help

### DIFF
--- a/src/kicad_tools/cli/format_options.py
+++ b/src/kicad_tools/cli/format_options.py
@@ -46,9 +46,14 @@ def add_format_flag(
     choices: tuple[str, ...] = (FORMAT_TEXT, FORMAT_JSON),
     default: str = FORMAT_TEXT,
     dest: str = "format",
-    help_text: str = "Output format (default: %(default)s)",
+    help_text: str | None = None,
 ) -> argparse.Action:
     """Add the canonical ``--format`` choice flag to *parser*."""
+    if help_text is None:
+        # argparse removes suppressed defaults before interpolating help.
+        help_text = "Output format"
+        if default != argparse.SUPPRESS:
+            help_text += " (default: %(default)s)"
     return parser.add_argument(
         "--format",
         choices=list(choices),

--- a/tests/test_format_options_suppressed.py
+++ b/tests/test_format_options_suppressed.py
@@ -1,0 +1,52 @@
+"""Suppressed defaults must work with argparse's help interpolation (Python 3.14)."""
+
+import argparse
+from unittest.mock import patch
+
+import pytest
+
+from kicad_tools.cli.format_options import add_format_flag
+from kicad_tools.cli.parts_cmd import main
+
+
+def test_suppressed_format_help_and_namespace():
+    parser = argparse.ArgumentParser()
+    add_format_flag(parser, default=argparse.SUPPRESS)
+    assert "Output format" in parser.format_help()
+    assert "default:" not in parser.format_help()
+    assert not hasattr(parser.parse_args([]), "format")
+    assert parser.parse_args(["--format", "json"]).format == "json"
+
+
+def test_normal_format_help_keeps_default():
+    parser = argparse.ArgumentParser()
+    add_format_flag(parser)
+    assert "default: text" in parser.format_help()
+    assert parser.parse_args([]).format == "text"
+
+
+def test_custom_format_help_is_preserved():
+    parser = argparse.ArgumentParser()
+    add_format_flag(parser, default=argparse.SUPPRESS, help_text="Choose a representation")
+    assert "Choose a representation" in parser.format_help()
+
+
+@pytest.mark.parametrize(
+    ("argv", "expected"),
+    [
+        (["cache", "stats"], "text"),
+        (["cache", "--format", "json", "stats"], "json"),
+        (["cache", "stats", "--format", "json"], "json"),
+        (["cache", "--format", "json", "stats", "--format", "text"], "text"),
+    ],
+)
+def test_parts_cache_format_precedence(argv, expected):
+    with patch("kicad_tools.cli.parts_cmd._cache", return_value=0) as handler:
+        assert main(argv) == 0
+    assert handler.call_args.args[0].format == expected
+
+
+def test_parts_sync_catalog_parser():
+    with patch("kicad_tools.cli.parts_cmd._sync_catalog", return_value=0) as handler:
+        assert main(["sync-catalog", "--format", "json"]) == 0
+    assert handler.call_args.args[0].format == "json"


### PR DESCRIPTION
## Summary
Fix the parts CLI parser crash on Python 3.14 when cache subcommands suppress their format defaults.

## Changes
- Generate format help without default interpolation when the default is suppressed.
- Preserve explicit help text, normal defaults, and parent/child format precedence.

## Acceptance Criteria Verification
| Criterion | Status | Verification |
|---|---|---|
| Suppressed help is safe | Pass | Helper construction and help rendering regression |
| Parent options survive omitted child flags | Pass | Cache parser precedence cases |
| Parts parser constructs on Python 3.14 without network | Pass | Mocked sync-catalog and cache handlers |
| Audit other shared-helper callers | Pass | Only parts cache action parsers pass SUPPRESS |

## Test Plan
74 tests pass on Python 3.12 and Python 3.14: `tests/test_format_options_suppressed.py` and `tests/test_format_json_sweep_families.py`. Changed-file Ruff lint and format checks pass.

TDD: yes — new regressions failed before the fix (one on Python 3.12; six on Python 3.14), then passed.

Closes #5028