### PR TITLE
fix(parts): preserve inventory provenance and reject unverified availability

### DIFF
--- a/docs/guides/manufacturing-export.md
+++ b/docs/guides/manufacturing-export.md
@@ -494,3 +494,25 @@ supplier access, uploads, approval, or orders. A narrow `refresh_inventory`
 increment can observe exact-ID stock through a caller-supplied official adapter,
 preserving unknown-vs-zero evidence; the full milestone B provenance/freshness
 contract remains blocked on #5033/#5034 (PRs #5115/#5090), so #5142 stays open.
+
+## Inventory provenance for parts and BOMs
+
+A catalog match establishes part identity; it does not prove current orderable
+stock. Lookup/search JSON, BOM availability, suggestions and enrichment records
+carry `inventory` metadata with `source` (`live`, `offline_catalog`, or
+`unknown`), the original `observed_at`, snapshot revision/time when known,
+local `read_at`, and `from_cache`. Cache reads and reinsertion preserve the
+original observation time. Older cache rows without provenance remain unknown.
+
+`stock_verified` requires a live observation no more than 24 hours old. This
+is a screening freshness limit, not a supplier reservation or order guarantee;
+refresh inventory before ordering. Offline snapshots never qualify as verified
+stock, even when their recorded count exceeds the requested quantity.
+Availability reports mark such matches unverified/unknown, while suggestions
+and BOM enrichment can still use them to identify parts. Export enrichment
+reports retain this provenance and warn when stock remains unverified.
+
+The offline dataset does not guarantee a stock-observation timestamp. Missing
+ages remain null; file modification time and download time are not substitutes.
+Callers with trusted snapshot metadata can provide `snapshot_revision`,
+`snapshot_at`, and `observed_at` to `JlcpartsCatalog` explicitly.

--- a/src/kicad_tools/assembly/validation.py
+++ b/src/kicad_tools/assembly/validation.py
@@ -27,6 +27,7 @@ class PartTier(Enum):
 class ValidationStatus(Enum):
     """Validation status for a part."""
 
+    UNKNOWN = "unknown"
     AVAILABLE = "available"
     LOW_STOCK = "low_stock"
     OUT_OF_STOCK = "out_of_stock"
@@ -51,6 +52,7 @@ class PartValidationResult:
     tier: PartTier
 
     # Stock info
+    inventory: dict = field(default_factory=dict)
     stock: int = 0
     in_stock: bool = False
 
@@ -110,6 +112,7 @@ class PartValidationResult:
             "status": self.status.value,
             "tier": self.tier.value,
             "stock": self.stock,
+            "inventory": self.inventory,
             "in_stock": self.in_stock,
             "mfr_part": self.mfr_part,
             "description": self.description,
@@ -185,6 +188,7 @@ class AssemblyValidationResult:
     def assembly_ready(self) -> bool:
         """True if all parts are available for assembly."""
         problem_statuses = {
+            ValidationStatus.UNKNOWN,
             ValidationStatus.OUT_OF_STOCK,
             ValidationStatus.NOT_FOUND,
             ValidationStatus.NO_LCSC,
@@ -414,7 +418,9 @@ class AssemblyValidator:
             tier = PartTier.EXTENDED
 
         # Determine status
-        if part.stock == 0:
+        if not part.stock_verified:
+            status = ValidationStatus.UNKNOWN
+        elif part.stock == 0:
             status = ValidationStatus.OUT_OF_STOCK
         elif part.stock < max(qty_needed * 2, self.LOW_STOCK_THRESHOLD):
             status = ValidationStatus.LOW_STOCK
@@ -430,7 +436,9 @@ class AssemblyValidator:
             status=status,
             tier=tier,
             stock=part.stock,
-            in_stock=part.stock > 0,
+            in_stock=part.stock_verified and part.stock > 0,
+            inventory=part.inventory_provenance(),
+            error=None if part.stock_verified else "Stock unverified: refresh live inventory",
             mfr_part=part.mfr_part,
             description=part.description,
         )

--- a/src/kicad_tools/cli/parts_cmd.py
+++ b/src/kicad_tools/cli/parts_cmd.py
@@ -271,6 +271,7 @@ def _lookup(args) -> int:
             "package": part.package,
             "package_type": part.package_type.value,
             "stock": part.stock,
+            "inventory": part.inventory_provenance(),
             "is_basic": part.is_basic,
             "is_preferred": part.is_preferred,
             "prices": [{"quantity": p.quantity, "unit_price": p.unit_price} for p in part.prices],
@@ -286,6 +287,10 @@ def _lookup(args) -> int:
         print(f"Category:     {part.category.value}")
         print(f"Package:      {part.package} ({part.package_type.value})")
         print(f"Stock:        {part.stock:,}")
+        if not part.stock_verified:
+            print(
+                "Stock unverified: catalog identity only; refresh live inventory before ordering."
+            )
         if part.is_basic:
             print("Type:         JLCPCB Basic (no extra fee)")
         elif part.is_preferred:
