### PR TITLE
feat(benchmark): measure Board09 host-bus routing with native validation

### DIFF
--- a/boards/09-usbc-pd-power/engineering/routing-investigation/host-bus/README.md
+++ b/boards/09-usbc-pd-power/engineering/routing-investigation/host-bus/README.md
@@ -21,3 +21,76 @@ router's obstacle escape and multi-terminal routing. See the parent engineering
 review for thermal and procurement gates still blocking manufacture.
 
 Host-bus benchmark request: [#5072](https://github.com/rjwalters/kicad-tools/issues/5072).
+
+## Executable benchmark
+
+From the repository root, with the development dependencies installed (`uv sync
+--frozen --extra dev`) and `kicad-cli` on PATH:
+
+```sh
+uv run python boards/09-usbc-pd-power/engineering/routing-investigation/host-bus/benchmark.py --results /tmp/board09-host-bus-results
+```
+
+The results directory must not already exist. Both committed command JSON files
+run sequentially, keeping their strict settings, four target nets, seed 42,
+eight iterations and net-class map. Each case copies the canonical project,
+schematic and libraries into its own directory, installs the numbered source,
+and preserves the project under **both** `usbc_pd_power` and `support` basenames.
+Repository PCB/project artifacts are never written. The router subprocess has a
+300-second safety cap; timings are observations, not CI thresholds. For comparable
+performance, use the same router backend/build and avoid concurrent workloads.
+`uv run kct build-native` builds the optional C++ extension; backend selection and
+fallbacks appear in each `router.log`.
+
+`results.json` contains the environment, exact commands, router return codes,
+wall time spent in routing (including process startup, excluding independent
+validation), per-net physical pad connectivity, preservation checks, and native
+validation results. Each case retains its own `result.json`, `router.log`, output
+PCB, and native DRC JSON/log. The final output, including zones refilled by
+`kicad-cli pcb drc --refill-zones --save-board`, is what is measured; a raw partial
+snapshot is never treated as canonical output.
+
+A target is `complete` only when **all** its original pads occur in one physical
+copper component, `partial` when at least two but not all are connected, and
+`unrouted` when every pad is separate. Missing/single-pad targets are `missing`;
+missing or unreadable output yields `unknown`. Neither can claim completion.
+`largest_component_pads` reports the largest physical group, so an unrouted
+multi-terminal net normally has a value of 1. Connectivity uses the existing
+label-independent pad partition extractor; native DRC remains an independent
+mandatory gate, including possible shorts that a partition alone cannot reject.
+
+`success: true` additionally requires a zero router exit code, all four targets
+preserved, unchanged placement/pad geometry, preserved existing segments/vias
+and zone definitions, outer-layer target tracks/zones, and a native-refilled
+report with zero violations and zero opens. Through vias between the outer
+layers are permitted. Zone fill polygons may change during refill. Missing
+KiCad produces `native_validation.status: unavailable`, never a clean report.
+The script exits zero when both measurements finish even if routing fails;
+automation should inspect `success`, not interpret the process exit as routing
+success. No routing heuristics or clearances are changed by this diagnostic.
+
+Fast regression coverage:
+
+```sh
+uv run pytest tests/test_board09_host_bus_benchmark.py tests/test_benchmarks.py --no-cov
+```
+
+## Measured run, 2026-09-10
+
+[Machine-readable measurements](measured-results.json) record KiCad 10.0.6,
+Python 3.12.13 and the host platform, against source revision `8801f88c`.
+The sweep host had concurrent work, so compare completion before comparing time.
+
+| Grid | Router elapsed | Complete / partial / unrouted | Native violations / opens |
+| --- | --- | --- | --- |
+| 0.1 mm | 40.69 s | 0 / 1 / 3 (MON_ALERT partial) | 0 / 9 |
+| 0.05 mm | 82.43 s | 0 / 0 / 4 | 0 / 10 |
+
+Both canonical routed outputs retained existing copper/zone definitions and
+placement, and their target copper remained on outer layers. Neither passed the
+success gate. In particular, the fine-grid result does not promote a few emitted
+segments to a connected branch. Logs showed C++ search exhaustion or clearance
+rejection followed by Python fallback; investigating those routing limitations
+is subsequent work. A separate fresh native refill of the manual canonical PCB
+in scratch returned zero violations and zero opens, confirming the comparison
+remains feasible without claiming that the autorouter solved it.

--- a/boards/09-usbc-pd-power/engineering/routing-investigation/host-bus/benchmark.py
+++ b/boards/09-usbc-pd-power/engineering/routing-investigation/host-bus/benchmark.py
@@ -1,0 +1,261 @@
+#!/usr/bin/env python3
+"""Measure the fixed four-net Board09 fixture without changing canonical artifacts."""
+
+import argparse
+import json
+import platform
+import shutil
+import subprocess
+import time
+from collections import Counter
+from dataclasses import asdict
+from pathlib import Path
+
+from kicad_tools.schema.pcb import PCB
+from kicad_tools.validate.connectivity import ConnectivityValidator
+
+ROOT = Path(__file__).resolve().parent
+OUTPUT = ROOT.parents[2] / "output"
+TARGETS = ("SCL", "SDA", "MON_ALERT", "PD_ALERT")
+
+
+def classify(pads, partition):
+    """Require every expected terminal in one physical component for completion."""
+    result = {}
+    for name in TARGETS:
+        expected = pads.get(name, set())
+        sizes = [len(expected & group) for group in partition]
+        largest = max(sizes, default=0)
+        status = (
+            "missing"
+            if len(expected) < 2
+            else (
+                "complete" if largest == len(expected) else "partial" if largest > 1 else "unrouted"
+            )
+        )
+        result[name] = {
+            "status": status,
+            "total_pads": len(expected),
+            "largest_component_pads": largest,
+        }
+    return result
+
+
+def prepare_case(directory, command_file):
+    """Copy project and libraries; alter only paths in the committed command."""
+    shutil.copytree(OUTPUT, directory)
+    shutil.copy2(ROOT / "numbered-source.kicad_pcb", directory / "usbc_pd_power.kicad_pcb")
+    shutil.copy2(directory / "usbc_pd_power.kicad_pro", directory / "support.kicad_pro")
+    command = json.loads((ROOT / command_file).read_text())
+    command[4] = str(directory / "usbc_pd_power.kicad_pcb")
+    for flag in ("-o", "--net-class-map"):
+        index = command.index(flag) + 1
+        command[index] = str(directory / Path(command[index]).name)
+    mapping = json.loads((directory / "net_class_map.json").read_text())
+    if any(not {1, 2} <= set(mapping[name]["avoid_layers"]) for name in TARGETS):
+        raise ValueError("Target net classes must avoid both inner layers")
+    return command
+
+
+def native_status(returncode, report):
+    valid = isinstance(report, dict) and all(
+        isinstance(report.get(key), list) for key in ("violations", "unconnected_items")
+    )
+    return {
+        "status": "passed"
+        if returncode == 0
+        and valid
+        and not report["violations"]
+        and not report["unconnected_items"]
+        else "failed",
+        "returncode": returncode,
+        "violations": len(report["violations"]) if valid else None,
+        "opens": len(report["unconnected_items"]) if valid else None,
+    }
+
+
+def validate_native(pcb):
+    executable = shutil.which("kicad-cli")
+    if executable is None:
+        return {"status": "unavailable", "reason": "kicad-cli not found"}
+    report_path = pcb.with_suffix(".drc.json")
+    report_path.unlink(missing_ok=True)
+    command = [
+        executable,
+        "pcb",
+        "drc",
+        str(pcb),
+        "--refill-zones",
+        "--save-board",
+        "--format",
+        "json",
+        "--output",
+        str(report_path),
+    ]
+    try:
+        process = subprocess.run(command, capture_output=True, text=True, timeout=180, check=False)
+        pcb.with_suffix(".drc.log").write_text(process.stdout + process.stderr)
+        report = json.loads(report_path.read_text()) if report_path.exists() else None
+        return {**native_status(process.returncode, report), "command": command}
+    except (OSError, ValueError, subprocess.TimeoutExpired) as error:
+        return {"status": "failed", "reason": str(error), "command": command}
+
+
+def target_pads(board):
+    return {
+        name: {
+            f"{fp.reference}.{pad.number}"
+            for fp in board.footprints
+            for pad in fp.pads
+            if pad.net_name == name
+        }
+        for name in TARGETS
+    }
+
+
+def copper(board):
+    """Geometry multiset ignores numeric net IDs and UUIDs rewritten by native save."""
+    segments = [("segment", s.start, s.end, s.width, s.layer, s.net_name) for s in board.segments]
+    vias = [("via", v.position, v.size, v.drill, tuple(v.layers), v.net_name) for v in board.vias]
+    # Filled polygons legitimately change during refill. Preserve zone boundaries,
+    # clearances, layer restrictions and thermal settings instead.
+    zones = []
+    for zone in board.zones:
+        fields = asdict(zone)
+        for key in ("net_number", "uuid", "filled_polygons", "filled_polygon_layers", "is_filled"):
+            fields.pop(key, None)
+        zones.append(("zone", json.dumps(fields, sort_keys=True)))
+    return Counter(segments + vias + zones)
+
+
+def placement(board):
+    return sorted(
+        (
+            fp.reference,
+            fp.position,
+            fp.rotation,
+            fp.layer,
+            tuple(
+                (
+                    p.number,
+                    p.position,
+                    p.size,
+                    p.rotation,
+                    p.shape,
+                    tuple(sorted(p.layers)),
+                    p.net_name,
+                )
+                for p in fp.pads
+            ),
+        )
+        for fp in board.footprints
+    )
+
+
+def inspect_output(source, output):
+    before, after = PCB.load(source), PCB.load(output)
+    pads = target_pads(before)
+    after_pads = target_pads(after)
+    partition = ConnectivityValidator(after).extract_pad_partition()
+    nets = classify(pads, partition)
+    outer = all(s.layer in {"F.Cu", "B.Cu"} for s in after.segments if s.net_name in TARGETS)
+    outer = outer and all(
+        z.layer in {"F.Cu", "B.Cu"}
+        for z in after.zones
+        if z.net_name in TARGETS and z.keepout is None
+    )
+    outer = outer and all(
+        set(v.layers) <= {"F.Cu", "B.Cu"} for v in after.vias if v.net_name in TARGETS
+    )
+    return {
+        "nets": nets,
+        "targets_preserved": pads == after_pads and all(len(pads[n]) >= 2 for n in TARGETS),
+        "existing_copper_preserved": not (copper(before) - copper(after)),
+        "placement_preserved": placement(before) == placement(after),
+        "target_copper_outer_only": outer,
+    }
+
+
+def run_case(directory, command_file):
+    command = prepare_case(directory, command_file)
+    source, output = directory / "usbc_pd_power.kicad_pcb", directory / "support.kicad_pcb"
+    output.unlink(missing_ok=True)
+    started = time.perf_counter()
+    result = {
+        "command": command,
+        "grid_mm": float(command[command.index("--grid") + 1]),
+        "nets": {
+            name: {"status": "unknown", "total_pads": None, "largest_component_pads": None}
+            for name in TARGETS
+        },
+    }
+    with (directory / "router.log").open("w") as log:
+        try:
+            process = subprocess.run(
+                command, stdout=log, stderr=subprocess.STDOUT, timeout=300, check=False
+            )
+            result["router_returncode"] = process.returncode
+        except (OSError, subprocess.TimeoutExpired) as error:
+            result.update(router_returncode=None, error=str(error))
+    result["elapsed_seconds"] = time.perf_counter() - started
+    result["native_validation"] = (
+        validate_native(output)
+        if output.exists()
+        else {"status": "unavailable", "reason": "router produced no PCB"}
+    )
+    if output.exists():
+        try:
+            result.update(inspect_output(source, output))
+        except (OSError, ValueError) as error:
+            result["inspection_error"] = str(error)
+    result["success"] = (
+        result["router_returncode"] == 0
+        and result["native_validation"]["status"] == "passed"
+        and all(
+            result.get(key, False)
+            for key in (
+                "targets_preserved",
+                "existing_copper_preserved",
+                "placement_preserved",
+                "target_copper_outer_only",
+            )
+        )
+        and len(result.get("nets", {})) == 4
+        and all(n["status"] == "complete" for n in result.get("nets", {}).values())
+    )
+    (directory / "result.json").write_text(json.dumps(result, indent=2) + "\n")
+    return result
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--results",
+        type=Path,
+        required=True,
+        help="New directory for retained scratch boards, logs and JSON",
+    )
+    args = parser.parse_args()
+    directory = args.results.resolve()
+    directory.mkdir(parents=True, exist_ok=False)
+    results = {
+        "environment": {"platform": platform.platform(), "python": platform.python_version()},
+        "cases": [],
+    }
+    if shutil.which("kicad-cli"):
+        results["environment"]["kicad"] = subprocess.run(
+            ["kicad-cli", "--version"], capture_output=True, text=True, check=False
+        ).stdout.strip()
+    for command_file in ("numbered-command.json", "fine-command.json"):
+        result = run_case(directory / command_file.removesuffix(".json"), command_file)
+        results["cases"].append(result)
+        (directory / "results.json").write_text(json.dumps(results, indent=2) + "\n")
+        print(
+            f"grid={result['grid_mm']} elapsed={result['elapsed_seconds']:.1f}s success={result['success']}",
+            flush=True,
+        )
+    return 0  # A measured routing failure is a benchmark result, not a harness crash.
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/boards/09-usbc-pd-power/engineering/routing-investigation/host-bus/measured-results.json
+++ b/boards/09-usbc-pd-power/engineering/routing-investigation/host-bus/measured-results.json
@@ -1,0 +1,91 @@
+{
+  "environment": {
+    "platform": "macOS-26.6.2-arm64-arm-64bit",
+    "python": "3.12.13",
+    "kicad": "10.0.6"
+  },
+  "cases": [
+    {
+      "grid_mm": 0.1,
+      "router_returncode": 1,
+      "elapsed_seconds": 40.69055683282204,
+      "native_validation": {
+        "status": "failed",
+        "returncode": 0,
+        "violations": 0,
+        "opens": 9
+      },
+      "nets": {
+        "SCL": {
+          "status": "unrouted",
+          "total_pads": 4,
+          "largest_component_pads": 1
+        },
+        "SDA": {
+          "status": "unrouted",
+          "total_pads": 4,
+          "largest_component_pads": 1
+        },
+        "MON_ALERT": {
+          "status": "partial",
+          "total_pads": 3,
+          "largest_component_pads": 2
+        },
+        "PD_ALERT": {
+          "status": "unrouted",
+          "total_pads": 3,
+          "largest_component_pads": 1
+        }
+      },
+      "targets_preserved": true,
+      "existing_copper_preserved": true,
+      "placement_preserved": true,
+      "target_copper_outer_only": true,
+      "success": false,
+      "command_file": "numbered-command.json"
+    },
+    {
+      "grid_mm": 0.05,
+      "router_returncode": 1,
+      "elapsed_seconds": 82.42769845807925,
+      "native_validation": {
+        "status": "failed",
+        "returncode": 0,
+        "violations": 0,
+        "opens": 10
+      },
+      "nets": {
+        "SCL": {
+          "status": "unrouted",
+          "total_pads": 4,
+          "largest_component_pads": 1
+        },
+        "SDA": {
+          "status": "unrouted",
+          "total_pads": 4,
+          "largest_component_pads": 1
+        },
+        "MON_ALERT": {
+          "status": "unrouted",
+          "total_pads": 3,
+          "largest_component_pads": 1
+        },
+        "PD_ALERT": {
+          "status": "unrouted",
+          "total_pads": 3,
+          "largest_component_pads": 1
+        }
+      },
+      "targets_preserved": true,
+      "existing_copper_preserved": true,
+      "placement_preserved": true,
+      "target_copper_outer_only": true,
+      "success": false,
+      "command_file": "fine-command.json"
+    }
+  ],
+  "source_sha256": "0320aa5c8704ed3435b1fec23215ed45a37ab70c0562163f02467f7584b2a97e",
+  "source_revision": "8801f88c7111190aebbb61f032a334ac8c580411",
+  "measured_on": "2026-09-10",
+  "notes": "Concurrent sweep host; diagnostic runtimes, not a performance threshold. Native output inspected again with final preservation checks. No successful autoroute claimed."
+}

