### PR TITLE
fix: retain unassigned SMD copper as via relocation obstacles

### DIFF
--- a/src/kicad_tools/cli/relocate_in_pad_vias.py
+++ b/src/kicad_tools/cli/relocate_in_pad_vias.py
@@ -385,13 +385,15 @@ def _first_offpad_signal_candidate(
 def _collect_smd_pads_by_net(
     pcb: PCB,
 ) -> dict[int, list[tuple[Footprint, Pad, tuple[float, float, float, float]]]]:
-    """Group SMD pads (net != 0) by net number with precomputed AABBs."""
+    """Group all SMD pads by net number with precomputed obstacle AABBs.
+
+    Net-zero pads still carry physical copper.  Retain them for clearance
+    checks; relocation callers exclude net-zero vias as electrical sources.
+    """
     pads_by_net: dict[int, list[tuple[Footprint, Pad, tuple[float, float, float, float]]]] = {}
     for fp in pcb.footprints:
         for pad in fp.pads:
             if not is_smd_pad(pad):
-                continue
-            if pad.net_number == 0:
                 continue
             bbox = pad_absolute_bbox(pad, fp)
             pads_by_net.setdefault(pad.net_number, []).append((fp, pad, bbox))
@@ -470,9 +472,9 @@ def _check_clearance(
                     f"({other.position[0]:.2f}, {other.position[1]:.2f})"
                 )
 
-    # SMD pads on other nets: copper clearance to pad AABB.
+    # Other-net and unassigned SMD pads: copper clearance to pad AABB.
     for net_number, entries in pads_by_net.items():
-        if net_number == via.net_number:
+        if net_number != 0 and net_number == via.net_number:
             continue
         for fp, pad, bbox in entries:
             cu_gap = _dist_point_to_aabb(new_x, new_y, bbox) - via_r

--- a/tests/test_fix_vias.py
+++ b/tests/test_fix_vias.py
@@ -2691,3 +2691,58 @@ class TestRelocatePhase3:
         rc = main([str(p), "--mfr", "jlcpcb", "--relocate-in-pad", "--dry-run", "-q"])
         assert rc in (0, 2)
         assert p.read_text() == original
+
+
+class TestUnassignedSmdObstacles:
+    """Net-zero pads are physical obstacles, not an electrical net (#5010)."""
+
+    @pytest.mark.parametrize("neighbor_x", [101.4, 101.65, 103.0])
+    def test_signal_candidate_respects_unassigned_copper(self, tmp_path: Path, neighbor_x: float):
+        content = _PCB_BOXED_IN.replace('(net 2 "SIG2"))', '(net 0 ""))').replace(
+            "(at 100.9 100)", f"(at {neighbor_x} 100)"
+        )
+        path = _write(tmp_path, content)
+        rules = get_mfr_design_rules("jlcpcb", 2, 1.0)
+        reports = []
+        for dry_run in (True, False):
+            pcb = PCB.load(path)
+            original = pcb._sexp.to_string()
+            report = relocate_in_pad_vias(pcb, rules, dry_run=dry_run)
+            reports.append(report)
+            if neighbor_x < 102:
+                assert not report.changed
+                assert len(report.skipped) == 1
+                assert "clearance" in report.skipped[0].reason
+                assert "pad" in report.skipped[0].reason
+                assert pcb._sexp.to_string() == original
+            else:
+                assert len(report.moved) == 1
+                assert not report.skipped
+                moved = report.moved[0]
+                # Independent rectangle geometry: the neighboring pad is 1 mm wide.
+                gap = neighbor_x - 0.5 - moved.new_x - 0.3
+                assert gap >= rules.min_clearance_mm
+                assert (pcb._sexp.to_string() == original) == dry_run
+        assert reports[0] == reports[1]
+
+    @pytest.mark.parametrize("net", [0, 1])
+    def test_only_assigned_same_net_copper_is_exempt(self, tmp_path: Path, net: int):
+        pcb = PCB.load(_write(tmp_path, _PCB_SIGNAL_IN_PAD.replace("(net 1", f"(net {net}")))
+        pads = _collect_smd_pads_by_net(pcb)
+        assert len(pads[net]) == 1
+        reason = _check_clearance(pcb, pcb.vias[0], 100, 100, pads, [], 0.127, 0.25)
+        assert (reason is None) == (net != 0)
+
+    @pytest.mark.parametrize("via_net", [0, 1])
+    def test_unassigned_pad_is_not_a_relocation_source(self, tmp_path: Path, via_net: int):
+        content = _PCB_SIGNAL_IN_PAD.replace('(net 1 "SIG1"))', '(net 0 ""))')
+        content = content.replace(
+            '(net 1) (uuid "via-inpad")', f'(net {via_net}) (uuid "via-inpad")'
+        )
+        pcb = PCB.load(_write(tmp_path, content))
+        original = pcb._sexp.to_string()
+        report = relocate_in_pad_vias(pcb, get_mfr_design_rules("jlcpcb", 2, 1.0))
+        assert not report.changed
+        assert not report.skipped
+        assert not report.unresolvable
+        assert pcb._sexp.to_string() == original

--- a/tests/test_relocate_drill_clearance.py
+++ b/tests/test_relocate_drill_clearance.py
@@ -257,3 +257,38 @@ def test_dense_field_never_introduces_a_new_violation() -> None:
             rules.min_hole_to_hole_mm,
         )
         assert reason is None, f"moved via {m.uuid[:8]} is not clearance-safe: {reason}"