@@ -332,6 +337,9 @@ def _search(args) -> int:
         print(f"No parts found for: {args.query}", file=sys.stderr)
         return 1
 
+    if args.format != "json" and any(not p.stock_verified for p in results.parts):
+        print("Warning: snapshot/unknown stock is unverified; matches establish identity only.")
+
     if args.format == "json":
         data = {
             "query": results.query,
@@ -343,6 +351,7 @@ def _search(args) -> int:
                     "description": p.description,
                     "package": p.package,
                     "stock": p.stock,
+                    "inventory": p.inventory_provenance(),
                     "is_basic": p.is_basic,
                     "best_price": p.best_price,
                 }
@@ -626,7 +635,7 @@ def _availability(args) -> int:
         _availability_table(result, items, schematic_path, args.quantity)
 
     # Return error code if issues found
-    if result.out_of_stock or result.missing:
+    if not result.all_available:
         return 1
     return 0
 
@@ -757,6 +766,7 @@ def _suggest_json(result, suggestions) -> None:
                 "description": s.best_suggestion.description,
                 "package": s.best_suggestion.package,
                 "stock": s.best_suggestion.stock,
+                "inventory": s.best_suggestion.inventory,
                 "is_basic": s.best_suggestion.is_basic,
                 "unit_price": s.best_suggestion.unit_price,
                 "confidence": s.best_suggestion.confidence,
@@ -770,6 +780,7 @@ def _suggest_json(result, suggestions) -> None:
                     "description": sug.description,
                     "package": sug.package,
                     "stock": sug.stock,
+                    "inventory": sug.inventory,
                     "is_basic": sug.is_basic,
                     "unit_price": sug.unit_price,
                     "confidence": sug.confidence,
@@ -783,6 +794,13 @@ def _suggest_json(result, suggestions) -> None:
 
 def _suggest_table(result, suggestions, schematic_path: Path) -> None:
     """Output suggestions as formatted table."""
+    if any(
+        s.best_suggestion and not s.best_suggestion.inventory.get("stock_verified", False)
+        for s in suggestions
+    ):
+        print(
+            "Warning: suggested part identities include unverified stock; refresh before ordering."
+        )
     print()
     print("=" * 90)
     print("LCSC PART SUGGESTIONS")
@@ -1047,6 +1065,8 @@ def _availability_table(result, items, schematic_path: Path, quantity: int) -> N
     print()
     if summary["all_available"]:
         print("✓ All parts available for ordering")
+    elif summary.get("unverified", 0) > 0:
+        print("Stock unverified: refresh live inventory before ordering.")
     elif summary["out_of_stock"] > 0:
         print("✗ Some parts out of stock - check alternatives above")
     else:

--- a/src/kicad_tools/cost/availability.py
+++ b/src/kicad_tools/cost/availability.py
@@ -41,6 +41,7 @@ class AlternativePart:
     stock: int
     price_diff: float | None  # Price difference vs original (None if unknown)
     is_basic: bool
+    inventory: dict = field(default_factory=dict)
 
 
 @dataclass
@@ -74,11 +75,15 @@ class PartAvailabilityResult:
 
     # Error info
     error: str | None = None
+    inventory: dict = field(default_factory=dict)
 
     @property
     def sufficient_stock(self) -> bool:
         """Check if enough stock for needed quantity."""
-        return self.quantity_available >= self.quantity_needed
+        return (
+            self.status in (AvailabilityStatus.AVAILABLE, AvailabilityStatus.LOW_STOCK)
+            and self.quantity_available >= self.quantity_needed
+        )
 
     @property
     def unit_price(self) -> float | None:
@@ -112,6 +117,7 @@ class PartAvailabilityResult:
             "status": self.status.value,
             "in_stock": self.in_stock,
             "sufficient_stock": self.sufficient_stock,
+            "inventory": self.inventory,
             "min_order_qty": self.min_order_qty,
             "price_breaks": self.price_breaks,
             "unit_price": self.unit_price,
@@ -123,6 +129,7 @@ class PartAvailabilityResult:
                     "mfr_part": alt.mfr_part,
                     "description": alt.description,
                     "stock": alt.stock,
+                    "inventory": alt.inventory,
                     "price_diff": alt.price_diff,
                     "is_basic": alt.is_basic,
                 }
@@ -187,6 +194,7 @@ class BOMAvailabilityResult:
             "low_stock": len(self.low_stock),
             "out_of_stock": len(self.out_of_stock),
             "missing": len(self.missing),
+            "unverified": sum(item.status == AvailabilityStatus.UNKNOWN for item in self.items),
             "all_available": self.all_available,
             "total_cost": self.total_cost,
             "quantity_multiplier": self.quantity_multiplier,
@@ -378,8 +386,12 @@ class LCSCAvailabilityChecker:
             )
 
         # Determine status
