### PR TITLE
fix(parts): preserve official API error reasons and status

### DIFF
--- a/src/kicad_tools/parts/__init__.py
+++ b/src/kicad_tools/parts/__init__.py
@@ -73,6 +73,7 @@ from .jlcpcb_api import (
     JLCCredentials,
     JLCIPNotWhitelistedError,
     JLCOpenAPIClient,
+    JLCPermissionError,
     JLCQuotaError,
 )
 from .lcsc import LCSCClient, LCSCForbiddenError, RateLimiter
@@ -110,6 +111,7 @@ __all__ = [
     "JLCAPIError",
     "JLCAuthError",
     "JLCIPNotWhitelistedError",
+    "JLCPermissionError",
     "JLCQuotaError",
     # Composition
     "ComposedPart",

--- a/src/kicad_tools/parts/jlcpcb_api.py
+++ b/src/kicad_tools/parts/jlcpcb_api.py
@@ -55,30 +55,25 @@ needed.
 
 Live-smoke result (2026-07, issue #4118)
 ----------------------------------------
-A one-off local smoke against ``open.jlcpcb.com`` with the owner's real key
-**confirmed the Base64 digest encoding is correct**:
+A one-off local smoke against ``open.jlcpcb.com`` observed a permission denial
+with Base64 signatures and a signature rejection with hex signatures. This
+supports the current Base64 default, but a permission denial alone does not
+establish that the signature verified. HTTP 403 can reflect IP restrictions,
+product permissions, or another access policy; classification uses the explicit
+server reason when available.
 
-* Base64 digest (either scheme keyword) -> HTTP 403,
-  ``"API insufficient permissions, access denied"`` -- i.e. the signature
-  *verified*, but the app was not permitted (a portal/permission/IP matter).
-* Hex digest -> HTTP 401, ``"The request signature verify failed"`` -- the
-  signature was rejected.
-
-So :data:`SIGNATURE_ENCODING` = ``"base64"`` is validated, and the scheme
-keyword does not affect signature verification. The remaining 403 is an
-owner-side developer-portal configuration matter (enable the Parts API product
-for the app / whitelist the calling IP), not a client bug -- which is why the
-feature ships inert-without-keys and defers that step to the owner.
 """
 
 from __future__ import annotations
 
 import base64
+import contextlib
 import hashlib
 import hmac
 import json
 import logging
 import os
+import re
 import secrets
 import time
 from datetime import datetime
@@ -137,9 +132,10 @@ class JLCAPIError(Exception):
     when they are available so callers can log something actionable.
     """
 
-    def __init__(self, message: str, *, code: int | None = None):
+    def __init__(self, message: str, *, code: int | None = None, http_status: int | None = None):
         super().__init__(message)
         self.code = code
+        self.http_status = http_status
 
 
 class JLCAuthError(JLCAPIError):
@@ -155,12 +151,13 @@ class JLCAuthError(JLCAPIError):
 class JLCIPNotWhitelistedError(JLCAPIError):
     """The caller's public IP is not on the app's IP whitelist.
 
-    The JLCPCB developer portal has an IP Whitelisting feature; requests from
-    an un-whitelisted IP are rejected. The exact business ``code``/``message``
-    for this case is **unconfirmed** without a live smoke test -- detection is
-    a best-effort message/code heuristic (see :func:`_classify_business_error`)
-    and should be refined once the owner runs the live smoke.
+    Selected only for an explicit IP/whitelist reason in the server response.
+    A generic HTTP 403 or product permission denial is insufficient evidence.
     """
+
+
+class JLCPermissionError(JLCAPIError):
+    """Access or product permission denied, without diagnosing an IP restriction."""
 
 
 class JLCQuotaError(JLCAPIError):
@@ -369,41 +366,51 @@ class JLCOpenAPIClient:
                 timeout=self.timeout,
             )
         except request_exc as e:
-            raise JLCAPIError(f"JLCPCB open-platform request failed: {e}") from e
+            reason = _safe_error_reason(
+                str(e),
+                (
+                    self.credentials.app_id,
+                    self.credentials.access_key,
+                    self.credentials.secret_key,
+                    headers["Authorization"],
+                    signature,
+                ),
+            )
+            raise JLCAPIError(f"JLCPCB open-platform request failed: {reason}") from None
 
-        # Transport-level auth rejections may surface as HTTP status rather than
-        # a business envelope; map the common ones before parsing JSON.
         status = response.status_code
-        if status in (401, 403):
-            raise JLCAuthError(
-                f"JLCPCB open-platform rejected the request (HTTP {status}); "
-                "verify credentials and that this IP is whitelisted.",
-                code=status,
-            )
-        if status == 429:
-            raise JLCQuotaError(
-                "JLCPCB open-platform rate limit exceeded (HTTP 429).",
-                code=status,
-            )
-
-        try:
-            envelope = response.json()
-        except ValueError as e:
-            raise JLCAPIError(
-                f"JLCPCB open-platform returned non-JSON response (HTTP {status})."
-            ) from e
+        envelope = None
+        # Error pages may be HTML or oversized. Bound JSON parsing for failed
+        # HTTP responses; component-detail success payloads may legitimately be large.
+        if status < 400 or len(response.content) <= 65536:
+            with contextlib.suppress(ValueError):
+                envelope = response.json()
 
         if not isinstance(envelope, dict):
-            raise JLCAPIError("JLCPCB open-platform returned an unexpected response shape.")
+            if status >= 400:
+                raise _classify_business_error(None, None, http_status=status)
+            raise JLCAPIError(
+                f"JLCPCB open-platform returned a non-JSON or unexpected response (HTTP {status}).",
+                http_status=status,
+            )
 
         code = envelope.get("code")
-        success = envelope.get("success")
-        if code == 200 and success:
-            data = envelope.get("data")
-            return {"data": data}
+        if 200 <= status < 300 and code == 200 and envelope.get("success"):
+            return {"data": envelope.get("data")}
 
-        # Business-level failure: classify into an actionable exception.
-        raise _classify_business_error(code, envelope.get("message"))
+        # Never include echoed request credentials, signatures, or headers in
+        # the exception. Only a bounded, sanitized message field is retained.
+        reason = _safe_error_reason(
+            envelope.get("message"),
+            (
+                self.credentials.app_id,
+                self.credentials.access_key,
+                self.credentials.secret_key,
+                headers["Authorization"],
+                signature,
+            ),
+        )
+        raise _classify_business_error(code, reason, http_status=status)
 
     def get_component_detail_by_codes(self, codes: list[str]) -> dict[str, Part]:
         """Look up component detail for one or more LCSC codes.
@@ -455,96 +462,65 @@ class JLCOpenAPIClient:
         return False
 
 
-def _classify_business_error(code: object, message: object) -> JLCAPIError:
-    """Map a non-success business envelope to a specific exception.
+def _safe_error_reason(message: object, secrets_to_redact: tuple[str, ...] = ()) -> str:
+    """Retain a short plain-text reason, never a serialized response envelope."""
+    if not isinstance(message, str) or not message:
+        return "unknown error"
+    if len(message) > 65536:
+        return "server error reason too large"
+    for secret in sorted(secrets_to_redact, key=len, reverse=True):
+        if secret:
+            message = message.replace(secret, "[redacted]")
+    return " ".join("".join(c if c.isprintable() else " " for c in message).split())[:512]
 
-    The precise business codes/messages for auth vs. IP-whitelist vs. quota are
-    **not first-party-documented**; this uses a best-effort message/code
-    heuristic (see per-branch comments) that the owner's live smoke should
-    refine. Anything unrecognized becomes a generic :class:`JLCAPIError` rather
-    than being conflated with a "part not found" miss.
-    """
-    msg = str(message) if message not in (None, "") else "unknown error"
-    code_int: int | None
+
+def _classify_business_error(
+    code: object, message: object, *, http_status: int | None = None
+) -> JLCAPIError:
+    """Use explicit reasons first, then status fallbacks without inferring IP or signature validity."""
+    msg = _safe_error_reason(message)
     try:
         code_int = int(str(code)) if code is not None else None
     except (TypeError, ValueError):
         code_int = None
-
     lowered = msg.lower()
-
-    # Signature rejection -- the *signature itself* did not verify. Confirmed
-    # message from the live API (2026-07, issue #4118 smoke): code 401,
-    # "The request signature verify failed". This is the actionable "your
-    # signing is wrong" case -- check the secret key and the signing variant.
-    if (
-        "signature" in lowered
-        or "sign verify" in lowered
-        or (code_int == 401 and ("verify" in lowered or "auth" in lowered))
+    details = f"(HTTP {http_status}, code={code_int}): {msg}"
+    error_type: type[JLCAPIError]
+    if "signature" in lowered or "sign verify" in lowered:
+        error_type = JLCAuthError
+        reason = "authentication failed (signature verification); check the signing configuration"
+    elif any(term in lowered for term in ("quota", "rate limit", "too many", "frequenc")):
+        error_type = JLCQuotaError
+        reason = "quota/rate limit exceeded"
+    elif "whitelist" in lowered or (
+        re.search(r"\bip\b", lowered)
+        and any(term in lowered for term in ("not allowed", "denied", "reject", "forbidden"))
     ):
-        return JLCAuthError(
-            f"JLCPCB open-platform signature verification failed (code={code_int}): {msg}. "
-            "Verify your JLCPCB_SECRET_KEY and the signing variant "
-            "(AUTH_SCHEME / SIGNATURE_ENCODING) in parts/jlcpcb_api.py.",
-            code=code_int,
-        )
-
-    # Quota / rate limit -- heuristic (UNCONFIRMED; refine via live smoke).
-    if (
-        code_int == 429
-        or "quota" in lowered
-        or "rate limit" in lowered
-        or "too many" in lowered
-        or "frequenc" in lowered
+        error_type = JLCIPNotWhitelistedError
+        reason = "IP access restriction; check the app's IP whitelist"
+    elif any(term in lowered for term in ("permission", "access denied", "forbidden")):
+        error_type = JLCPermissionError
+        reason = "access denied; check app/product permissions"
+    elif any(
+        term in lowered
+        for term in ("auth", "credential", "access key", "accesskey", "secret", "token")
     ):
-        return JLCQuotaError(
-            f"JLCPCB open-platform quota/rate limit exceeded (code={code_int}): {msg}.",
-            code=code_int,
-        )
-
-    # Permission / IP-whitelist rejection -- the signature verified but the app
-    # is not permitted. Confirmed message from the live API (2026-07 smoke):
-    # code 403, "API insufficient permissions, access denied". This is a portal
-    # configuration matter (enable the Parts API product for the app and/or add
-    # this machine's public IP to the app's IP whitelist), NOT a signing bug.
-    if (
-        code_int == 403
-        or "whitelist" in lowered
-        or "ip " in lowered
-        or "not allowed" in lowered
-        or "permission" in lowered
-        or "access denied" in lowered
-        or "denied" in lowered
-        or "forbidden" in lowered
-    ):
-        return JLCIPNotWhitelistedError(
-            f"JLCPCB open-platform denied access (code={code_int}): {msg}. "
-            "The signature verified, but the app lacks permission: enable the "
-            "Parts/component API product for this app and/or add your public IP "
-            "to the app's IP whitelist in the developer portal.",
-            code=code_int,
-        )
-
-    # Other auth-ish failures (missing token, bad access key, etc.).
-    if (
-        code_int in (401, 403)
-        or "auth" in lowered
-        or "credential" in lowered
-        or "access key" in lowered
-        or "accesskey" in lowered
-        or "secret" in lowered
-        or "token" in lowered
-    ):
-        return JLCAuthError(
-            f"JLCPCB open-platform authentication failed (code={code_int}): {msg}. "
-            "Verify your access/secret keys and the signing variant "
-            "(AUTH_SCHEME / SIGNATURE_ENCODING).",
-            code=code_int,
-        )
-
-    return JLCAPIError(
-        f"JLCPCB open-platform returned a business error (code={code_int}): {msg}.",
-        code=code_int,
+        error_type = JLCAuthError
+        reason = "authentication failed"
+    elif code_int == 429 or http_status == 429:
+        error_type = JLCQuotaError
+        reason = "quota/rate limit exceeded"
+    elif code_int == 401 or http_status == 401:
+        error_type = JLCAuthError
+        reason = "authentication failed"
+    elif code_int == 403 or http_status == 403:
+        error_type = JLCPermissionError
+        reason = "access denied"
+    else:
+        error_type = JLCAPIError
+        reason = "request failed"
+    return error_type(
+        f"JLCPCB open-platform {reason} {details}.", code=code_int, http_status=http_status
     )
 
 

--- a/tests/parts/test_jlcpcb_api.py
+++ b/tests/parts/test_jlcpcb_api.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import base64
 import hashlib
 import hmac
+import json
 from unittest import mock
 
 import pytest
@@ -176,6 +177,7 @@ class _FakeResponse:
         self.status_code = status_code
         self._json_data = json_data
         self._raise_json = raise_json
+        self.content = b"<html>Denied</html>" if raise_json else json.dumps(json_data).encode()
 
     def json(self):
         if self._raise_json:
@@ -334,13 +336,8 @@ def test_business_error_real_signature_failure_maps_to_auth():
         client.get_component_detail_by_codes(["C1"])
 
 
-def test_business_error_real_permission_denied_maps_to_whitelist():
-    """Confirmed live message (issue #4118 smoke): 403 insufficient permissions.
-
-    Signature verified but the app is not permitted -- a portal/IP matter, so
-    it maps to the actionable IP/permission exception rather than a generic auth
-    failure.
-    """
+def test_business_error_real_permission_denied_maps_to_permission():
+    """Product permission denial does not establish an IP or signature diagnosis."""
     resp = _FakeResponse(
         json_data={
             "code": 403,
@@ -349,7 +346,7 @@ def test_business_error_real_permission_denied_maps_to_whitelist():
         }
     )
     client, _ = _client_with_response(resp)
-    with pytest.raises(JLCIPNotWhitelistedError):
+    with pytest.raises(jlcpcb_api.JLCPermissionError):
         client.get_component_detail_by_codes(["C1"])
 
 
@@ -514,3 +511,76 @@ def test_lcsc_search_never_uses_official(monkeypatch):
     ):
         client.search("100nF 0402")
     fake_official.get_component_detail_by_codes.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    ("status", "code", "message", "error_type"),
+    [
+        (403, 7101, "The request client ip is not allowed", "JLCIPNotWhitelistedError"),
+        (403, 403, "API insufficient permissions, access denied", "JLCPermissionError"),
+        (401, 401, "The request signature verify failed", "JLCAuthError"),
+        (403, 429, "API quota exceeded", "JLCQuotaError"),
+    ],
+)
+def test_http_error_preserves_business_reason(status, code, message, error_type):
+    client, _ = _client_with_response(
+        _FakeResponse(status_code=status, json_data={"code": code, "message": message})
+    )
+    with pytest.raises(JLCAPIError) as exc:
+        client.get_component_detail_by_codes(["C1"])
+    assert type(exc.value).__name__ == error_type
+    assert exc.value.code == code
+    assert exc.value.http_status == status
+    assert message in str(exc.value)
+    assert "signature verified" not in str(exc.value).lower()
+
+
+def test_html_403_does_not_diagnose_credentials_or_ip():
+    client, _ = _client_with_response(_FakeResponse(status_code=403, raise_json=True))
+    with pytest.raises(JLCAPIError) as exc:
+        client.get_component_detail_by_codes(["C1"])
+    assert type(exc.value).__name__ == "JLCPermissionError"
+    assert exc.value.http_status == 403
+    assert "whitelist" not in str(exc.value).lower()
+
+
+def test_http_error_cannot_return_success_envelope():
+    client, _ = _client_with_response(
+        _FakeResponse(status_code=503, json_data={"code": 200, "success": True, "data": []})
+    )
+    with pytest.raises(JLCAPIError) as exc:
+        client.get_component_detail_by_codes(["C1"])
+    assert exc.value.http_status == 503
+
+
+def test_server_error_reason_redacts_credentials_and_controls():
+    reason = f"IP not allowed: {FAKE_APP_ID} {FAKE_ACCESS_KEY} {FAKE_SECRET_KEY}\n\x1b[31m"
+    client, _ = _client_with_response(_FakeResponse(json_data={"code": 403, "message": reason}))
+    with pytest.raises(JLCAPIError) as exc:
+        client.get_component_detail_by_codes(["C1"])
+    message = str(exc.value)
+    for secret in (FAKE_APP_ID, FAKE_ACCESS_KEY, FAKE_SECRET_KEY):
+        assert secret not in message
+    assert "\n" not in message and "\x1b" not in message
+
+
+def test_oversized_http_error_is_not_parsed():
+    response = _FakeResponse(status_code=403, json_data={"message": "x" * 100000})
+    response.content = b"x" * 100000
+    response.json = mock.Mock(side_effect=AssertionError("oversized body parsed"))
+    client, _ = _client_with_response(response)
+    with pytest.raises(JLCAPIError) as exc:
+        client.get_component_detail_by_codes(["C1"])
+    response.json.assert_not_called()
+    assert exc.value.http_status == 403
+    assert len(str(exc.value)) < 1024
+
+
+def test_transport_error_redacts_credentials():
+    requests = pytest.importorskip("requests")
+    client, session = _client_with_response(_FakeResponse())
+    session.post = mock.Mock(side_effect=requests.RequestException(f"failed for {FAKE_SECRET_KEY}"))
+    with pytest.raises(JLCAPIError) as exc:
+        client.get_component_detail_by_codes(["C1"])
+    assert FAKE_SECRET_KEY not in str(exc.value)
+    assert exc.value.__suppress_context__


### PR DESCRIPTION
## Summary
Preserve official Parts API error reasons on HTTP failures so an explicit IP-whitelist rejection is actionable instead of being reported as a generic credential failure.

## Changes
- Parse bounded error JSON before classification and retain separate HTTP and business codes.
- Distinguish explicit IP restrictions, app/product permission denials, authentication/signature failures, and quota errors; add JLCPermissionError for non-IP access denials.
- Sanitize and bound server reasons, redact request credentials/signatures from response and transport errors, and retain safe fallbacks for HTML/oversized errors.
- Do not infer successful signature verification from HTTP 403, or accept a success envelope on an HTTP failure.

## Acceptance Criteria Verification
| Criterion | Status | Verification |
|---|---|---|
| HTTP 403 explicit IP rejection is preserved | Pass | Mock 403 with business code 7101 and the reported server message |
| Signature rejection remains authentication failure | Pass | HTTP 401 and business signature tests |
| Generic HTML and product denial do not diagnose IP | Pass | Dedicated fallback and permission tests |
| Quota remains distinguishable | Pass | HTTP/business quota coverage |
| Preserve safe message and statuses | Pass | Exception type, reason, business code and HTTP status assertions |
| Bound parsing and prevent credential disclosure | Pass | Oversized-body, control-character, credential-echo and transport-exception tests |

## Test Plan
Independent exact-head review: 98 parts tests pass, changed-file Ruff lint/format and scoped mypy pass. All 14 active CI checks pass on `2839c9df`; the full suite reports 27,588 passed and 100 skipped, with two standalone Board05 manufacturing tests also passing. The two Board07 jobs remain suspended by the existing upstream setting.

TDD: yes — eight new regression cases failed before the fix; all pass afterward. A further transport-redaction regression passes.

Closes #5043