--- a/tests/test_board09_host_bus_benchmark.py
+++ b/tests/test_board09_host_bus_benchmark.py
@@ -1,0 +1,153 @@
+"""Fast gates for the real Board09 routing diagnostic."""
+
+import importlib.util
+import json
+from pathlib import Path
+
+import pytest
+
+PATH = (
+    Path(__file__).parents[1]
+    / "boards/09-usbc-pd-power/engineering/routing-investigation/host-bus/benchmark.py"
+)
+spec = importlib.util.spec_from_file_location("host_bus_benchmark", PATH)
+benchmark = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(benchmark)
+
+
+def test_partial_branch_does_not_complete_multiterminal_net():
+    pads = {name: {f"{name}.1", f"{name}.2", f"{name}.3"} for name in benchmark.TARGETS}
+    groups = [{"SCL.1", "SCL.2"}, {"SCL.3"}, pads["SDA"]]
+    result = benchmark.classify(pads, groups)
+    assert result["SCL"]["status"] == "partial"
+    assert result["SDA"]["status"] == "complete"
+    assert result["MON_ALERT"]["status"] == "unrouted"
+    assert json.loads(json.dumps(result)) == result
+
+
+def test_missing_targets_fail_closed():
+    result = benchmark.classify({}, [])
+    assert len(result) == 4
+    assert all(info["status"] == "missing" for info in result.values())
+
+
+def test_scratch_commands_keep_strict_settings_and_both_project_names(tmp_path):
+    for command_file in ("numbered-command.json", "fine-command.json"):
+        directory = tmp_path / command_file
+        command = benchmark.prepare_case(directory, command_file)
+        assert "--preserve-existing" in command
+        assert "--strict-layers" in command
+        assert command[command.index("--nets") + 1] == ",".join(benchmark.TARGETS)
+        assert command[command.index("--seed") + 1] == "42"
+        assert command[command.index("--iterations") + 1] == "8"
+        assert (directory / "support.kicad_pro").read_bytes() == (
+            directory / "usbc_pd_power.kicad_pro"
+        ).read_bytes()
+        assert Path(command[4]).parent == directory
+        assert Path(command[command.index("-o") + 1]).parent == directory
+
+
+@pytest.mark.parametrize(
+    "report",
+    [
+        {},
+        {"violations": [], "unconnected_items": [{}]},
+        {"violations": [{}], "unconnected_items": []},
+    ],
+)
+def test_native_invalid_reports_do_not_pass(report):
+    assert benchmark.native_status(0, report)["status"] != "passed"
+
+
+def test_native_failure_and_missing_tool(tmp_path, monkeypatch):
+    assert (
+        benchmark.native_status(1, {"violations": [], "unconnected_items": []})["status"]
+        == "failed"
+    )
+    monkeypatch.setattr(benchmark.shutil, "which", lambda _: None)
+    assert benchmark.validate_native(tmp_path / "support.kicad_pcb")["status"] == "unavailable"
+
+
+def test_native_clean_report():
+    assert (
+        benchmark.native_status(0, {"violations": [], "unconnected_items": []})["status"]
+        == "passed"
+    )
+
+
+def test_native_refills_and_rejects_missing_report(tmp_path, monkeypatch):
+    from types import SimpleNamespace
+
+    seen = []
+    monkeypatch.setattr(benchmark.shutil, "which", lambda _: "/fake/kicad-cli")
+
+    def run(command, **kwargs):
+        seen.extend(command)
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(benchmark.subprocess, "run", run)
+    result = benchmark.validate_native(tmp_path / "support.kicad_pcb")
+    assert "--refill-zones" in seen and "--save-board" in seen
+    assert result["status"] == "failed"
+
+
+@pytest.mark.parametrize(
+    "failure",
+    [None, "native", "partial", "missing", "inner", "copper", "placement", "targets", "router"],
+)
+def test_success_requires_all_independent_gates(tmp_path, monkeypatch, failure):
+    from types import SimpleNamespace
+
+    def run(command, **kwargs):
+        (tmp_path / "case/support.kicad_pcb").write_text("mock routed output")
+        return SimpleNamespace(returncode=1 if failure == "router" else 0)
+
+    monkeypatch.setattr(benchmark.subprocess, "run", run)
+    monkeypatch.setattr(
+        benchmark,
+        "validate_native",
+        lambda _: {"status": "failed" if failure == "native" else "passed"},
+    )
+    info = {
+        "nets": {name: {"status": "complete"} for name in benchmark.TARGETS},
+        "targets_preserved": failure != "targets",
+        "existing_copper_preserved": failure != "copper",
+        "placement_preserved": failure != "placement",
+        "target_copper_outer_only": failure != "inner",
+    }
+    if failure == "partial":
+        info["nets"]["SCL"]["status"] = "partial"
+    if failure == "missing":
+        info["nets"] = {}
+    monkeypatch.setattr(benchmark, "inspect_output", lambda *args: info)
+    result = benchmark.run_case(tmp_path / "case", "numbered-command.json")
+    assert result["success"] is (failure is None)
+    assert json.loads((tmp_path / "case/result.json").read_text()) == result
+
+
+def test_copper_preservation_includes_zone_boundary_but_allows_refill():
+    from types import SimpleNamespace
+
+    from kicad_tools.schema.pcb import Zone
+
+    zone = Zone(net_number=1, net_name="GND", layer="In1.Cu", polygon=[(0, 0), (1, 0), (1, 1)])
+    board = SimpleNamespace(segments=[], vias=[], zones=[zone])
+    before = benchmark.copper(board)
+    zone.filled_polygons = [[(0.1, 0.1), (0.9, 0.1), (0.9, 0.9)]]
+    zone.is_filled = True
+    assert benchmark.copper(board) == before
+    zone.polygon[0] = (0.2, 0.2)
+    assert before - benchmark.copper(board)
+
+
+def test_no_router_output_is_unknown_not_zero_net_success(tmp_path, monkeypatch):
+    from types import SimpleNamespace
+
+    monkeypatch.setattr(
+        benchmark.subprocess, "run", lambda *args, **kwargs: SimpleNamespace(returncode=0)
+    )
+    result = benchmark.run_case(tmp_path / "case", "numbered-command.json")
+    assert result["success"] is False
+    assert set(result["nets"]) == set(benchmark.TARGETS)
+    assert all(n["status"] == "unknown" for n in result["nets"].values())
+    assert result["native_validation"]["status"] == "unavailable"