+
+
+def test_drill_candidate_avoids_unassigned_smd_pad(tmp_path) -> None:
+    """The shared obstacle collector rejects an escape landing on net-zero copper."""
+    from kicad_tools.cli.relocate_in_pad_vias import _collect_smd_pads_by_net
+
+    pcb = _stack_board()
+    path = tmp_path / "net-zero.kicad_pcb"
+    pcb.save(path)
+    content = path.read_text().rstrip()
+    path.write_text(
+        content[:-1]
+        + f"""
+        (footprint "test:unused" (layer "F.Cu")
+          (at {22 + pcb._board_origin[0]} {20.5 + pcb._board_origin[1]})
+          (pad "1" smd rect (at 0 0) (size 0.4 0.4) (layers "F.Cu")))
+        )"""
+    )
+    pcb = PCB.load(path)
+    via = list(pcb.vias)[1]
+    rules = _tier1_rules()
+    target = _find_target(
+        pcb,
+        via,
+        (22, 20.5),
+        _collect_smd_pads_by_net(pcb),
+        [],
+        rules.min_clearance_mm,
+        rules.min_hole_to_hole_mm,
+    )
+    assert target is not None
+    # Measure independently of the shared clearance helper.
+    dx = max(21.8 - target[0], 0, target[0] - 22.2)
+    dy = max(20.3 - target[1], 0, target[1] - 20.7)
+    assert math.hypot(dx, dy) - via.size / 2 >= rules.min_clearance_mm - 1e-6


### PR DESCRIPTION
## Summary
Via relocation could land on unassigned SMD copper because the obstacle collector discarded net-zero pads. Retain that geometry so overlapping and insufficient-clearance candidates are rejected in both relocation consumers.

## Changes
- Collect net-zero SMD pads alongside assigned pads, while preserving the callers' exclusion of net-zero vias as relocation sources.
- Exempt SMD copper only when it belongs to the same nonzero net.
- Add geometric regressions for overlap, insufficient clearance, safe relocation, source eligibility, same-net exemptions, and drill-clearance candidate selection.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Net-zero SMD copper blocks unsafe assigned-net candidates | Passed | Overlapping and 0.073 mm-gap cases reject the former x=100.777 landing; drill candidate independently measured clear of unused pad |
| Unassigned copper is not a same-net source or exemption | Passed | Parameterized net-zero/assigned via source tests and explicit same-net clearance controls |
| Rejection preserves via/traces and reports the decision; safe control moves | Passed | Entire serialized board unchanged after rejected real/dry runs; reports equal; safe case moves only in real run |
| Assigned same-net behavior remains covered | Passed | Existing tests and explicit assigned-net exemption control pass; connectivity #4981 and stub-path #5065 remain separate |

## Test Plan
- `uv run pytest tests/test_fix_vias.py tests/test_relocate_drill_clearance.py --no-cov -q`: 120 passed.
- `uv run ruff check .`: passed; changed-file formatting and `git diff --check` passed.
- Whole-repository formatting reports 7 pre-existing board/fixture files; baseline-gated mypy reports 4 pre-existing errors in stripline.py, pcb.py, and missing shapely.geometry stubs. No unrelated files were modified.
- Geometric tests use synthetic compact PCB fixtures, not the original board04 artifact. Native board04 refill/DRC was not performed for this PR.

TDD: yes — tests/test_fix_vias.py regressions were written first and failed on unsafe relocation/net-zero collection before the fix (3 failures, 4 controls passing). The drill-consumer regression in tests/test_relocate_drill_clearance.py also fails against the pre-fix source; all pass with the fix.

Closes #5010