### PR TITLE
fix(export): bundle project-local symbol library dependencies

### DIFF
--- a/boards/04-stm32-devboard/generate_design.py
+++ b/boards/04-stm32-devboard/generate_design.py
@@ -1833,25 +1833,6 @@ def generate_manufacturing(routed_path: Path, output_dir: Path) -> bool:
             print(f"   Export error: {error}")
         return False
 
-    # The schematic's local symbol bindings must travel with the native project.
-    import hashlib
-    import json
-    import zipfile
-
-    project_zip = mfr_dir / "kicad_project.zip"
-    with zipfile.ZipFile(project_zip, "a", zipfile.ZIP_DEFLATED) as archive:
-        for source in [*output_dir.glob("*.kicad_sym"), output_dir / "sym-lib-table"]:
-            if source.is_file():
-                archive.write(source, source.name)
-    manifest_path = mfr_dir / "manifest.json"
-    if manifest_path.exists():
-        manifest = json.loads(manifest_path.read_text())
-        manifest["files"][project_zip.name] = {
-            "sha256": hashlib.sha256(project_zip.read_bytes()).hexdigest(),
-            "size": project_zip.stat().st_size,
-        }
-        manifest_path.write_text(json.dumps(manifest, indent=2) + "\n")
-
     process["validate_process"](routed_path)
 
     print(f"\n   SUCCESS: manufacturing artifacts written to {mfr_dir}")

--- a/docs/guides/manufacturing-export.md
+++ b/docs/guides/manufacturing-export.md
@@ -13,6 +13,20 @@ To order assembled PCBs from JLCPCB, you need:
 
 kicad-tools can generate all of these in JLCPCB's required format.
 
