### PR TITLE
fix(deploy): require the exact scoped Pages project

### DIFF
--- a/scripts/deploy-site.sh
+++ b/scripts/deploy-site.sh
@@ -159,11 +159,11 @@ assert_cloudflare_account() {
 
   info "Cloudflare account matches the configured identity pin."
 
-  # Non-fatal: confirm the kicad-tools Pages project is reachable.  The very
-  # first deploy may predate project creation, so only WARN if it's missing.
+  # Scoped credentials must reach the exact existing project. OAuth retains
+  # the first-deploy warning when the project has not been created yet.
   local projects
   if projects="$("$@" pages project list 2>&1)"; then
-    if ! printf '%s\n' "${projects}" | grep -q 'kicad-tools'; then
+    if ! printf '%s\n' "${projects}" | grep -Eq '(^|[[:space:]│|])kicad-tools([[:space:]│|]|$)'; then
       if [ -n "${CLOUDFLARE_ACCOUNT_ID:-}" ]; then
         err "Configured account does not expose the existing kicad-tools Pages project. Refusing to deploy."
         exit 1

--- a/tests/test_deploy_account_guard.py
+++ b/tests/test_deploy_account_guard.py
@@ -2,6 +2,7 @@
 
 import hashlib
 import os
+import shlex
 import subprocess
 from pathlib import Path
 
@@ -11,22 +12,34 @@ SCRIPT = Path(__file__).resolve().parents[1] / "scripts/deploy-site.sh"
 
 
 @pytest.mark.parametrize(
-    "account,accessible,expected",
+    "account,projects,expected",
     [
-        ("a" * 32, True, 0),
-        ("b" * 32, True, 1),
-        ("a" * 32, False, 1),
+        ("a" * 32, "kicad-tools", 0),
+        ("", "kicad-tools", 0),
+        ("", "other-project", 0),
+        ("a" * 32, "│ kicad-tools │ kicad-tools.pages.dev │", 0),
+        ("b" * 32, "kicad-tools", 1),
+        ("a" * 32, None, 1),
+        ("a" * 32, "", 1),
+        ("a" * 32, "other-project", 1),
+        ("a" * 32, "kicad-tools-preview", 1),
+        ("a" * 32, "old-kicad-tools", 1),
+        ("a" * 32, "kicad-tools.pages.dev", 1),
     ],
 )
-def test_scoped_pages_account_guard(tmp_path, account, accessible, expected):
+def test_scoped_pages_account_guard(tmp_path, account, projects, expected):
     source = SCRIPT.read_text()
     guard = source[source.index("# --- Logging helpers") : source.index("# --- Parse flags")]
-    # whoami intentionally cannot return account information with this token.
+    # Scoped tokens cannot use whoami; OAuth falls back to it without an explicit account.
     mock = tmp_path / "wrangler"
     mock.write_text(
         "#!/bin/bash\n"
-        'if [ "$1" = whoami ]; then exit 99; fi\n'
-        + ("echo kicad-tools\n" if accessible else "exit 1\n")
+        + (
+            'if [ "$1" = whoami ]; then exit 99; fi\n'
+            if account
+            else 'if [ "$1" = whoami ]; then echo ' + "a" * 32 + "; exit 0; fi\n"
+        )
+        + ("printf '%s\\n' " + shlex.quote(projects) + "\n" if projects is not None else "exit 1\n")
     )
     mock.chmod(0o700)
     env = {


### PR DESCRIPTION
Fixes #5027.

Scoped Pages credentials and pinned-account verification are already implemented on main. Complete the missing-project guard: require the exact `kicad-tools` project name, rather than accepting `kicad-tools-preview`, `old-kicad-tools`, or a domain-only match. Retain the OAuth first-deploy fallback.

Validation: 11 mocked Wrangler guard cases pass; the three lookalike cases failed before the change. Bash syntax, Ruff, and diff checks pass. Tests cover scoped access without whoami, exact table output, account mismatch, failed/absent project access, and OAuth fallback. No deployment or credential loading was performed.