-        status = self._determine_status(part.stock, quantity_needed)
-        in_stock = part.stock > 0
+        status = (
+            self._determine_status(part.stock, quantity_needed)
+            if part.stock_verified
+            else AvailabilityStatus.UNKNOWN
+        )
+        in_stock = part.stock_verified and part.stock > 0
 
         # Extract price breaks
         price_breaks = [(p.quantity, p.unit_price) for p in part.prices]
@@ -403,6 +415,8 @@ class LCSCAvailabilityChecker:
             price_breaks=price_breaks,
             lead_time_days=None,  # LCSC API doesn't provide this currently
             alternatives=alternatives,
+            inventory=part.inventory_provenance(),
+            error=None if part.stock_verified else "Stock unverified: refresh live inventory",
         )
 
     def _determine_status(self, stock: int, needed: int) -> AvailabilityStatus:
@@ -452,6 +466,7 @@ class LCSCAvailabilityChecker:
                         mfr_part=part.mfr_part,
                         description=part.description,
                         stock=part.stock,
+                        inventory=part.inventory_provenance(),
                         price_diff=price_diff,
                         is_basic=part.is_basic,
                     )

--- a/src/kicad_tools/cost/suggest.py
+++ b/src/kicad_tools/cost/suggest.py
@@ -63,6 +63,7 @@ class SuggestedPart:
     is_preferred: bool
     unit_price: float | None
     confidence: float  # 0.0 to 1.0
+    inventory: dict = field(default_factory=dict)
 
     @property
     def type_str(self) -> str:
@@ -637,6 +638,7 @@ class PartSuggester:
                         description=part.description,
                         package=part.package,
                         stock=part.stock,
+                        inventory=part.inventory_provenance(),
                         is_basic=part.is_basic,
                         is_preferred=part.is_preferred,
                         unit_price=part.best_price,

--- a/src/kicad_tools/export/bom_enrich.py
+++ b/src/kicad_tools/export/bom_enrich.py
@@ -45,6 +45,7 @@ class EnrichmentEntry:
     confidence: float = 0.0
     part_type: str = ""  # "Basic" | "Pref" | "Ext" | ""
     error: str = ""
+    inventory: dict = field(default_factory=dict)
 
 
 @dataclass
@@ -98,6 +99,13 @@ class EnrichmentReport:
         parts.append(f"{self.already_populated} from schematic")
         parts.append(f"{self.unmatched} unmatched")
         lines = [f"LCSC enrichment: {', '.join(parts)}"]
+        if any(
+            e.source in ("auto", "cache") and not e.inventory.get("stock_verified", False)
+            for e in self.entries
+        ):
+            lines.append(
+                "Stock unverified for identity matches; refresh live inventory before ordering."
+            )
         if self.unmatched_entries:
             lines.append("Unmatched parts:")
             for entry in self.unmatched_entries:
@@ -230,7 +238,9 @@ def enrich_bom_lcsc(
                     footprint,
                     lcsc,
                 )
+                cached_part = cache.get(lcsc, ignore_expiry=True)
                 return EnrichmentEntry(
+                    inventory=cached_part.inventory_provenance() if cached_part is not None else {},
                     value=value,
                     footprint=footprint,
                     references=refs,
@@ -399,6 +409,7 @@ def enrich_bom_lcsc(
                         source="auto",
                         confidence=best.confidence,
                         part_type=best.type_str,
+                        inventory=best.inventory,
                     )
                 )
                 logger.info(

--- a/src/kicad_tools/parts/cache.py
+++ b/src/kicad_tools/parts/cache.py
@@ -57,7 +57,7 @@ class PartsCache:
         print(f"Cached parts: {stats['total']}")
     """
 
-    SCHEMA_VERSION = 2
+    SCHEMA_VERSION = 3
     DEFAULT_TTL_DAYS = 7
 
     def __init__(
@@ -107,6 +107,7 @@ class PartsCache:
                     datasheet_url TEXT,
                     product_url TEXT,
                     fetched_at TEXT,
+                    inventory TEXT,
                     cached_at TEXT
                 );
 
@@ -150,6 +151,8 @@ class PartsCache:
                     PRIMARY KEY (component_value, footprint)
                 );
             """)
+        if from_version < 3:
+            conn.execute("ALTER TABLE parts ADD COLUMN inventory TEXT")
         conn.execute(
             "UPDATE meta SET value = ? WHERE key = 'schema_version'",
             (str(self.SCHEMA_VERSION),),
@@ -196,6 +199,7 @@ class PartsCache:
             "product_url": part.product_url,
             "fetched_at": part.fetched_at.isoformat() if part.fetched_at else None,
             "cached_at": datetime.now().isoformat(),
+            "inventory": json.dumps(part.inventory_provenance()),
         }
 
     def _row_to_part(self, row: sqlite3.Row) -> Part:
@@ -216,7 +220,15 @@ class PartsCache:
         if row["fetched_at"]:
             fetched_at = datetime.fromisoformat(row["fetched_at"])
 
