### PR TITLE
fix(parts): exclude unpopulated symbols from sourcing preflight

### DIFF
--- a/src/kicad_tools/cli/commands/parts.py
+++ b/src/kicad_tools/cli/commands/parts.py
@@ -74,7 +74,7 @@ def run_parts_command(args) -> int:
 
 def _run_suggest_command(args) -> int:
     """Suggest LCSC part numbers for components without them."""
-    from kicad_tools.cost.suggest import PartSuggester
+    from kicad_tools.cost.suggest import SuggestionResult
     from kicad_tools.schema.bom import extract_bom
 
     input_path = Path(args.schematic)
@@ -93,27 +93,33 @@ def _run_suggest_command(args) -> int:
         print("No components found in schematic.", file=sys.stderr)
         return 1
 
-    # Filter to non-DNP items
-    active_items = [item for item in bom.items if not item.dnp]
-
-    if not active_items:
-        print("No active (non-DNP) components found.", file=sys.stderr)
-        return 1
-
-    # Count items needing LCSC numbers
+    # Match BOM.total_components and the downstream matcher's population policy.
+    active_items = [item for item in bom.items if not item.dnp and not item.is_virtual]
     missing_lcsc = [item for item in active_items if not item.lcsc]
+    reference_counts = {
+        "active_references": len(active_items),
+        "missing_lcsc_references": len(missing_lcsc),
+    }
 
-    if not missing_lcsc and not args.show_all:
-        print("All components already have LCSC part numbers.")
+    if not active_items or (not missing_lcsc and not args.show_all):
+        if args.format == "json":
+            _print_json_result(SuggestionResult(), **reference_counts)
+        elif not active_items:
+            print("No populated components need suggestions.")
+        else:
+            print("All populated components already have LCSC part numbers.")
         return 0
 
     print(
-        f"Analyzing {len(active_items)} components ({len(missing_lcsc)} missing LCSC numbers)...",
+        f"Analyzing {len(active_items)} populated references "
+        f"({len(missing_lcsc)} missing LCSC numbers)...",
         file=sys.stderr,
     )
 
-    # Create suggester with options
+    # Load the optional suggester only when populated components need work.
     try:
