### PR TITLE
fix: canonicalize mypy diagnostic aliases and annotate inference gaps

### DIFF
--- a/scripts/ci/check_mypy_baseline.py
+++ b/scripts/ci/check_mypy_baseline.py
@@ -18,8 +18,8 @@ useless.  Instead we normalize each error to a stable *signature*:
 
     <path>\t<error-code>\t<normalized-message>
 
-The line number is dropped, and volatile substrings in the message (numbers,
-quoted identifiers, temp module paths) are masked so a signature stays stable
+The line number is dropped, and bare integers in the message are masked
+while equivalent diagnostic templates are canonicalized so a signature stays stable
 across unrelated edits.  We then compare *multisets* of signatures: the
 current run may contain each baseline signature at most as many times as the
 baseline does.  Any signature that appears more often than the baseline (or
@@ -93,6 +93,15 @@ _ERROR_LINE_RE = re.compile(
 # and must be masked so a signature stays stable.
 _NUMBER_RE = re.compile(r"\b\d+\b")
 
+# Mypy 2.x renamed these templates without changing the underlying errors.
+# Match whole templates and retain their quoted payloads verbatim; replacing
+# argument/parameter globally would erase meaningful identifiers and types.
+_DEFAULT_PARAMETER_RE = re.compile(
+    r'^Incompatible default for parameter ("[^"\n]+") '
+    r'\(default has type ("[^"\n]+"), parameter has type ("[^"\n]+")\)$'
+)
+_GENERIC_ARGUMENTS_RE = re.compile(r'^Missing type arguments for generic type ("[^"\n]+")$')
+
 
 def normalize_message(message: str) -> str:
     """Mask volatile substrings in a mypy error message.
@@ -106,7 +115,18 @@ def normalize_message(message: str) -> str:
     collapse distinct errors into one signature, letting genuinely new errors
     hide behind an existing baseline entry.
     """
-    return _NUMBER_RE.sub("N", message).strip()
+    message = message.strip()
+    if match := _DEFAULT_PARAMETER_RE.fullmatch(message):
+        name, default_type, parameter_type = match.groups()
+        message = (
+            f"Incompatible default for argument {name} "
+            f"(default has type {default_type}, argument has type {parameter_type})"
+        )
+    elif match := _GENERIC_ARGUMENTS_RE.fullmatch(message):
+        message = f"Missing type parameters for generic type {match.group(1)}"
+    elif message == "Function is missing a type annotation for one or more parameters":
+        message = "Function is missing a type annotation for one or more arguments"
+    return _NUMBER_RE.sub("N", message)
 
 
 def signature(path: str, message: str, code: str) -> str:
@@ -290,6 +310,10 @@ def load_baseline(baseline_path: Path) -> Counter[str]:
         line = raw_line.rstrip("\n")
         if not line or line.lstrip().startswith("#"):
             continue
+        parts = line.split("\t", 2)
+        if len(parts) == 3:
+            path, code, message = parts
+            line = signature(path, message, code)
         counts[line] += 1
     return counts
 

--- a/src/kicad_tools/cli/sch_summary.py
+++ b/src/kicad_tools/cli/sch_summary.py
@@ -60,7 +60,7 @@ def gather_summary(schematic_path: str, verbose: bool = False) -> dict:
     path = Path(schematic_path)
 
     # Basic info
-    summary = {
+    summary: dict[str, object] = {
         "file": path.name,
         "path": str(path),
     }
@@ -95,16 +95,18 @@ def gather_summary(schematic_path: str, verbose: bool = False) -> dict:
                 prefix = "".join(c for c in item.reference if c.isalpha())
                 ref_counts[prefix] += 1
 
-        summary["components"] = {
+        components: dict[str, object] = {
             "total": bom.total_components,
             "unique_parts": bom.unique_parts,
             "dnp": bom.dnp_count,
             "by_type": dict(ref_counts.most_common()),
         }
 
+        summary["components"] = components
+
         if verbose:
             groups = bom_filtered.grouped()
-            summary["components"]["top_parts"] = [
+            components["top_parts"] = [
                 {"value": g.value, "qty": g.quantity, "refs": g.references}
                 for g in sorted(groups, key=lambda x: -x.quantity)[:10]
             ]
@@ -137,7 +139,7 @@ def gather_summary(schematic_path: str, verbose: bool = False) -> dict:
             except Exception:
                 continue
 
-        summary["connectivity"] = {
+        connectivity: dict[str, object] = {
             "wires": total_wires,
             "junctions": total_junctions,
             "labels": total_labels,
@@ -145,8 +147,10 @@ def gather_summary(schematic_path: str, verbose: bool = False) -> dict:
             "hierarchical_labels": total_hierarchical_labels,
         }
 
+        summary["connectivity"] = connectivity
+
         if verbose:
-            summary["connectivity"]["unique_signals"] = sorted(label_names)[:20]
+            connectivity["unique_signals"] = sorted(label_names)[:20]
 
     except Exception:
         summary["connectivity"] = {}

--- a/src/kicad_tools/library/generators/sot.py
+++ b/src/kicad_tools/library/generators/sot.py
@@ -76,6 +76,10 @@ def create_sot(
         attr="smd",
     )
 
+    # Coordinates are millimeters in both standard and custom layouts.
+    x: float
+    y: float
+
     # Add pads
     if pad_positions is not None:
         for i, (x, y) in enumerate(pad_positions):

--- a/tests/test_ci_mypy_baseline.py
+++ b/tests/test_ci_mypy_baseline.py
@@ -554,3 +554,70 @@ def test_cold_run_ignores_a_poisoned_cache(mod, tmp_path: Path, monkeypatch) -> 
         f"cold run replayed the stale cached error -- the gate is still trapped:\n{cold}"
     )
     assert mod.parse_mypy_output(cold) == Counter(), cold
+
+
+# Captured diagnostic templates from the mypy 1.19.1 ledger and 2.3.1 CI.
+_DIAGNOSTIC_ALIASES = [
+    (
+        'Incompatible default for argument "name" (default has type "None", argument has type "str")',
+        'Incompatible default for parameter "name" (default has type "None", parameter has type "str")',
+    ),
+    (
+        'Missing type parameters for generic type "dict"',
+        'Missing type arguments for generic type "dict"',
+    ),
+    (
+        "Function is missing a type annotation for one or more arguments",
+        "Function is missing a type annotation for one or more parameters",
+    ),
+]
+
+
+@pytest.mark.parametrize("old,new", _DIAGNOSTIC_ALIASES)
+@pytest.mark.parametrize("reverse", [False, True])
+def test_diagnostic_aliases_compare_on_either_side(mod, tmp_path, old, new, reverse):
+    baseline_message, current_message = (new, old) if reverse else (old, new)
+    baseline = _write(tmp_path, "baseline.txt", f"src/a.py\tmisc\t{baseline_message}\n")
+    output = _write(tmp_path, "output.txt", f"src/a.py:10: error: {current_message}  [misc]\n")
+    assert mod.main(["--baseline", str(baseline), "--mypy-output", str(output)]) == 0
+    # Normalization cannot grant a second occurrence of the same debt.
+    output.write_text(output.read_text() * 2)
+    assert mod.main(["--baseline", str(baseline), "--mypy-output", str(output)]) == 2
+
+
+@pytest.mark.parametrize(
+    "replacement",
+    [
+        ('"name"', '"other"'),
+        ('"str"', '"bytes"'),
+        ('"None"', '"int"'),
+        ("src/a.py", "src/b.py"),
+        ("[assignment]", "[arg-type]"),
+    ],
+)
+def test_diagnostic_aliases_preserve_semantic_differences(mod, tmp_path, replacement):
+    old, new = _DIAGNOSTIC_ALIASES[0]
+    baseline = _write(tmp_path, "baseline.txt", f"src/a.py\tassignment\t{old}\n")
+    raw = f"src/a.py:10: error: {new}  [assignment]\n"
+    output = _write(tmp_path, "output.txt", raw.replace(*replacement))
+    assert mod.main(["--baseline", str(baseline), "--mypy-output", str(output)]) == 2
+
+
+def test_aliases_preserve_quoted_template_words(mod):
+    message = (
+        'Incompatible default for parameter "parameter" '
+        '(default has type "None", parameter has type "Literal[\'argument\']")'
+    )
+    assert mod.normalize_message(message) == (
+        'Incompatible default for argument "parameter" '
+        '(default has type "None", argument has type "Literal[\'argument\']")'
+    )
+    unrelated = 'Unexpected parameter "argument", parameter has type "str"'
+    assert mod.normalize_message(unrelated) == unrelated
+
+
+def test_mixed_alias_baseline_keeps_total_allowance(mod, tmp_path):
+    old, new = _DIAGNOSTIC_ALIASES[1]
+    baseline = _write(tmp_path, "baseline.txt", f"src/a.py\tmisc\t{old}\nsrc/a.py\tmisc\t{new}\n")
+    loaded = mod.load_baseline(baseline)
+    assert loaded == Counter({mod.signature("src/a.py", old, "misc"): 2})


### PR DESCRIPTION
Mypy 2.3.1 renames three existing diagnostic templates, making 50 already-budgeted errors appear new. Canonicalize those exact templates on both sides of the baseline comparison and annotate three upgrade-specific inference gaps without expanding the debt allowance.

The four-file change preserves identifiers, type details, paths, error codes and multiplicities. It annotates existing heterogeneous schematic summary dictionaries and SOT coordinates; runtime behavior is unchanged. No changes to uv.lock, pyproject.toml, or the baseline ledger.

Validation at signed-off head 26111e7eb913ed4faeb1537c3465665e47328ca1, rebased onto main df2134e56d99a1b0653fe11d1c8daa4a791bfdf0 (including #5045):

- 123 focused baseline/generator tests passed; Ruff check/format and diff checks passed.
- CI dependency installation: `uv sync --frozen --extra dev`.
- Identical-source cold mypy 1.19.1: 1,446 diagnostics; mypy 2.3.1: 1,439. Both baseline comparisons exit 0. Normalized 2.3.1-minus-1.19.1 multiset is empty; seven old diagnostics disappear. No debt suppression or ledger update.
- Combined integration probe: temporarily applied the exact #4922 lockfile patch at 399e510b3a36ace9081efd41b78ba03d6a933b4e to this head. Resolved 13 identical resolution-marker ordering conflicts by retaining the upgrade's Python 3.15/3.14 split. The resulting lock retains main changes and the upgrade's 300 additions/132 deletions (SHA256 09e75cd8c396be0db3c17abdcb23319e8915a0bb9b1dd05d30d5f21d063a8f9e). `uv sync --frozen --extra dev` installed mypy 2.3.1 and its locked transitive upgrades. The actual cold gate `uv run --frozen --no-sync python scripts/ci/check_mypy_baseline.py` exited 0: 1,439 diagnostics within 1,472 allowed.
- Restored the original committed lock and environment after the integration probe. The dependency PR was not modified. All four previously blocking main diagnostics are resolved by merged #5045.

The local combined-state acceptance test now passes. The actual #4922 PR remains open at its original head and still requires its own rebase/CI lifecycle; this PR keeps the issue link non-closing rather than claiming that upgrade is integrated.

Part of #4962