+        inventory = json.loads(row["inventory"]) if row["inventory"] else {}
         return Part(
+            stock_source=inventory.get("source", "unknown"),
+            snapshot_revision=inventory.get("snapshot_revision"),
+            snapshot_at=datetime.fromisoformat(inventory["snapshot_at"])
+            if inventory.get("snapshot_at")
+            else None,
+            read_at=datetime.now(),
+            from_cache=True,
             lcsc_part=row["lcsc_part"],
             mfr_part=row["mfr_part"] or "",
             manufacturer=row["manufacturer"] or "",
@@ -320,14 +332,14 @@ class PartsCache:
                     tolerance, voltage_rating, power_rating, temperature_range,
                     specs, stock, min_order, prices,
                     is_basic, is_preferred, datasheet_url, product_url,
-                    fetched_at, cached_at
+                    fetched_at, cached_at, inventory
                 ) VALUES (
                     :lcsc_part, :mfr_part, :manufacturer, :description,
                     :category, :package, :package_type, :value,
                     :tolerance, :voltage_rating, :power_rating, :temperature_range,
                     :specs, :stock, :min_order, :prices,
                     :is_basic, :is_preferred, :datasheet_url, :product_url,
-                    :fetched_at, :cached_at
+                    :fetched_at, :cached_at, :inventory
                 )
                 """,
                 row,
@@ -353,14 +365,14 @@ class PartsCache:
                     tolerance, voltage_rating, power_rating, temperature_range,
                     specs, stock, min_order, prices,
                     is_basic, is_preferred, datasheet_url, product_url,
-                    fetched_at, cached_at
+                    fetched_at, cached_at, inventory
                 ) VALUES (
                     :lcsc_part, :mfr_part, :manufacturer, :description,
                     :category, :package, :package_type, :value,
                     :tolerance, :voltage_rating, :power_rating, :temperature_range,
                     :specs, :stock, :min_order, :prices,
                     :is_basic, :is_preferred, :datasheet_url, :product_url,
-                    :fetched_at, :cached_at
+                    :fetched_at, :cached_at, :inventory
                 )
                 """,
                 rows,

--- a/src/kicad_tools/parts/jlcparts_catalog.py
+++ b/src/kicad_tools/parts/jlcparts_catalog.py
@@ -100,15 +100,36 @@ class JlcpartsCatalog:
             part = catalog.lookup("C123456")
     """
 
-    def __init__(self, db_path: Path | None = None):
+    def __init__(
+        self,
+        db_path: Path | None = None,
+        *,
+        snapshot_revision: str | None = None,
+        snapshot_at: datetime | None = None,
+        observed_at: datetime | None = None,
+    ):
         """Initialize the catalog reader.
 
         Args:
             db_path: Path to the jlcparts SQLite file (default:
                 ``~/.cache/kicad-tools/jlcparts.sqlite3``). The file is not
                 required to exist.
+            snapshot_revision: Trusted dataset revision, when supplied by its producer.
+            snapshot_at: Dataset snapshot time, not local download/read time.
+            observed_at: Original stock observation time, if known. Missing
+                metadata remains unknown; filesystem mtimes are never substituted.
         """
         self.db_path = db_path or get_catalog_path()
+        self.snapshot_revision = snapshot_revision
+        self.snapshot_at = snapshot_at
+        self.observed_at = observed_at
+
+    def _part_from_row(self, row: sqlite3.Row) -> Part:
+        part = _row_to_part(row)
+        part.snapshot_revision = self.snapshot_revision
+        part.snapshot_at = self.snapshot_at
+        part.fetched_at = self.observed_at
+        return part
 
     @property
     def available(self) -> bool:
@@ -148,7 +169,7 @@ class JlcpartsCatalog:
         if row is None:
             return None
 
-        return _row_to_part(row)
+        return self._part_from_row(row)
 
     def lookup_many(self, lcsc_parts: list[str]) -> dict[str, Part]:
         """Look up multiple parts by exact LCSC number.
@@ -184,7 +205,7 @@ class JlcpartsCatalog:
                     list(id_to_key.keys()),
                 )
                 for row in cursor:
-                    part = _row_to_part(row)
+                    part = self._part_from_row(row)
                     key = id_to_key.get(int(row["lcsc"]), part.lcsc_part)
                     result[key] = part
         except sqlite3.Error as e:
@@ -287,7 +308,7 @@ class JlcpartsCatalog:
             logger.warning(f"jlcparts catalog search failed for {query!r}: {e}")
             return []
 
-        return [_row_to_part(row) for row in rows]
+        return [self._part_from_row(row) for row in rows]
 
     def count(self) -> int:
         """Return the number of components in the catalog (0 if absent)."""
@@ -386,7 +407,8 @@ def _row_to_part(row: sqlite3.Row) -> Part:
         is_preferred=library_type == "preferred",
         datasheet_url=col_str("datasheet"),
         product_url=f"https://jlcpcb.com/partdetail/{lcsc_part}" if lcsc_part else "",
