### PR TITLE
test: pin joystick capability geometry and retain bounded routing diagnostics

### DIFF
--- a/boards/03-usb-joystick/regression-fixture/README.md
+++ b/boards/03-usb-joystick/regression-fixture/README.md
@@ -7,10 +7,22 @@ This synthetic 32-pad controller layout preserves the geometry exercised by
 legacy #2760/#3183/#3308 escape-routing capability tests. It is not a working
 circuit or a manufacturing release. Do not select it for gallery or export.
 
-`tests/test_board_03_regression.py::routed_board_03` uses this snapshot;
+`tests/test_board_03_regression.py::routed_board_03` and
+`tests/router/test_board03_routing_baseline.py` use this snapshot;
 real circuit, native DRC and manufacturing tests use the revision-B files in
 `output/` and `tests/test_board_03_real_hardware.py`.
 
 Tracked in [#5042](https://github.com/rjwalters/kicad-tools/issues/5042).
 
-Historical silkscreen witness `usb_joystick_routed.kicad_pcb` from `06fb5e30` preserves known defects for detector parity tests. It is not manufacturing data. SHA-256: `f4ee2d9b1cf82f10aa86d5ac8277118518d0d9a9ba9de2c3abdafe69eee14397`.
+Historical silkscreen witness `usb_joystick_routed.kicad_pcb` from `06fb5e30` preserves known defects for detector parity and historical fix-drc tests. It is not manufacturing data. SHA-256: `f4ee2d9b1cf82f10aa86d5ac8277118518d0d9a9ba9de2c3abdafe69eee14397`.
+
+The historical CLI baseline asserts the unchanged 13/13 reach floor and checks
+this snapshot's SHA-256 and 32-pad MCU. Its frozen June recipe is independent
+of revision B's reviewed routing replay. CLI runs use a 600-second routing
+budget and 900-second process cap; copied inputs, any partial PCB, and stdout/
+stderr logs remain under pytest's temporary directory, named in timeout
+failures. The in-process capability fixture has a 480-second outer routing
+budget and the module's 600-second pytest backstop; routing statistics are
+written to its pytest temporary directory even when interrupted. Neither path
+writes to this archive or production `output/`. Hardware circuit and native
+DRC tests remain on revision B, with their existing zero-error contract.

--- a/tests/router/test_board03_routing_baseline.py
+++ b/tests/router/test_board03_routing_baseline.py
@@ -1,5 +1,11 @@
 """Board 03 (usb-joystick) routing baseline regression guard.
 
+Historical capability tests use the SHA-pinned 32-pad snapshot in
+``regression-fixture/``. Production DRC below still checks revision B in
+``output/``. CLI runs retain temporary PCB/log artifacts on timeout (900s
+process cap; 600s routing budget), and never regenerate or overwrite inputs.
+The June recipe described below is frozen, not the current hardware recipe.
+
 This test pins the **measured routing reach** of
 ``boards/03-usb-joystick/`` against the ``kct route`` CLI as of
 June 2026.
@@ -176,19 +182,21 @@ References:
 
 from __future__ import annotations
 
+import hashlib
 import os
 import re
 import shutil
 import subprocess
 import sys
-import tempfile
 from pathlib import Path
 
 import pytest
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 BOARD_DIR = REPO_ROOT / "boards" / "03-usb-joystick"
-UNROUTED_PCB = BOARD_DIR / "output" / "usb_joystick.kicad_pcb"
+UNROUTED_PCB = BOARD_DIR / "regression-fixture" / "usb_joystick.kicad_pcb"
+HISTORICAL_SHA256 = "6c4292a95345a7670ebc3879262d192edf40c90335ba6bee83c3c88441d18c98"
+ROUTE_TIMEOUT = 900
 COMMITTED_ROUTED_PCB = BOARD_DIR / "output" / "usb_joystick_routed.kicad_pcb"
 
 # Acceptance criteria for the June 2026 baseline.
@@ -383,12 +391,11 @@ def _parse_per_net_status(stdout: str) -> dict[str, str]:
 def _write_diffpair_sidecar(dest_dir: Path) -> Path:
     """Write the board 03 net-class sidecar into ``dest_dir``.
 
-    Mirrors ``generate_design.py:route_pcb()`` exactly: annotate the USB
+    Replays the historical June recipe: annotate the USB
     D+/D- pair with ``diffpair_partner`` and a 0.15mm
     ``intra_pair_clearance`` (#3095) so the ``--net-class-map`` flag can
     hand the CoupledPathfinder the coupled-routing metadata.  Returns the
-    path to the written ``net_class_map.json``.  KEEP IN SYNC with
-    generate_design.py:route_pcb() (Issue #3922).
+    path to the written ``net_class_map.json`` (Issue #3922).
     """
     import json as _json
     from dataclasses import replace as _dc_replace
@@ -419,113 +426,120 @@ def _write_diffpair_sidecar(dest_dir: Path) -> Path:
 
 @pytest.fixture(scope="module")
 def unrouted_pcb_path() -> Path:
-    """Verify the committed unrouted board 03 PCB exists.
-
-    The PCB is committed under ``boards/03-usb-joystick/output/``.  If
-    the file is missing the test cannot run -- skip with a clear message.
-    """
-    if not UNROUTED_PCB.exists():
-        pytest.skip(
-            f"Board 03 unrouted PCB not found at {UNROUTED_PCB!s}; "
-            "regenerate via `uv run python boards/03-usb-joystick/generate_pcb.py`."
-        )
+    """Require the frozen synthetic fixture; never regenerate with revision B."""
+    assert UNROUTED_PCB.is_file(), "Historical board03 fixture missing; restore it from git"
+    assert hashlib.sha256(UNROUTED_PCB.read_bytes()).hexdigest() == HISTORICAL_SHA256
     return UNROUTED_PCB
 
 
-def _run_kct_route(unrouted: Path, seed: int) -> str:
+def _run_kct_route(unrouted: Path, seed: int, artifacts: Path) -> str:
     """Run ``kct route --backend cpp --seed N --auto-fix`` and capture stdout.
 
-    Mirrors the recipe in the parent issue (#3259) and the standard
-    fleet/build invocation.  Routes to a tmpdir so it never overwrites
-    the committed artifact.
+    Replays the historical June recipe independently of the revision-B
+    hardware replay. Inputs and any partial output remain in pytest artifacts.
     """
-    with tempfile.TemporaryDirectory() as td:
-        pcb_copy = Path(td) / "usb_joystick.kicad_pcb"
-        shutil.copy2(unrouted, pcb_copy)
-        output_path = Path(td) / "usb_joystick_routed.kicad_pcb"
-        # Issue #3922: mirror the production net-class sidecar so
-        # ``--net-class-map`` (below) reads the same USB D+/D-
-        # diffpair_partner / intra_pair_clearance metadata the recipe
-        # writes.  KEEP IN SYNC with generate_design.py:route_pcb().
-        sidecar_path = _write_diffpair_sidecar(output_path.parent)
-        cmd = [
-            sys.executable,
-            "-m",
-            "kicad_tools.cli",
-            "route",
-            str(pcb_copy),
-            "--output",
-            str(output_path),
-            "--seed",
-            str(seed),
-            "--manufacturer",
-            "jlcpcb-tier1",
-            "--backend",
-            "cpp",
-            # Issue #3799: kept in lock-step with the production recipe in
-            # ``generate_design.py:route_pcb()`` -- --deterministic-budget
-            # (#3538) routes under a fixed iteration backstop instead of the
-            # per-net wall-clock cutoff, so the seed-42 re-route is
-            # byte-identical (UUID-normalized) across machines.
-            "--deterministic-budget",
-            "--timeout",
-            "600",
-            # Issue #3922: --differential-pairs was silently dropped in the
-            # #3308/#3410 recipe consolidation, so USB_D+/USB_D- routed
-            # through the plain per-net A* loop and the CoupledPathfinder
-            # (Phase A) was never invoked.  Restored here in lock-step with
-            # generate_design.py:route_pcb().  --net-class-map forwards the
-            # sidecar so the router reads the diff-pair metadata.
-            "--differential-pairs",
-            "--net-class-map",
-            str(sidecar_path),
-            # Issue #3922: --auto-layers is kept (the default) so the escape
-            # pre-phase board 03's fine-pitch USB-C needs still runs (13/13 +
-            # 0 native DRC).  On this board --differential-pairs is inert at
-            # routing time because route_cmd's escape / escalation dispatch
-            # does not consult it (tracked in #3952); forcing the diff-pair
-            # path with --no-auto-layers would reintroduce a DRC clearance
-            # violation.  KEEP IN SYNC with generate_design.py:route_pcb().
-            # Issues #3507/#3454: ``--raw`` removed in lock-step with the
-            # production recipe in ``generate_design.py:route_pcb()`` --
-            # the grid-transactional optimize pass retired the
-            # deterministic clearance_segment_via merge violation that
-            # made it load-bearing.  Keep these flag lists in sync.
-        ]
-        # Issue #3799: pin PYTHONHASHSEED to match the production recipe so
-        # the baseline measured here is the SAME copper the recipe emits.
-        _route_env = os.environ.copy()
-        _route_env["PYTHONHASHSEED"] = "42"
-        proc = subprocess.run(
-            cmd,
-            capture_output=True,
-            text=True,
-            timeout=900,
-            check=False,
-            env=_route_env,
-        )
-        # Exit codes from cli/route_cmd.py:
-        #   0 = full route + DRC clean
-        #   2 = partial routing below --min-completion
-        #   3 = >= min-completion but DRC violations remain
-        # Board 03 lands at 2 or 3 (partial + DRC).  Codes 1 and 5 are
-        # fatal (crash / SIGINT).
-        if proc.returncode in (1, 5):
-            pytest.fail(
-                f"kct route returned fatal exit code {proc.returncode}\n"
-                f"stderr (last 2000 chars):\n{proc.stderr[-2000:]}\n"
-                f"stdout (last 2000 chars):\n{proc.stdout[-2000:]}"
+    artifacts.mkdir(parents=True, exist_ok=True)
+    pcb_copy = artifacts / "usb_joystick.kicad_pcb"
+    shutil.copy2(unrouted, pcb_copy)
+    output_path = artifacts / "usb_joystick_routed.kicad_pcb"
+    # Issue #3922: preserve the historical net-class sidecar so
+    # ``--net-class-map`` (below) reads the same USB D+/D-
+    # diffpair_partner / intra_pair_clearance metadata the recipe
+    # writes.  Frozen with the historical June recipe.
+    sidecar_path = _write_diffpair_sidecar(output_path.parent)
+    cmd = [
+        sys.executable,
+        "-m",
+        "kicad_tools.cli",
+        "route",
+        str(pcb_copy),
+        "--output",
+        str(output_path),
+        "--seed",
+        str(seed),
+        "--manufacturer",
+        "jlcpcb-tier1",
+        "--backend",
+        "cpp",
+        # Issue #3799: frozen from the historical recipe in
+        # ``generate_design.py:route_pcb()`` -- --deterministic-budget
+        # (#3538) routes under a fixed iteration backstop instead of the
+        # per-net wall-clock cutoff, so the seed-42 re-route is
+        # byte-identical (UUID-normalized) across machines.
+        "--deterministic-budget",
+        "--timeout",
+        "600",
+        # Issue #3922: --differential-pairs was silently dropped in the
+        # #3308/#3410 recipe consolidation, so USB_D+/USB_D- routed
+        # through the plain per-net A* loop and the CoupledPathfinder
+        # (Phase A) was never invoked.  Restored here in lock-step with
+        # the June recipe.  --net-class-map forwards the
+        # sidecar so the router reads the diff-pair metadata.
+        "--differential-pairs",
+        "--net-class-map",
+        str(sidecar_path),
+        # Issue #3922: --auto-layers is kept (the default) so the escape
+        # pre-phase board 03's fine-pitch USB-C needs still runs (13/13 +
+        # 0 native DRC).  On this board --differential-pairs is inert at
+        # routing time because route_cmd's escape / escalation dispatch
+        # does not consult it (tracked in #3952); forcing the diff-pair
+        # path with --no-auto-layers would reintroduce a DRC clearance
+        # violation.  Frozen with the historical June recipe.
+        # Issues #3507/#3454: ``--raw`` removed in lock-step with the
+        # production recipe in ``generate_design.py:route_pcb()`` --
+        # the grid-transactional optimize pass retired the
+        # deterministic clearance_segment_via merge violation that
+        # made it load-bearing.  Keep these historical flags pinned.
+    ]
+    # Issue #3799: retain the historical hash seed independently of the
+    # current real-hardware routing replay.
+    _route_env = os.environ.copy()
+    _route_env["PYTHONHASHSEED"] = "42"
+    _route_env["PYTHONUNBUFFERED"] = "1"
+    stdout_path, stderr_path = artifacts / "stdout.log", artifacts / "stderr.log"
+    with stdout_path.open("w") as stdout, stderr_path.open("w") as stderr:
+        try:
+            proc = subprocess.run(
+                cmd,
+                stdout=stdout,
+                stderr=stderr,
+                text=True,
+                timeout=ROUTE_TIMEOUT,
+                check=False,
+                env=_route_env,
             )
-        return proc.stdout
+        except subprocess.TimeoutExpired:
+            pytest.fail(
+                f"Historical board03 seed {seed} exceeded {ROUTE_TIMEOUT}s; "
+                f"partial PCB, stdout and stderr retained in {artifacts}"
+            )
+    proc.stdout = stdout_path.read_text()
+    proc.stderr = stderr_path.read_text()
+    # Exit codes from cli/route_cmd.py:
+    #   0 = full route + DRC clean
+    #   2 = partial routing below --min-completion
+    #   3 = >= min-completion but DRC violations remain
+    # Board 03 lands at 2 or 3 (partial + DRC).  Codes 1 and 5 are
+    # fatal (crash / SIGINT).
+    if proc.returncode in (1, 5):
+        pytest.fail(
+            f"kct route returned fatal exit code {proc.returncode}\n"
+            f"stderr (last 2000 chars):\n{proc.stderr[-2000:]}\n"
+            f"stdout (last 2000 chars):\n{proc.stdout[-2000:]}"
+        )
+    return proc.stdout
 
 
 @pytest.fixture(scope="module")
-def route_stdout(unrouted_pcb_path: Path) -> str:
-    """Run the canonical ``kct route`` invocation once per module."""
-    return _run_kct_route(unrouted_pcb_path, seed=42)
+def route_stdout(unrouted_pcb_path: Path, tmp_path_factory) -> str:
+    """Run the frozen historical ``kct route`` invocation once per module."""
+    return _run_kct_route(
+        unrouted_pcb_path, seed=42, artifacts=tmp_path_factory.mktemp("board03-seed42")
+    )
 
 
 @pytest.mark.slow
+@pytest.mark.timeout(960)
 class TestBoard03RoutingBaseline:
     """Pin the June 2026 routing reach baseline for board 03.
 
@@ -685,40 +699,41 @@ class TestBoard03RoutingBaseline:
         )
 
 
-def test_recipe_includes_differential_pairs_flag() -> None:
-    """Guard against recipe consolidations silently dropping --differential-pairs.
+def test_historical_route_timeout_retains_partial_diagnostics(monkeypatch, tmp_path):
+    """A terminated subprocess must leave its output and partial board inspectable."""
 
-    Issue #3922: the #3308/#3410 consolidation dropped ``--differential-pairs``
-    from ``generate_design.py:route_pcb()`` without any test detecting it, so
-    the recipe stopped even requesting diff-pair routing and the boards/README
-    claim went false.  This fast text-search guard makes the flag a contract:
-    if a future refactor drops it, this test goes red before the regression
-    can ship.  ``--net-class-map`` is checked too because it forwards the
-    diff-pair metadata (and engages the validate-side diff-pair DRC rules).
+    def timeout(cmd, **kwargs):
+        assert "--differential-pairs" in cmd and "--net-class-map" in cmd
+        assert kwargs["timeout"] == ROUTE_TIMEOUT
+        assert Path(cmd[cmd.index("--output") + 1]).parent == tmp_path
+        kwargs["stdout"].write("partial net USB_D+\n")
+        kwargs["stderr"].write("routing deadline\n")
+        Path(cmd[cmd.index("--output") + 1]).write_text("partial copper")
+        raise subprocess.TimeoutExpired(cmd, ROUTE_TIMEOUT)
 
-    NB: on board 03 the flag is currently inert at routing time -- route_cmd's
-    escape / escalation dispatch does not consult it (tracked in #3952).  This
-    guard therefore protects the recipe *contract*, not the runtime behavior;
-    the runtime behavior is documented by the xfail'd
-    ``test_coupled_pathfinder_phase_a_invoked`` above.
-    """
-    source = (BOARD_DIR / "generate_design.py").read_text()
-    assert "--differential-pairs" in source, (
-        "generate_design.py:route_pcb() must include '--differential-pairs' so "
-        "the recipe requests diff-pair-aware routing.  If you changed the "
-        "routing recipe, keep the flag and mirror it in _run_kct_route() "
-        "(Issue #3922)."
-    )
-    assert "--net-class-map" in source, (
-        "generate_design.py:route_pcb() must forward '--net-class-map' so the "
-        "router reads the USB D+/D- diffpair_partner / intra_pair_clearance "
-        "metadata from the sidecar; without it --differential-pairs falls back "
-        "to default spacing (Issue #3922)."
-    )
+    monkeypatch.setattr(subprocess, "run", timeout)
+    before = UNROUTED_PCB.read_bytes()
+    with pytest.raises(pytest.fail.Exception, match="partial PCB, stdout and stderr retained"):
+        _run_kct_route(UNROUTED_PCB, 42, tmp_path)
+    assert (tmp_path / "stdout.log").read_text() == "partial net USB_D+\n"
+    assert (tmp_path / "stderr.log").read_text() == "routing deadline\n"
+    assert (tmp_path / "usb_joystick_routed.kicad_pcb").read_text() == "partial copper"
+    assert UNROUTED_PCB.read_bytes() == before
+
+
+def test_historical_geometry_is_32_pad_and_release_is_separate(unrouted_pcb_path):
+    from kicad_tools.schema import PCB
+
+    board = PCB.load(unrouted_pcb_path)
+    u1 = next(fp for fp in board.footprints if fp.reference == "U1")
+    assert len(u1.pads) == 32
+    assert COMMITTED_ROUTED_PCB.parent == BOARD_DIR / "output"
+    assert REQUIRED_NETS_ROUTED == EXPECTED_TOTAL_NETS == 13
 
 
 @pytest.mark.slow
-def test_routing_reach_deterministic_across_seeds(unrouted_pcb_path: Path) -> None:
+@pytest.mark.timeout(2800)
+def test_routing_reach_deterministic_across_seeds(unrouted_pcb_path: Path, tmp_path: Path) -> None:
     """The same reach (13/13 post-#3410) is produced for seeds 1, 42, and 99.
 
     The negotiated A* router uses the global seed for tie-breaks during
@@ -733,7 +748,7 @@ def test_routing_reach_deterministic_across_seeds(unrouted_pcb_path: Path) -> No
     """
     counts = {}
     for seed in (1, 42, 99):
-        stdout = _run_kct_route(unrouted_pcb_path, seed=seed)
+        stdout = _run_kct_route(unrouted_pcb_path, seed=seed, artifacts=tmp_path / f"seed-{seed}")
         parsed = _parse_routed_net_count(stdout)
         assert parsed is not None, (
             f"Could not parse routed net count for seed {seed}; "

--- a/tests/test_board_03_regression.py
+++ b/tests/test_board_03_regression.py
@@ -63,6 +63,7 @@ References:
 
 from __future__ import annotations
 
+import json
 import os
 import re
 import subprocess
@@ -134,7 +135,7 @@ def unrouted_pcb_path() -> Path:
 
 
 @pytest.fixture(scope="module")
-def routed_board_03(unrouted_pcb_path: Path):
+def routed_board_03(unrouted_pcb_path: Path, tmp_path_factory):
     """Route the frozen synthetic board03 geometry with ``route_all``.
 
     Revision B has a real 44-pin MCU and different connections. Applying
@@ -225,21 +226,52 @@ def routed_board_03(unrouted_pcb_path: Path):
     # pins reach the EscapeRouter's in-pad rescue path (#3183).
     _prior_extended = _os.environ.get("KICAD_TOOLS_EXTENDED_PITCH_IN_PAD_FALLBACK")
     _os.environ["KICAD_TOOLS_EXTENDED_PITCH_IN_PAD_FALLBACK"] = "1"
+    diagnostics = tmp_path_factory.mktemp("board03-capability") / "routing-statistics.json"
     try:
         # Force lazy escape router re-init now that the env var is set.
         router._escape_router = None
         router.route_all(
             enable_in_pad_escape_rescues=True,
             in_pad_escape_rescue_pins={"U1": ["12", "13", "14", "15", "26", "27"]},
-            suppress_no_timeout_warning=True,
+            timeout=480,
         )
     finally:
         if _prior_extended is None:
             _os.environ.pop("KICAD_TOOLS_EXTENDED_PITCH_IN_PAD_FALLBACK", None)
         else:
             _os.environ["KICAD_TOOLS_EXTENDED_PITCH_IN_PAD_FALLBACK"] = _prior_extended
+        # route_all returns partial routes at its outer deadline; pytest
+        # enforces the 600s hard backstop for a single stuck A* search.
+        diagnostics.write_text(json.dumps(router.get_statistics(), indent=2, default=str))
+        print(f"Historical board03 partial routing statistics: {diagnostics}")
 
     return router, net_map
+
+
+def test_historical_route_interruption_preserves_statistics(monkeypatch, tmp_path_factory):
+    from types import SimpleNamespace
+
+    def interrupted_route(**kwargs):
+        assert kwargs["timeout"] == 480
+        raise TimeoutError("simulated interrupted A* search")
+
+    router = SimpleNamespace(
+        net_class_map={},
+        route_all=interrupted_route,
+        get_statistics=lambda: {"nets_routed": 3, "nets_failed": 10},
+    )
+    monkeypatch.setattr(
+        sys.modules[__name__], "load_pcb_for_routing", lambda *a, **kw: (router, {})
+    )
+    monkeypatch.setenv("KICAD_TOOLS_EXTENDED_PITCH_IN_PAD_FALLBACK", "original")
+    with pytest.raises(TimeoutError, match="simulated interrupted"):
+        routed_board_03.__wrapped__(UNROUTED_PCB, tmp_path_factory)
+    assert os.environ["KICAD_TOOLS_EXTENDED_PITCH_IN_PAD_FALLBACK"] == "original"
+    diagnostics = list(
+        tmp_path_factory.getbasetemp().glob("board03-capability*/routing-statistics.json")
+    )
+    assert diagnostics
+    assert json.loads(diagnostics[-1].read_text()) == {"nets_routed": 3, "nets_failed": 10}
 
 
 @pytest.mark.slow
@@ -1000,7 +1032,7 @@ def test_fix_drc_preserves_safe_nudges_on_routed_board(tmp_path) -> None:
     least one nudge that did NOT touch a regressed net, so the post-fix
     summary reports ``Repaired K/N`` with K > 0.
 
-    This test loads the committed routed PCB and runs ``fix-drc``
+    This test loads the frozen historical routed PCB and runs ``fix-drc``
     in-process via the CLI module; no router invocation is required.
     The board 03 routed PCB has ~4 clearance violations clustered around
     the USB diff-pair flip-routing corridor; some of those nudges touch
@@ -1008,11 +1040,8 @@ def test_fix_drc_preserves_safe_nudges_on_routed_board(tmp_path) -> None:
     geometry) and some do not.  The granular rollback should preserve
     the latter group.
     """
-    if not ROUTED_PCB_FILE.exists():
-        pytest.skip(
-            f"Board 03 routed PCB not found at {ROUTED_PCB_FILE!s}; "
-            "regenerate via the board's generate/route demo scripts."
-        )
+    historical_routed = BOARD_DIR / "regression-fixture" / "usb_joystick_routed.kicad_pcb"
+    assert historical_routed.is_file(), "Historical routed board03 missing; restore it from git"
 
     output_file = tmp_path / "usb_joystick_repaired.kicad_pcb"
 
@@ -1022,7 +1051,7 @@ def test_fix_drc_preserves_safe_nudges_on_routed_board(tmp_path) -> None:
             "-m",
             "kicad_tools.cli",
             "fix-drc",
-            str(ROUTED_PCB_FILE),
+            str(historical_routed),
             "-o",
             str(output_file),
             "--format",


### PR DESCRIPTION
## Summary

The CLI joystick baseline still ran its historical 13-net recipe on the redesigned 44-pin hardware. Pin it to the existing archived 32-pad geometry and retain bounded routing diagnostics so capability failures remain reproducible without touching production artifacts.

## Changes

- Check the historical PCB hash and 32-pad MCU; preserve the 13/13 routing floor. Missing fixtures fail with restore-from-git guidance.
- Keep the June CLI recipe separate from the current hardware generator. Replace the obsolete current-generator flag check with an executable command/timeout control.
- Retain per-seed copied inputs, any partial PCB, and stdout/stderr in pytest temporary directories. Keep the 600-second CLI routing budget and 900-second process cap, with pytest backstops sized for one/three runs.
- Give the in-process fixture a 480-second outer budget within its existing 600-second pytest cap, saving routing statistics on return/interruption and restoring the escape environment setting.
- Move the historical fix-drc witness to the existing archived routed PCB. Production DRC and revision-B circuit/replay checks continue using their existing real-hardware paths.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Historical tests use original 32-pad geometry | Passed | SHA-256 and parsed MCU pad-count guard; CLI and in-process native runs pass |
| Real hardware tests verify the 44-pin circuit and reviewed copper | Passed | Existing real-hardware and non-slow board03 regression suites: 31 passed, 1 existing skip |
| Neither category overwrites released artifacts | Passed | Routing copies input into pytest temp directories; hardware generators use explicit temp paths; no board output changed in git status |
| Bounded long fixtures retain partial diagnostics | Passed | Simulated subprocess timeout retains stdout/stderr/partial PCB; simulated in-process interruption retains statistics and restores environment |
| Historical floors remain unchanged | Passed | CLI seed 42 reaches 13/13 with 0 partial and 0 unrouted; committed production DRC guard passes with existing zero-error ceiling |

## Test Plan

TDD: no — fixture audit and regression controls developed together; timeout controls inject interruptions and verify surviving artifacts rather than waiting for real deadlines.

- Built native backend with `uv run kct build-native` before routing measurements.
- `pytest tests/router/test_board03_routing_baseline.py -q --no-cov -k 'not deterministic'`: **7 passed**, 1 three-seed matrix deselected, **116.08 s**. Includes the real seed-42 route and committed production DRC guard. Final routing: **13/13, partial 0/13, unrouted 0/13**.
- `pytest tests/test_board_03_regression.py::test_usb_diff_pair_routes_via_coupled_pathfinder -q --no-cov`: **1 passed**, **5.39 s**.
- `pytest tests/test_board_03_real_hardware.py tests/test_board_03_regression.py -q --no-cov -m 'not slow'`: **31 passed, 1 skipped, 4 deselected** after configuring the mounted KiCad symbol/footprint directories. Initial runs without the required library environment failed fixture setup; no source fix was needed.
- New historical path/interruption controls: **3 passed**. After moving fix-drc to its historical witness, its focused test independently passed in **2.41 s**.
- Ruff lint/format and `git diff --check`: passed. Main-clean check confirms only pre-existing `.squad/` dirt; no new contamination.
- Native tools used `/tmp/loom-kicad-native-sweep-20260910/KiCad/KiCad.app/Contents/MacOS` on PATH, `KICAD_SYMBOL_DIR` pointing to its `Contents/SharedSupport/symbols`, and `KICAD10_FOOTPRINT_DIR` to `Contents/SharedSupport/footprints`.

The unchanged three-seed matrix was not run locally. The single-seed route and timeout command control exercise the changed helper; CI outcomes are pending. No production source, geometry, baseline ledger, or #5045 peer-owned changes are included.

Known integration limitation: base `8801f88c` has four independently reproduced Type Check failures tracked by #5044 / PR #5045 (stripline assignment/operator, PCB Pad/SExp assignment, missing shapely stubs). That repair remains open; this test-only change neither fixes nor rebaselines those unrelated failures.

Closes #5042