+The manufacturing package's `kicad_project.zip` includes the selected PCB,
+adjacent schematic/project files, and the project-local `sym-lib-table` with
+its referenced KiCad symbol libraries. Relative paths and `${KIPRJMOD}/`
+paths retain their subdirectories after extraction. Repeated references
+to the same file produce one archive member.
+
+Project ZIP creation reports an export error for a malformed table, missing
+library, or nonportable table entry (absolute paths, parent traversal,
+host environment variables, non-KiCad libraries, or symlinks outside the
+project). Move those dependencies under the project and use project-relative
+URIs before exporting. Libraries supplied by KiCad's global installation
+are not copied; footprint libraries and 3D models are outside this symbol
+packaging support.
+
 ## Prerequisites
 
 ```bash

--- a/src/kicad_tools/export/manufacturing.py
+++ b/src/kicad_tools/export/manufacturing.py
@@ -20,6 +20,7 @@ from pathlib import Path
 import kicad_tools
 from kicad_tools.exceptions import FileNotFoundError as KiCadFileNotFoundError
 from kicad_tools.parts.lcsc import LCSCDependencyMissingError
+from kicad_tools.sexp import parse_file
 
 from .assembly import AssemblyConfig, AssemblyPackage, AssemblyPackageResult
 from .preflight import PreflightChecker, PreflightConfig, PreflightResult
@@ -225,6 +226,58 @@ def verify_manifest(manifest_path: str | Path) -> list[str]:
     return problems
 
 
+def _project_symbol_files(project_dir: Path) -> list[Path]:
+    """Collect portable symbol-table dependencies before writing an archive.
+
+    Keep lexical paths for archive names, but resolve symlinks when checking
+    containment. Never expand host environment variables or copy global libraries.
+    """
+    table_path = project_dir / "sym-lib-table"
+    if not table_path.exists() and not table_path.is_symlink():
+        return []
+    root = project_dir.resolve()
+    if not table_path.resolve().is_relative_to(root):
+        raise ValueError("Nonportable sym-lib-table: table resolves outside the project")
+    try:
+        table = parse_file(table_path)
+    except (OSError, ValueError) as exc:
+        raise ValueError(f"Cannot read sym-lib-table: {exc}") from exc
+    if table.name != "sym_lib_table":
+        raise ValueError("Malformed sym-lib-table: expected sym_lib_table root")
+
+    files = [table_path]
+    for lib in table.find_all("lib"):
+        name_node = lib.get("name")
+        name = name_node.get_first_atom() if name_node else "<unnamed>"
+        uri_node = lib.get("uri")
+        uri = uri_node.get_first_atom() if uri_node else None
+        type_node = lib.get("type")
+        if type_node is None or type_node.get_first_atom() != "KiCad":
+            raise ValueError(f"Nonportable symbol library {name!r}: expected KiCad library type")
+        if not isinstance(uri, str) or not uri:
+            raise ValueError(f"Malformed sym-lib-table: library {name!r} has no URI")
+        relative_uri = uri.removeprefix("${KIPRJMOD}/")
+        relative = Path(relative_uri)
+        if (
+            "$" in relative_uri
+            or "\\" in relative_uri
+            or ":" in relative_uri
+            or relative.is_absolute()
+            or ".." in relative.parts
+            or relative.suffix != ".kicad_sym"
+        ):
+            raise ValueError(f"Nonportable symbol library {name!r}: {uri!r}")
+        target = project_dir / relative
+        if not target.resolve().is_relative_to(root):
+            raise ValueError(
+                f"Nonportable symbol library {name!r}: {uri!r} resolves outside project"
+            )
+        if not target.is_file():
+            raise FileNotFoundError(f"Missing project symbol library {name!r}: {uri!r}")
+        files.append(target)
+    return files
+
+
 def _create_project_zip(
     pcb_path: Path,
     output_dir: Path,
@@ -233,7 +286,8 @@ def _create_project_zip(
     """Create a ZIP containing the KiCad project files.
 
     Includes only the specific PCB being exported, plus .kicad_sch and
-    .kicad_pro files.  Other .kicad_pcb variants (intermediate builds,
+    .kicad_pro files and project-local symbol-table dependencies.
+    Other .kicad_pcb variants (intermediate builds,
     working copies, etc.) and backup files are excluded to keep the
     manufacturing package clean.
     """
@@ -256,9 +310,11 @@ def _create_project_zip(
     if not project_files:
         raise FileNotFoundError(f"No KiCad project files found in {project_dir}")
 
+    project_files.extend(_project_symbol_files(project_dir))
+    project_files = sorted(set(project_files))
     with zipfile.ZipFile(zip_path, "w", zipfile.ZIP_DEFLATED) as zf:
-        for f in sorted(project_files):
-            zf.write(f, f.name)
+        for f in project_files:
+            zf.write(f, f.relative_to(project_dir).as_posix())
 
     logger.info(f"Created project ZIP: {zip_path} ({len(project_files)} files)")
     return zip_path

--- a/tests/test_manufacturing_package.py
+++ b/tests/test_manufacturing_package.py
@@ -2,6 +2,8 @@
 
 import json
 import logging
+import shutil
+import subprocess
 import zipfile
 from pathlib import Path
 
@@ -16,6 +18,22 @@ from kicad_tools.export.manufacturing import (
     _sha256_file,
 )
 from kicad_tools.export.preflight import PreflightChecker, PreflightConfig, PreflightResult
+
+
+@pytest.fixture
+def local_symbol_project(tmp_path):
+    """A real schematic with a generated local symbol, independent of stock libraries."""
+    from kicad_tools.schematic.models.schematic import Schematic
+
+    project = tmp_path / "project"
+    project.mkdir()
+    pcb = project / "board.kicad_pcb"
+    pcb.write_text("(kicad_pcb)")
+    sch = Schematic(title="Portable symbols")
+    sch.add_pwr_symbol("VMOTOR", x=100, y=100)
+    sch.write(project / "board.kicad_sch")
+    (project / "board.kicad_pro").write_text("{}")
+    return pcb
 
 
 class TestSha256File:
@@ -101,6 +119,136 @@ class TestCreateProjectZip:
 
         zip_path = _create_project_zip(project_dir / "board.kicad_pcb", out_dir, "my_project.zip")
         assert zip_path.name == "my_project.zip"
+
+    @pytest.mark.parametrize("prefix", ["", "${KIPRJMOD}/"])
+    def test_local_symbols_preserve_paths_and_deduplicate(
+        self, local_symbol_project, tmp_path, prefix
+    ):
+        pcb = local_symbol_project
+        project = pcb.parent
+        nested = project / "symbols" / "nested"
+        nested.mkdir(parents=True)
+        source = project / "kicad_tools_pwr.kicad_sym"
+        shutil.copyfile(source, nested / "power.kicad_sym")
+        table = project / "sym-lib-table"
+        table.write_text(
+            "(sym_lib_table (version 7)"
+            '(lib (name "direct") (type "KiCad") (uri "${KIPRJMOD}/kicad_tools_pwr.kicad_sym"))'
+            f'(lib (name "kicad_tools_pwr") (type "KiCad") (uri "{prefix}symbols/nested/power.kicad_sym"))'
+            f'(lib (name "alias") (type "KiCad") (uri "{prefix}symbols/nested/power.kicad_sym")))'
+        )
+        (project / "other.kicad_pcb").write_text("(kicad_pcb)")
+        (project / "board_backup_old.kicad_sch").write_text("(kicad_sch)")
+        archive = _create_project_zip(pcb, tmp_path)
+        with zipfile.ZipFile(archive) as zf:
+            assert set(zf.namelist()) == {
+                "board.kicad_pcb",
+                "board.kicad_sch",
+                "board.kicad_pro",
+                "sym-lib-table",
+                "kicad_tools_pwr.kicad_sym",
+                "symbols/nested/power.kicad_sym",
+            }
+            assert len(zf.namelist()) == len(set(zf.namelist()))
+            extracted = tmp_path / "extracted"
+            zf.extractall(extracted)
+        assert (extracted / "symbols/nested/power.kicad_sym").read_bytes() == source.read_bytes()
+        assert (extracted / "sym-lib-table").read_bytes() == table.read_bytes()
+
+    @pytest.mark.parametrize(
+        "uri",
+        [
+            "${KIPRJMOD}/missing.kicad_sym",
+            "../outside.kicad_sym",
+            "/tmp/outside.kicad_sym",
+            "C:/outside.kicad_sym",
+            "${KICAD10_SYMBOL_DIR}/Device.kicad_sym",
+            "https://example.com/a.kicad_sym",
+        ],
+    )
+    def test_missing_or_nonportable_library_fails_before_zip(
+        self, local_symbol_project, tmp_path, uri
+    ):
+        pcb = local_symbol_project
+        (pcb.parent / "sym-lib-table").write_text(
+            f'(sym_lib_table (lib (name "test") (type "KiCad") (uri "{uri}")))'
+        )
+        with pytest.raises((ValueError, FileNotFoundError), match="symbol library 'test'"):
+            _create_project_zip(pcb, tmp_path)
+        assert not (tmp_path / "kicad_project.zip").exists()
+
+    @pytest.mark.parametrize(
+        "table", ["(sym_lib_table", "(wrong)", '(sym_lib_table (lib (name "bad")))']
+    )
+    def test_malformed_table(self, local_symbol_project, tmp_path, table):
+        pcb = local_symbol_project
+        (pcb.parent / "sym-lib-table").write_text(table)
+        with pytest.raises(ValueError, match="sym-lib-table|symbol library"):
+            _create_project_zip(pcb, tmp_path)
+
+    def test_external_symlink_is_not_packaged(self, local_symbol_project, tmp_path):
+        pcb = local_symbol_project
+        library = pcb.parent / "kicad_tools_pwr.kicad_sym"
+        outside = tmp_path / "outside.kicad_sym"
+        library.rename(outside)
+        library.symlink_to(outside)
+        with pytest.raises(ValueError, match="resolves outside project"):
+            _create_project_zip(pcb, tmp_path)
+
+    def test_native_erc_library_resolution_survives_extraction(
+        self, local_symbol_project, tmp_path
+    ):
+        from kicad_tools.cli.runner import find_kicad_cli
+
+        cli = find_kicad_cli()
+        if cli is None:
+            pytest.skip("kicad-cli not installed")
+        pcb = local_symbol_project
+        # Exercise a real nested dependency, not just ZIP member presence.
+        project = pcb.parent
+        (project / "symbols").mkdir()
+        (project / "kicad_tools_pwr.kicad_sym").rename(project / "symbols/power.kicad_sym")
+        table = project / "sym-lib-table"
+        table.write_text(
+            table.read_text().replace("/kicad_tools_pwr.kicad_sym", "/symbols/power.kicad_sym")
+        )
+
+        def library_findings(schematic, name):
+            report = tmp_path / f"{name}.json"
+            process = subprocess.run(
+                [
+                    str(cli),
+                    "sch",
+                    "erc",
+                    "--format",
+                    "json",
+                    "--severity-all",
+                    "--output",
+                    str(report),
+                    str(schematic),
+                ],
+                capture_output=True,
+                text=True,
+                timeout=60,
+            )
+            assert process.returncode == 0, process.stderr
+            data = json.loads(report.read_text())
+            return [
+                v
+                for sheet in data["sheets"]
+                for v in sheet["violations"]
+                if v["type"] == "lib_symbol_issues"
+            ]
+
+        assert library_findings(project / "board.kicad_sch", "original") == []
+        archive = _create_project_zip(pcb, tmp_path)
+        extracted = tmp_path / "extracted"
+        with zipfile.ZipFile(archive) as zf:
+            zf.extractall(extracted)
+        assert library_findings(extracted / "board.kicad_sch", "extracted") == []
+        # Positive control: this native invocation detects the original omission.
+        (extracted / "sym-lib-table").unlink()
+        assert library_findings(extracted / "board.kicad_sch", "missing")
 
 
 class TestManufacturingConfig:
@@ -402,17 +550,10 @@ class TestManufacturingPackageExport:
     but exercise the project ZIP and manifest logic for real.
     """
 
-    def test_project_zip_and_manifest(self, tmp_path, monkeypatch):
+    def test_project_zip_and_manifest(self, tmp_path, monkeypatch, local_symbol_project):
         """Test that project ZIP and manifest are generated correctly."""
         # Create a minimal project directory
-        project_dir = tmp_path / "project"
-        project_dir.mkdir()
-        pcb = project_dir / "board.kicad_pcb"
-        pcb.write_text("(kicad_pcb)")
-        sch = project_dir / "board.kicad_sch"
-        sch.write_text("(kicad_sch)")
-        pro = project_dir / "board.kicad_pro"
-        pro.write_text("{}")
+        pcb = local_symbol_project
 
         out_dir = tmp_path / "output"
 
@@ -457,6 +598,8 @@ class TestManufacturingPackageExport:
             assert "board.kicad_pcb" in zf.namelist()
             assert "board.kicad_sch" in zf.namelist()
             assert "board.kicad_pro" in zf.namelist()
+            assert "sym-lib-table" in zf.namelist()
+            assert "kicad_tools_pwr.kicad_sym" in zf.namelist()
 
         # Manifest should exist
         assert result.manifest_path is not None
@@ -473,6 +616,19 @@ class TestManufacturingPackageExport:
         # to result.manifest_path AFTER writing. So let's just verify checksums.
         bom_sha = manifest["files"]["bom_jlcpcb.csv"]["sha256"]
         assert bom_sha == _sha256_file(result.assembly_result.bom_path)
+        zip_info = manifest["files"]["kicad_project.zip"]
+        assert zip_info["sha256"] == _sha256_file(result.project_zip_path)
+        assert zip_info["size"] == result.project_zip_path.stat().st_size
+
+    def test_symbol_dependency_error_marks_export_failed(self, local_symbol_project, tmp_path):
+        pcb = local_symbol_project
+        (pcb.parent / "kicad_tools_pwr.kicad_sym").unlink()
+        package = ManufacturingPackage(pcb_path=pcb, manufacturer="jlcpcb")
+        result = ManufacturingResult(output_dir=tmp_path)
+        package._generate_project_zip(tmp_path, result)
+        assert not result.success
+        assert result.project_zip_path is None
+        assert "Missing project symbol library" in result.errors[0]
 
     def test_no_report_flag(self, tmp_path, monkeypatch):
         """Test that --no-report skips report generation."""


### PR DESCRIPTION
## Summary

Project ZIP exports now include project-local symbol tables and their referenced KiCad libraries, preserving schematic library resolution after extraction.

## Changes

- Parse and validate symbol-table dependencies before creating the archive; retain nested project-relative paths and deduplicate members.
- Report missing/nonportable dependencies through the existing export error contract. Reject external paths, environment-dependent URIs, unsupported library types and outside-project symlinks.
- Add compact generated-symbol fixtures and document the packaging contract.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Include local table and direct/nested libraries | Complete | Relative and KIPRJMOD paths covered; extracted bytes and table preserved |
| Explicit missing/nonportable diagnostics | Complete | Missing, absolute, traversal, environment, URL, symlink and malformed-table cases; export result reports failure |
| Preserve selection, backups and duplicate contracts | Complete | Only selected PCB and non-backup schematic/project files; one member per dependency path |
| Preserve manifest size/SHA256 | Complete | Ordinary manufacturing export test verifies ZIP bytes against manifest |
| Native ERC parity | Complete | KiCad original/extracted projects have zero library-resolution findings; removing extracted table produces findings |
| Remove Board04 append/rehash workaround | Complete | Rebased after #5045 merged and removed the workaround; normal export supplies local libraries and manifest hashes |

## Test Plan

Latest integration: 89 packaging/process tests passed. Independent re-review: 19 focused tests passed, including native extraction parity and a missing-table failure control. Actual Board04 source/extracted ERC findings match; 30 environment-related warnings remain visible in both.

- `uv run pytest tests/test_manufacturing_package.py --no-cov -q`: **81 passed**, including native ERC control.
- Ruff lint and format checks on changed Python files: passed.
- `git diff --check`: passed.
- Focused mypy: six pre-existing errors in unchanged portions of manufacturing.py; confirmed identical diagnostics against HEAD using `--shadow-file`. No new diagnostics.

TDD: no — implementation and regression fixtures developed together; native missing-table control independently verifies sensitivity to the original defect.

Closes #5071