-        fetched_at=datetime.now(),
+        stock_source="offline_catalog",
+        read_at=datetime.now(),
     )
 
 

--- a/src/kicad_tools/parts/jlcpcb_api.py
+++ b/src/kicad_tools/parts/jlcpcb_api.py
@@ -634,4 +634,5 @@ def _parse_official_component(data: dict) -> Part:
         datasheet_url=datasheet_url,
         product_url=f"https://jlcpcb.com/partdetail/{code}" if code else "",
         fetched_at=datetime.now(),
+        stock_source="live",
     )

--- a/src/kicad_tools/parts/lcsc.py
+++ b/src/kicad_tools/parts/lcsc.py
@@ -699,6 +699,7 @@ class LCSCClient:
             datasheet_url=data.get("dataManualUrl") or "",
             product_url=f"https://jlcpcb.com/partdetail/{data.get('componentCode', '')}",
             fetched_at=datetime.now(),
+            stock_source="live",
         )
 
     def search(

--- a/src/kicad_tools/parts/models.py
+++ b/src/kicad_tools/parts/models.py
@@ -7,7 +7,7 @@ Defines dataclasses for parts, availability, and search results.
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from datetime import datetime
+from datetime import datetime, timedelta
 from enum import Enum
 from typing import TYPE_CHECKING
 
@@ -99,6 +99,32 @@ class Part:
 
     # Cache metadata
     fetched_at: datetime | None = None
+    stock_source: str = "unknown"
+    snapshot_revision: str | None = None
+    snapshot_at: datetime | None = None
+    read_at: datetime | None = None
+    from_cache: bool = False
+
+    @property
+    def stock_verified(self) -> bool:
+        """Live observation within 24 hours; not a supplier reservation guarantee."""
+        if self.stock_source != "live" or self.fetched_at is None:
+            return False
+        age = datetime.now(tz=self.fetched_at.tzinfo) - self.fetched_at
+        return timedelta(0) <= age <= timedelta(hours=24)
+
+    def inventory_provenance(self) -> dict:
+        """JSON-safe provenance; read/cache time never replaces observation time."""
+        return {
+            "source": self.stock_source,
+            "observed_at": self.fetched_at.isoformat() if self.fetched_at else None,
+            "snapshot_revision": self.snapshot_revision,
+            "snapshot_at": self.snapshot_at.isoformat() if self.snapshot_at else None,
+            "read_at": self.read_at.isoformat() if self.read_at else None,
+            "from_cache": self.from_cache,
+            "stock_verified": self.stock_verified,
+            "verification_max_age_hours": 24,
+        }
 
     @property
     def in_stock(self) -> bool:
@@ -234,7 +260,11 @@ class PartAvailability:
     @property
     def sufficient_stock(self) -> bool:
         """Check if enough stock for needed quantity."""
-        return self.quantity_available >= self.quantity_needed
+        return (
+            self.part is not None
+            and self.part.stock_verified
+            and self.quantity_available >= self.quantity_needed
+        )
 
     @property
     def status(self) -> str:
@@ -243,6 +273,8 @@ class PartAvailability:
             return f"Error: {self.error}"
         if not self.matched:
             return "Not found"
+        if self.part is not None and not self.part.stock_verified:
+            return "Stock unverified (refresh live inventory)"
         if not self.in_stock:
             return "Out of stock"
         if not self.sufficient_stock:
@@ -296,7 +328,14 @@ class BOMAvailability:
     @property
     def out_of_stock(self) -> list[PartAvailability]:
         """Get items that are out of stock."""
-        return [item for item in self.items if item.matched and not item.in_stock]
+        return [
+            item
+            for item in self.items
+            if item.matched
+            and item.part is not None
+            and item.part.stock_verified
+            and not item.in_stock
+        ]
 
     @property
     def low_stock(self) -> list[PartAvailability]:
@@ -304,7 +343,11 @@ class BOMAvailability:
         return [
             item
             for item in self.items
-            if item.matched and item.in_stock and not item.sufficient_stock
+            if item.matched
+            and item.part is not None
+            and item.part.stock_verified
+            and item.in_stock
+            and not item.sufficient_stock
         ]
 
     @property
@@ -320,4 +363,8 @@ class BOMAvailability:
             "missing": len(self.missing_parts),
             "out_of_stock": len(self.out_of_stock),
             "low_stock": len(self.low_stock),
+            "unverified": sum(
+                item.matched and item.part is not None and not item.part.stock_verified
+                for item in self.items
+            ),
         }