### PR DESCRIPTION
## Summary
Add an executable Board09 four-net host-bus benchmark that measures both committed grid cases in isolated scratch projects and requires independent native-refilled validation for any success claim.

Closes #5072

## Changes
- Preserve the exact strict routing commands, supporting libraries and both source/output project basenames.
- Report per-net physical pad connectivity, routing time, return code, native DRC status, outer-layer target copper, and existing copper/zone/placement preservation.
- Fail the success gate on partial/missing targets, missing output or KiCad, malformed/native-failing reports, inner-layer target copper or changed source geometry.
- Document invocation and commit portable measured results. No routing heuristics or board artifacts changed.

## Acceptance Criteria Verification
- [x] One documented command executes 0.1 and 0.05 mm grids, four targets, seed 42/eight iterations and all original strict settings.
- [x] JSON separately identifies complete/partial/unrouted/missing/unknown targets and runtime; partial branches cannot count as complete multi-terminal nets.
- [x] Success requires native refill with zero violations/opens plus preservation and outer-layer checks. Both measured autorouter results correctly fail.
- [x] Fast tests cover scratch paths/project names, partial/missing connectivity, all success gates, failed/missing native validation, zone preservation and JSON output.
- [x] Executed both real cases on macOS arm64, Python 3.12.13, KiCad 10.0.6. 0.1 mm: 40.69 s, 0 complete/1 partial/3 unrouted, native 0 violations/9 opens. 0.05 mm: 82.43 s, 0 complete/0 partial/4 unrouted, native 0 violations/10 opens. Both retain existing copper/zone definitions and placement and outer-layer target copper.
- [x] Fresh independent native refill of the manual comparison PCB in scratch reports 0 violations/0 opens. This is comparison evidence, not autorouter success.

## Test Plan
TDD: Added the initial eight harness tests first; collection failed because the benchmark module did not exist. Implemented to green, then extended coverage to 20 tests for independent success gates and preservation.

- `uv run pytest tests/test_board09_host_bus_benchmark.py --no-cov -q`: 20 passed.
- Earlier combined focused/existing run: `uv run pytest tests/test_board09_host_bus_benchmark.py tests/test_benchmarks.py --no-cov -q`: 47 passed (18 harness + 29 existing), 6 existing router timeout warnings; two additional harness tests pass in the final focused run.
- Ruff check and format check on changed Python files pass; `git diff --check` passes.
- Real artifacts retained at `/tmp/board09-benchmark-5072`, with portable results committed as `measured-results.json`; final preservation inspection rerun on both refilled outputs after tightening zone/pad checks.
- Broad suite left to CI; no build gate is configured. Runtime values came from a concurrent sweep host and are diagnostic, not performance assertions. No successful autoroute is claimed.