+        from kicad_tools.cost.suggest import PartSuggester
+
         with PartSuggester(
             prefer_basic=not args.no_basic_preference,
             min_stock=args.min_stock,
@@ -132,23 +138,26 @@ def _run_suggest_command(args) -> int:
     if not args.show_all:
         result.suggestions = [s for s in result.suggestions if s.needs_lcsc]
 
-    if not result.suggestions:
+    if not result.suggestions and args.format != "json":
         print("No components need suggestions.")
         return 0
 
     # Output results
     if args.format == "json":
-        _print_json_result(result)
+        _print_json_result(result, **reference_counts)
     else:
         _print_table_result(result)
 
     return 0
 
 
-def _print_json_result(result) -> None:
+def _print_json_result(result, *, active_references: int, missing_lcsc_references: int) -> None:
     """Print suggestions as JSON."""
     output = {
         "summary": {
+            "active_references": active_references,
+            "missing_lcsc_references": missing_lcsc_references,
+            "count_unit": "grouped_parts",
             "total_components": result.total_components,
             "missing_lcsc": result.missing_lcsc,
             "found_suggestions": result.found_suggestions,
@@ -227,7 +236,7 @@ def _print_table_result(result) -> None:
 
     print()
     print(
-        f"Summary: {result.found_suggestions}/{result.missing_lcsc} components with suggestions found"
+        f"Summary: {result.found_suggestions}/{result.missing_lcsc} grouped parts with suggestions found"
     )
     if result.no_suggestions > 0:
-        print(f"         {result.no_suggestions} components could not be matched")
+        print(f"         {result.no_suggestions} grouped parts could not be matched")

--- a/tests/test_parts_suggest_preflight.py
+++ b/tests/test_parts_suggest_preflight.py
@@ -1,0 +1,93 @@
+"""Sourcing preflight uses populated references, not virtual or excluded symbols."""
+
+import builtins
+import json
+from argparse import Namespace
+from unittest.mock import patch
+
+import pytest
+
+from kicad_tools.cli.commands.parts import _run_suggest_command
+from kicad_tools.cost.suggest import PartSuggestion, SuggestionResult
+from kicad_tools.schema.bom import BOM, BOMItem
+
+
+def item(reference, **kwargs):
+    return BOMItem(reference, "10k", "Resistor_SMD:R_0603", "Device:R", **kwargs)
+
+
+@pytest.fixture
+def args(tmp_path):
+    schematic = tmp_path / "test.kicad_sch"
+    schematic.touch()
+    return Namespace(
+        schematic=str(schematic),
+        show_all=False,
+        no_basic_preference=False,
+        min_stock=100,
+        max_suggestions=2,
+        format="json",
+    )
+
+
+@pytest.mark.parametrize("show_all", [False, True])
+@pytest.mark.parametrize("output_format", ["json", "table"])
+def test_excluded_bom_never_constructs_suggester(args, capsys, show_all, output_format):
+    args.show_all = show_all
+    args.format = output_format
+    bom = BOM(items=[item("TP1", in_bom=False), item("#PWR01"), item("R1", dnp=True)])
+    with (
+        patch("kicad_tools.schema.bom.extract_bom", return_value=bom),
+        patch("kicad_tools.cost.suggest.PartSuggester") as suggester,
+    ):
+        assert _run_suggest_command(args) == 0
+    suggester.assert_not_called()
+    output = capsys.readouterr()
+    assert "Analyzing" not in output.err
+    if output_format == "json":
+        payload = json.loads(output.out)
+        assert payload["suggestions"] == []
+        assert payload["summary"]["active_references"] == 0
+
+
+def test_sourced_and_excluded_bom_needs_no_optional_suggester(args, capsys):
+    bom = BOM(items=[item("R1", lcsc="C25804"), item("TP1", in_bom=False)])
+    original_import = builtins.__import__
+
+    def reject_suggester(name, globals=None, locals=None, fromlist=(), level=0):
+        if name == "kicad_tools.cost.suggest" and "PartSuggester" in fromlist:
+            raise ImportError("optional suggester must not be loaded")
+        return original_import(name, globals, locals, fromlist, level)
+
+    with (
+        patch("kicad_tools.schema.bom.extract_bom", return_value=bom),
+        patch("builtins.__import__", side_effect=reject_suggester),
+    ):
+        assert _run_suggest_command(args) == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["summary"]["active_references"] == 1
+    assert payload["summary"]["missing_lcsc_references"] == 0
+
+
+@pytest.mark.parametrize("output_format", ["json", "table"])
+def test_populated_references_and_grouped_results_are_distinct(args, capsys, output_format):
+    args.format = output_format
+    bom = BOM(items=[item("R1"), item("R2"), item("TP1", in_bom=False), item("R3", dnp=True)])
+    result = SuggestionResult(suggestions=[PartSuggestion("R1", "10k", "R_0603", "0603", None)])
+    with (
+        patch("kicad_tools.schema.bom.extract_bom", return_value=bom),
+        patch("kicad_tools.cost.suggest.PartSuggester") as suggester,
+    ):
+        suggester.return_value.__enter__.return_value.suggest_for_bom.return_value = result
+        assert _run_suggest_command(args) == 0
+    suggester.return_value.__enter__.return_value.suggest_for_bom.assert_called_once_with(bom)
+    output = capsys.readouterr()
+    assert "Analyzing 2 populated references (2 missing LCSC numbers)" in output.err
+    if output_format == "json":
+        summary = json.loads(output.out)["summary"]
+        assert summary["active_references"] == 2
+        assert summary["missing_lcsc_references"] == 2
+        assert summary["count_unit"] == "grouped_parts"
+        assert summary["total_components"] == 1
+    else:
+        assert "grouped parts" in output.out


### PR DESCRIPTION
## Summary
Exclude BOM-excluded, virtual, and DNP symbols from parts-suggest preflight so unsourced test pads do not trigger sourcing work or inflate counts.

## Changes
- Use the BOM population policy for active and missing-LCSC reference counts.
- Return successfully without loading the suggester for all-excluded and fully sourced BOMs.
- Emit JSON for no-work results; preserve existing grouped counters and identify their unit, alongside explicit populated-reference counters. Label text summaries as grouped parts.

## Acceptance Criteria Verification
| Criterion | Status | Verification |
|---|---|---|
| Exclude test pads, power symbols, and DNP | Pass | Mixed and all-excluded BOM tests |
| Skip suggester for all-excluded BOM | Pass | Mock constructor stays uncalled, with and without show-all |
| Sourced resistor plus excluded pad needs no optional suggester | Pass | Import rejection test |
| Unsourced populated resistors still request suggestions | Pass | Mock handler receives the BOM |
| Distinguish reference and group counts | Pass | Two references / one group, JSON and table assertions |

## Test Plan
121 tests pass on Python 3.12 and Python 3.14 across the new preflight regressions, cost suggestion tests, cost tests, and missing-parts-extra tests. Changed-file Ruff lint and format checks pass.

TDD: yes — all seven new regression cases failed before the fix and pass afterward.

Closes #4990