--- a/tests/parts/test_jlcparts_catalog.py
+++ b/tests/parts/test_jlcparts_catalog.py
@@ -1141,3 +1141,188 @@ def test_cli_surfaces_extraction_error(catalog_db: Path, tmp_path: Path, monkeyp
     assert "not deflate-compressed" in err
     # No partial catalog left behind.
     assert not dest.exists()
+
+
+def test_inventory_observation_and_snapshot_survive_all_reads(catalog_db, tmp_path):
+    from datetime import datetime
+
+    observed = datetime(2025, 1, 2)
+    snapshot = datetime(2025, 1, 3)
+    catalog = JlcpartsCatalog(
+        catalog_db, observed_at=observed, snapshot_at=snapshot, snapshot_revision="fixture-v1"
+    )
+    first = catalog.lookup("C25804")
+    second = catalog.lookup("C25804")
+    assert first and second
+    assert first.fetched_at == second.fetched_at == observed
+    assert first.read_at <= second.read_at
+    cache = PartsCache(tmp_path / "parts.db")
+    cache.put(first)
+    cache.put_many([second])
+    cached = cache.get_many(["C25804"])["C25804"]
+    assert cached.from_cache
+    for part in [
+        first,
+        second,
+        cached,
+        catalog.lookup_many(["C25804"])["C25804"],
+        *catalog.search("10k"),
+    ]:
+        assert part.stock_source == "offline_catalog"
+        assert part.fetched_at == observed
+        assert part.snapshot_at == snapshot
+        assert part.snapshot_revision == "fixture-v1"
+        assert not part.stock_verified
+
+
+def test_unknown_age_catalog_cannot_qualify_bom(catalog_db):
+    from types import SimpleNamespace
+
+    from kicad_tools.assembly.validation import (
+        AssemblyValidationResult,
+        AssemblyValidator,
+        ValidationStatus,
+    )
+    from kicad_tools.cost.availability import (
+        AvailabilityStatus,
+        BOMAvailabilityResult,
+        LCSCAvailabilityChecker,
+    )
+    from kicad_tools.parts.models import BOMAvailability, PartAvailability
+
+    part = JlcpartsCatalog(catalog_db).lookup("C25804")
+    assert part and part.stock > 0
+    assert part.fetched_at is None
+    assert part.snapshot_at is None
+    assert part.inventory_provenance()["observed_at"] is None
+    basic = PartAvailability(
+        "R1",
+        "10k",
+        "0402",
+        "C25804",
+        part=part,
+        matched=True,
+        in_stock=True,
+        quantity_needed=1,
+        quantity_available=part.stock,
+    )
+    assert not BOMAvailability([basic]).all_available
+    assert "unverified" in basic.status
+    checked = LCSCAvailabilityChecker(find_alternatives=False)._check_item(
+        "R1", "10k", "0402", None, "C25804", 1, {"C25804": part}
+    )
+    assert checked.status == AvailabilityStatus.UNKNOWN
+    assert not BOMAvailabilityResult([checked]).all_available
+    assert checked.to_dict()["inventory"]["source"] == "offline_catalog"
+    group = SimpleNamespace(
+        lcsc="C25804", quantity=1, references="R1", value="10k", footprint="0402"
+    )
+    assembly = AssemblyValidator()._validate_group(group, 1, {"C25804": part})
+    assert assembly.status == ValidationStatus.UNKNOWN
+    assert not AssemblyValidationResult([assembly]).assembly_ready
+
+
+def test_cached_legacy_source_is_unknown(catalog_db, tmp_path):
+    import sqlite3
+    from datetime import datetime
+
+    cache = PartsCache(tmp_path / "legacy.db")
+    live = Part(lcsc_part="C25804", stock=100, stock_source="live", fetched_at=datetime.now())
+    cache.put(live)
+    with sqlite3.connect(cache.db_path) as conn:
+        conn.execute("UPDATE parts SET inventory = NULL")
+    loaded = cache.get("C25804")
+    assert loaded and loaded.stock_source == "unknown"
+    assert not loaded.stock_verified
+    assert loaded.fetched_at == live.fetched_at
+
+
+def test_expired_live_cache_reinsertion_cannot_refresh_observation(tmp_path):
+    import sqlite3
+    from datetime import datetime, timedelta
+
+    original_time = datetime.now() - timedelta(days=10)
+    cache = PartsCache(tmp_path / "cache.db")
+    part = Part("C1", stock=100, stock_source="live", fetched_at=original_time)
+    cache.put(part)
+    with sqlite3.connect(cache.db_path) as conn:
+        conn.execute("UPDATE parts SET cached_at = ?", (original_time.isoformat(),))
+    assert cache.get("C1") is None
+    old = cache.get("C1", ignore_expiry=True)
+    assert old and not old.stock_verified
+    cache.put(old)
+    reread = cache.get("C1")
+    assert reread and reread.fetched_at == original_time
+    assert not reread.stock_verified
+    # Only an actual new live observation renews verification.
+    fresh = Part("C1", stock=200, stock_source="live", fetched_at=datetime.now())
+    cache.put(fresh)
+    assert cache.get("C1").stock_verified
+
+
+def test_inventory_cache_schema_migration_preserves_unknown_source(tmp_path):
+    import sqlite3
+    from datetime import datetime
+
+    path = tmp_path / "legacy.db"
+    cache = PartsCache(path)
+    cache.put(Part("C1", stock=100, fetched_at=datetime.now()))
+    with sqlite3.connect(path) as conn:
+        conn.execute("ALTER TABLE parts DROP COLUMN inventory")
+        conn.execute("UPDATE meta SET value = '2' WHERE key = 'schema_version'")
+    migrated = PartsCache(path).get("C1")
+    assert migrated and migrated.stock == 100
+    assert migrated.stock_source == "unknown" and not migrated.stock_verified
+
+
+def test_offline_fallback_cache_and_cli_json_keep_provenance(
+    catalog_db, tmp_path, monkeypatch, capsys
+):
+    import json
+    from types import SimpleNamespace
+
+    from kicad_tools.cli.parts_cmd import _lookup
+
+    client = LCSCClient(cache=PartsCache(tmp_path / "parts.db"), use_official_api=False)
+    monkeypatch.setattr(client, "_get_catalog", lambda: JlcpartsCatalog(catalog_db))
+    monkeypatch.setattr(client, "_fetch_part", lambda *args, **kwargs: None)
+    assert client.lookup("C25804").stock_source == "offline_catalog"
+    cached = client.lookup_many(["C25804"])["C25804"]
+    assert cached.fetched_at is None and not cached.stock_verified
+    monkeypatch.setattr("kicad_tools.parts.LCSCClient", lambda: client)
+    assert _lookup(SimpleNamespace(part="C25804", no_cache=False, format="json")) == 0
+    data = json.loads(capsys.readouterr().out)
+    assert data["stock"] > 0
+    assert data["inventory"]["source"] == "offline_catalog"
+    assert data["inventory"]["observed_at"] is None
+    assert not data["inventory"]["stock_verified"]
+
+
+def test_suggestion_and_export_keep_offline_inventory(catalog_db, tmp_path, monkeypatch):
+    from types import SimpleNamespace
+
+    from kicad_tools.cost.suggest import PartSuggester
+    from kicad_tools.export.bom_enrich import enrich_bom_lcsc
+    from kicad_tools.parts.models import SearchResult
+    from kicad_tools.schema.bom import BOMItem
+
+    part = JlcpartsCatalog(catalog_db).lookup("C25804")
+    client = SimpleNamespace(
+        cache=PartsCache(tmp_path / "parts.db"),
+        search=lambda *args, **kwargs: SearchResult("10k", parts=[part]),
+        close=lambda: None,
+    )
+    monkeypatch.setattr(PartSuggester, "_get_client", lambda self: client)
+    suggestion = PartSuggester().suggest_for_component(
+        "R1", "10k", "Resistor_SMD:R_0402_1005Metric"
+    )
+    assert suggestion.best_suggestion
+    assert suggestion.best_suggestion.inventory["source"] == "offline_catalog"
+    assert not suggestion.best_suggestion.inventory["stock_verified"]
+    item = BOMItem(
+        reference="R1", value="10k", footprint="Resistor_SMD:R_0402_1005Metric", lib_id="Device:R"
+    )
+    report = enrich_bom_lcsc([item])
+    assert item.lcsc == "C25804"  # Offline identity matching remains useful.
+    assert report.entries[0].inventory["source"] == "offline_catalog"
+    assert any("Stock unverified" in line for line in report.summary_lines())

--- a/tests/test_alternatives.py
+++ b/tests/test_alternatives.py
@@ -1,5 +1,6 @@
 """Tests for the alternative part finder module."""
 
+from datetime import datetime
 from unittest.mock import MagicMock
 
 import pytest
@@ -414,12 +415,14 @@ class TestAlternativePartFinder:
         )
         assert finder._get_availability_status(avail) == "low_stock"
 
-        # OK - no alternatives needed
+        # OK - no alternatives needed (matched parts carry a verified Part,
+        # per the real check_bom() population path in parts/lcsc.py)
         avail = PartAvailability(
             reference="R1",
             value="10k",
             footprint="0402",
             lcsc_part="C123",
+            part=Part("C123", stock_source="live", fetched_at=datetime.now()),
             matched=True,
             in_stock=True,
             quantity_needed=10,

--- a/tests/test_assembly_validation.py
+++ b/tests/test_assembly_validation.py
@@ -394,6 +394,8 @@ class TestAssemblyValidator:
             mock_client = MagicMock()
             mock_client.lookup_many.return_value = {
                 "C123456": Part(
+                    stock_source="live",
+                    fetched_at=datetime.now(),
                     lcsc_part="C123456",
                     mfr_part="RC0402",
                     stock=50000,
@@ -434,6 +436,8 @@ class TestAssemblyValidator:
             mock_client = MagicMock()
             mock_client.lookup_many.return_value = {
                 "C123456": Part(
+                    stock_source="live",
+                    fetched_at=datetime.now(),
                     lcsc_part="C123456",
                     mfr_part="RC0402",
                     stock=50000,
@@ -458,6 +462,8 @@ class TestAssemblyValidator:
             mock_client = MagicMock()
             mock_client.lookup_many.return_value = {
                 "C123456": Part(
+                    stock_source="live",
+                    fetched_at=datetime.now(),
                     lcsc_part="C123456",
                     mfr_part="RC0402",
                     stock=50,  # Low stock
@@ -481,6 +487,8 @@ class TestAssemblyValidator:
             mock_client = MagicMock()
             mock_client.lookup_many.return_value = {
                 "C123456": Part(
+                    stock_source="live",
+                    fetched_at=datetime.now(),
                     lcsc_part="C123456",
                     mfr_part="RC0402",
                     stock=0,  # Out of stock
@@ -504,6 +512,8 @@ class TestAssemblyValidator:
             mock_client = MagicMock()
             mock_client.lookup_many.return_value = {
                 "C123456": Part(
+                    stock_source="live",
+                    fetched_at=datetime.now(),
                     lcsc_part="C123456",
                     mfr_part="RC0402",
                     stock=50000,

--- a/tests/test_parts.py
+++ b/tests/test_parts.py
@@ -99,6 +99,7 @@ class TestPartAvailability:
             lcsc_part="C123456",
             quantity_needed=100,
             quantity_available=500,
+            part=Part("C123456", stock_source="live", fetched_at=datetime.now()),
         )
         assert avail.sufficient_stock is True
 
@@ -111,6 +112,7 @@ class TestPartAvailability:
             value="10k",
             footprint="0402",
             lcsc_part="C123456",
+            part=Part("C123456", stock_source="live", fetched_at=datetime.now()),
             matched=True,
             in_stock=True,
             quantity_needed=10,
@@ -134,6 +136,7 @@ class TestPartAvailability:
             value="10k",
             footprint="0402",
             lcsc_part="C123456",
+            part=Part("C123456", stock_source="live", fetched_at=datetime.now()),
             matched=True,
             in_stock=False,
         )
@@ -145,6 +148,7 @@ class TestPartAvailability:
             value="10k",
             footprint="0402",
             lcsc_part="C123456",
+            part=Part("C123456", stock_source="live", fetched_at=datetime.now()),
             matched=True,
             in_stock=True,
             quantity_needed=100,
@@ -211,6 +215,7 @@ class TestBOMAvailability:
                     value="10k",
                     footprint="0402",
                     lcsc_part="C123",
+                    part=Part("C123456", stock_source="live", fetched_at=datetime.now()),
                     matched=True,
                     in_stock=True,
                     quantity_needed=10,
@@ -222,6 +227,7 @@ class TestBOMAvailability:
                     value="100nF",
                     footprint="0402",
                     lcsc_part="C456",
+                    part=Part("C123456", stock_source="live", fetched_at=datetime.now()),
                     matched=True,
                     in_stock=False,
                     quantity_needed=5,
@@ -233,6 +239,7 @@ class TestBOMAvailability:
                     value="STM32",
                     footprint="LQFP48",
                     lcsc_part="C789",
+                    part=Part("C123456", stock_source="live", fetched_at=datetime.now()),
                     matched=True,
                     in_stock=True,
                     quantity_needed=100,


### PR DESCRIPTION
Offline catalog reads currently manufacture a fresh inventory observation timestamp, allowing historical stock to appear verified. Preserve supplier source and original observation time through catalog/cache reads, CLI output, availability checks, assembly validation, suggestions, and BOM export enrichment. Offline identity matches remain usable, while offline, unknown, or observations older than the documented 24-hour software freshness policy cannot qualify stock availability. This policy does not reserve supplier stock.

Cache migration preserves existing identities without promoting legacy rows to live provenance. Local read time, snapshot metadata, and cache provenance remain separate from the observation timestamp. Current main's backend-unavailable classification remains distinct from this change's unverified-stock classification.

Validation:

- Latest repair `3360cc81`: both low-stock and out-of-stock text alternative lists preserve reported quantities while explicitly marking offline/unknown stock unverified and requesting a live refresh. Four captured-output controls cover both branches and live/offline alternatives; the two offline cases fail before the fix. All41 focused provenance/alternative tests pass after the fix, independently re-run by the sweep. Ruff lint/format and whitespace pass. Fresh CI and independent Judge review are required for this head.

Integration validation on `3120f200` (main `943e39be`):

- 428 tests passed across catalog, parts/cache, cost, assembly validation, BOM enrichment, alternatives, official API and suggestion suites; a new mixed-batch integration test also passed.
- The mixed-batch test preserves distinct offline/unverified, live/available, live/zero-stock, backend-unavailable and confirmed-missing results, including both summary counts and original observation times.
- Ruff lint/format and whitespace checks passed. The repository mypy gate passed:1421 existing errors within the1472 baseline, no new type errors; baseline unchanged.
- The only textual main-integration conflict was in the availability summary; both `unverified` and `unavailable` counts are retained. Fresh CI and independent Judge review remain required.

Unknown catalog snapshot age stays unknown rather than inheriting download time or filesystem mtime. Tests use controlled transports and observations; no live supplier availability or factory acceptance is claimed.

Closes #5034

