### PR TITLE
feat: search safe alternate escapes for blocked in-pad vias

### DIFF
--- a/src/kicad_tools/cli/commands/validation.py
+++ b/src/kicad_tools/cli/commands/validation.py
@@ -89,6 +89,8 @@ def run_fix_vias_command(args) -> int:
         sub_argv.append("--skip-if-clearance-violation")
     if getattr(args, "relocate_in_pad", False):
         sub_argv.append("--relocate-in-pad")
+    if getattr(args, "search_alternatives", False):
+        sub_argv.append("--search-alternatives")
     for net in getattr(args, "nets", None) or []:
         sub_argv.extend(["--net", net])
     return fix_vias_main(sub_argv)

--- a/src/kicad_tools/cli/fix_vias_cmd.py
+++ b/src/kicad_tools/cli/fix_vias_cmd.py
@@ -791,7 +791,13 @@ def _run_relocate_in_pad(args, pcb_path: Path, resolved_layers: int) -> int:
 
     # Resolve the source project's hole floor before a renamed output is saved.
     try:
-        result = relocate_in_pad_vias(pcb, rules, nets=nets, dry_run=args.dry_run)
+        result = relocate_in_pad_vias(
+            pcb,
+            rules,
+            nets=nets,
+            dry_run=args.dry_run,
+            search_alternatives=getattr(args, "search_alternatives", False),
+        )
     except (ValueError, OSError) as exc:
         print(f"Error resolving relocation constraints: {exc}", file=sys.stderr)
         return 1
@@ -913,6 +919,11 @@ Examples:
             "are reported (skipped/unresolvable), never left silently in-pad. "
             "This is a distinct pass from via resizing."
         ),
+    )
+    parser.add_argument(
+        "--search-alternatives",
+        action="store_true",
+        help="With --relocate-in-pad, try up to 24 safe cardinal/45-degree alternatives when the preferred escape is blocked (default: disabled).",
     )
     parser.add_argument(
         "--net",

--- a/src/kicad_tools/cli/parser.py
+++ b/src/kicad_tools/cli/parser.py
@@ -5141,6 +5141,11 @@ def _add_fix_vias_parser(subparsers) -> None:
     )
     fix_vias_parser.add_argument("pcb", help="Path to .kicad_pcb file")
     fix_vias_parser.add_argument(
+        "--search-alternatives",
+        action="store_true",
+        help="With --relocate-in-pad, search safe alternate escapes if the preferred slide is blocked",
+    )
+    fix_vias_parser.add_argument(
         "--mfr",
         choices=get_all_manufacturer_names(),
         default="jlcpcb",

--- a/src/kicad_tools/cli/relocate_in_pad_vias.py
+++ b/src/kicad_tools/cli/relocate_in_pad_vias.py
@@ -385,6 +385,72 @@ def _first_offpad_plane_candidate(
     return None
 
 
+def _alternative_board_region(pcb: PCB):
+    """Return actual straight Edge.Cuts area, including holes, or fail closed.
+
+    No outline is allowed for legacy outline-free fixtures. Unsupported curved
+    or footprint outlines and open contours cannot prove containment and yield
+    an empty region, refusing the optional search without changing the board.
+    """
+    from shapely.geometry import GeometryCollection, Polygon
+    from shapely.ops import polygonize_full, unary_union  # type: ignore[import-untyped]
+
+    lines = []
+    ox, oy = pcb.board_origin
+
+    def xy(node):
+        return (node.get_float(0) - ox, node.get_float(1) - oy)
+
+    for node in pcb._sexp.children:
+        if node.is_atom:
+            continue
+        items = node.children if node.name in ("footprint", "module") else [node]
+        for item in items:
+            layer = item.find("layer")
+            if layer is None or layer.get_string(0) != "Edge.Cuts":
+                continue
+            if item is not node:
+                return GeometryCollection()
+            if item.name == "gr_line":
+                points = [xy(item.find("start")), xy(item.find("end"))]
+            elif item.name == "gr_rect":
+                x1, y1 = xy(item.find("start"))
+                x2, y2 = xy(item.find("end"))
+                points = [(x1, y1), (x2, y1), (x2, y2), (x1, y2), (x1, y1)]
+            elif item.name == "gr_poly":
+                pts = item.find("pts")
+                if pts is None:
+                    return GeometryCollection()
+                points = [xy(pt) for pt in pts.children if pt.name == "xy"]
+                if len(points) < 3:
+                    return GeometryCollection()
+                points.append(points[0])
+            else:
+                return GeometryCollection()
+            lines.append(LineString(points))
+    if not lines:
+        return None
+    faces, cuts, dangles, invalid = polygonize_full(unary_union(lines))
+    if not cuts.is_empty or not dangles.is_empty or not invalid.is_empty:
+        return GeometryCollection()
+    # Polygonization includes each cutout as a face too. Combine the unique
+    # exterior rings by parity, retaining holes instead of union-filling them.
+    region = GeometryCollection()
+    for face in faces.geoms:
+        region = region.symmetric_difference(Polygon(face.exterior))
+    return region
+
+
+def _alternative_contained(region, via: Via, target, width: float) -> bool:
+    if region is None:
+        return True
+    path = LineString([via.position, target])
+    # Exact centerline distance avoids inscribed round-buffer approximations.
+    return bool(
+        region.covers(path) and path.distance(region.boundary) >= max(width, via.size) / 2 + 1e-6
+    )
+
+
 def _first_offpad_signal_candidate(
     pcb: PCB,
     via: Via,
@@ -396,6 +462,8 @@ def _first_offpad_signal_candidate(
     stub_layers: list[str] | None = None,
     stub_width: float = 0.2,
     min_hole_clearance: float | None = None,
+    *,
+    search_alternatives: bool = False,
 ) -> tuple[float, float] | None:
     """Find the first clearance-safe off-pad location for a **signal** via.
 
@@ -413,6 +481,11 @@ def _first_offpad_signal_candidate(
     """
     pad_cx = (bbox[0] + bbox[2]) / 2.0
     pad_cy = (bbox[1] + bbox[3]) / 2.0
+    region = _alternative_board_region(pcb) if search_alternatives else None
+    if search_alternatives:
+        # Cardinal/45-degree stubs originate at the existing via, even when
+        # its center is offset from the source pad.
+        pad_cx, pad_cy = via.position
     via_r = via.size / 2.0
     step = via.size + min_clearance
     extra_offsets = (0.0, step * 0.5, step)
@@ -424,6 +497,18 @@ def _first_offpad_signal_candidate(
             nx = pad_cx + dx * slide
             ny = pad_cy + dy * slide
 
+            if not _alternative_contained(region, via, (nx, ny), stub_width):
+                continue
+            if search_alternatives and any(
+                is_smd_pad(other_pad)
+                and _dist_point_to_aabb(nx, ny, pad_absolute_bbox(other_pad, fp))
+                < via.drill / 2.0 + min_clearance - 1e-6
+                for fp in pcb.footprints
+                for other_pad in fp.pads
+            ):
+                # Same-net pads still physically overlap a drilled hole. A
+                # fallback must not merely transfer via-in-pad to another pad.
+                continue
             # (a) via copper must clear the pad bbox edge by min_clearance.
             if _dist_point_to_aabb(nx, ny, bbox) - via_r < min_clearance - 1e-6:
                 continue
@@ -1023,6 +1108,7 @@ def relocate_in_pad_vias(
     nets: set[str] | None = None,
     dry_run: bool = False,
     min_hole_clearance_mm: float | None = None,
+    search_alternatives: bool = False,
 ) -> RelocationResult:
     """Slide signal in-pad vias off-pad, preserving connectivity (Phase 1).
 
@@ -1031,6 +1117,11 @@ def relocate_in_pad_vias(
         design_rules: Active manufacturer rules.  A no-op when
             ``via_in_pad_supported`` is True.  ``min_clearance_mm`` and
             ``min_hole_to_hole_mm`` gate the off-pad placement.
+        search_alternatives: Opt in to a bounded 24-candidate cardinal/45-degree
+            search when the preferred single escape is blocked. Alternatives
+            preserve the full via land on every spanned layer and require full
+            stub containment in straight Edge.Cuts outlines (including cutouts).
+            Unsupported/open outlines conservatively refuse the alternative.
         nets: Optional set of net *names* to restrict the pass to.  ``None``
             means all nets.
         dry_run: When True, compute the report but do not mutate the board.
@@ -1052,7 +1143,11 @@ def relocate_in_pad_vias(
         # Later candidates must see earlier planned vias AND their stubs.
         # Simulating the normal mutation path also keeps reports equivalent.
         return relocate_in_pad_vias(
-            copy.deepcopy(pcb), design_rules, nets=nets, min_hole_clearance_mm=min_hole_clearance
+            copy.deepcopy(pcb),
+            design_rules,
+            nets=nets,
+            min_hole_clearance_mm=min_hole_clearance,
+            search_alternatives=search_alternatives,
         )
 
     result = RelocationResult()
@@ -1295,6 +1390,54 @@ def relocate_in_pad_vias(
                 min_hole_to_hole,
                 min_hole_clearance,
             )
+            if search_alternatives:
+                reason = reason or _check_stub_clearance(
+                    pcb,
+                    via,
+                    (new_x, new_y),
+                    stub_layers,
+                    stub_width,
+                    min_clearance,
+                    min_hole_clearance,
+                )
+                if reason is not None:
+                    # A via may touch pads, fills, or tracks anywhere on its
+                    # land, on any spanned layer. Retain that entire contact
+                    # area, including contacts not centered on its drill.
+                    all_layers = [layer.name for layer in pcb.copper_layers]
+                    indices = [
+                        all_layers.index(layer) for layer in via.layers if layer in all_layers
+                    ]
+                    alternative_layers = (
+                        all_layers[min(indices) : max(indices) + 1]
+                        if len(indices) == len(via.layers) and len(indices) >= 2
+                        else []
+                    )
+                    alternative_width = max(stub_width, via.size)
+                    target = (
+                        _first_offpad_signal_candidate(
+                            pcb,
+                            via,
+                            bbox,
+                            pads_by_net,
+                            tht_pads,
+                            min_clearance,
+                            min_hole_to_hole,
+                            alternative_layers,
+                            alternative_width,
+                            min_hole_clearance,
+                            search_alternatives=True,
+                        )
+                        if alternative_layers
+                        else None
+                    )
+                    if target is not None:
+                        new_x, new_y = target
+                        stub_layers = alternative_layers
+                        stub_width = alternative_width
+                        reason = None
+                    else:
+                        reason += "; no safe bounded alternative (clearance/board containment)"
             if reason is not None:
                 result.skipped.append(
                     ViaRelocationSkip(

--- a/src/kicad_tools/cli/relocate_in_pad_vias.py
+++ b/src/kicad_tools/cli/relocate_in_pad_vias.py
@@ -399,7 +399,15 @@ def _alternative_board_region(pcb: PCB):
     ox, oy = pcb.board_origin
 
     def xy(node):
-        return (node.get_float(0) - ox, node.get_float(1) - oy)
+        if node is None or len(node.get_atoms()) != 2:
+            return None
+        try:
+            x, y = (float(value) for value in node.get_atoms())
+        except (TypeError, ValueError):
+            return None
+        if not math.isfinite(x) or not math.isfinite(y):
+            return None
+        return (x - ox, y - oy)
 
     for node in pcb._sexp.children:
         if node.is_atom:
@@ -414,8 +422,11 @@ def _alternative_board_region(pcb: PCB):
             if item.name == "gr_line":
                 points = [xy(item.find("start")), xy(item.find("end"))]
             elif item.name == "gr_rect":
-                x1, y1 = xy(item.find("start"))
-                x2, y2 = xy(item.find("end"))
+                start, end = xy(item.find("start")), xy(item.find("end"))
+                if start is None or end is None:
+                    return GeometryCollection()
+                x1, y1 = start
+                x2, y2 = end
                 points = [(x1, y1), (x2, y1), (x2, y2), (x1, y2), (x1, y1)]
             elif item.name == "gr_poly":
                 pts = item.find("pts")
@@ -426,6 +437,8 @@ def _alternative_board_region(pcb: PCB):
                     return GeometryCollection()
                 points.append(points[0])
             else:
+                return GeometryCollection()
+            if any(point is None for point in points):
                 return GeometryCollection()
             lines.append(LineString(points))
     if not lines:

--- a/tests/fixtures/via_relocation/blocked_slide.kicad_pcb
+++ b/tests/fixtures/via_relocation/blocked_slide.kicad_pcb
@@ -1,0 +1,8 @@
+(kicad_pcb (version 20240108) (generator "test") (general (thickness 1.6))
+(layers (0 "F.Cu" signal) (31 "B.Cu" signal) (44 "Edge.Cuts" user))
+(net 0 "") (net 1 "SIG")
+(gr_rect (start 0 0) (end 20 20) (stroke (width .1) (type default)) (fill none) (layer "Edge.Cuts"))
+(footprint "Test:Pad" (layer "F.Cu") (at 10 10) (property "Reference" "U1" (at 0 -2) (layer "F.SilkS")) (pad "1" smd rect (at 0 0) (size 1 1) (layers "F.Cu") (net 1 "SIG")))
+(via (at 10 10) (size .45) (drill .2) (layers "F.Cu" "B.Cu") (net 1) (uuid "11111111-1111-4111-8111-111111111111"))
+(via (at 10.7016 10.3) (size .45) (drill .2) (layers "F.Cu" "B.Cu") (net 1) (uuid "22222222-2222-4222-8222-222222222222"))
+(segment (start 10 10) (end 12 10) (width .2) (layer "F.Cu") (net 1) (uuid "33333333-3333-4333-8333-333333333333")))

--- a/tests/test_fix_vias.py
+++ b/tests/test_fix_vias.py
@@ -3901,3 +3901,24 @@ def test_public_cli_search_alternatives_moves_blocked_via(tmp_path):
     pcb = PCB.load(board)
     assert pcb.vias[0].position == pytest.approx((10, 10.8266))
     assert pcb.vias[0].uuid == "11111111-1111-4111-8111-111111111111"
+
+
+@pytest.mark.parametrize(
+    "outline",
+    [
+        '(gr_line (end 12 12) (layer "Edge.Cuts"))',
+        '(gr_rect (start 0 0) (layer "Edge.Cuts"))',
+        '(gr_line (start nope 0) (end 12 12) (layer "Edge.Cuts"))',
+        '(gr_poly (pts (xy 0 0) (xy 12) (xy 12 12)) (layer "Edge.Cuts"))',
+        '(gr_line (start nan 0) (end 12 12) (layer "Edge.Cuts"))',
+    ],
+)
+def test_alternative_invalid_outline_coordinates_refuse_without_mutation(tmp_path, outline):
+    board = _blocked_slide_board(tmp_path, outline)
+    pcb = PCB.load(board)
+    before = pcb._sexp.to_string()
+    result = relocate_in_pad_vias(
+        pcb, get_mfr_design_rules("jlcpcb", 4, 1.0), search_alternatives=True
+    )
+    assert not result.changed
+    assert pcb._sexp.to_string() == before

--- a/tests/test_fix_vias.py
+++ b/tests/test_fix_vias.py
@@ -3271,6 +3271,300 @@ def test_invalid_hole_floor_cli_preserves_source(tmp_path, capsys):
     assert board.read_bytes() == original
 
 
+def test_blocked_slide_alternative_preserves_copper(tmp_path):
+    source = Path(__file__).parent / "fixtures/via_relocation/blocked_slide.kicad_pcb"
+    board = _write(tmp_path, source.read_text())
+    pcb = PCB.load(board)
+    original = [(s.start, s.end, s.width, s.layer, s.net_number, s.uuid) for s in pcb.segments]
+    rules = get_mfr_design_rules("jlcpcb", 4, 1.0)
+    assert not relocate_in_pad_vias(pcb, rules).moved
+    result = relocate_in_pad_vias(pcb, rules, search_alternatives=True)
+    assert len(result.moved) == 1
+    assert result.moved[0].new_x == pytest.approx(10)
+    assert result.moved[0].new_y == pytest.approx(10.8266)
+    pcb.save(board)
+    reloaded = PCB.load(board)
+    assert [
+        (s.start, s.end, s.width, s.layer, s.net_number, s.uuid) for s in reloaded.segments[:1]
+    ] == original
+    assert reloaded.vias[0].uuid == "11111111-1111-4111-8111-111111111111"
+    assert {s.layer for s in reloaded.segments[1:]} == {"F.Cu", "B.Cu"}
+    assert all(s.width == 0.45 and s.net_number == 1 for s in reloaded.segments[1:])
+
+
+def _blocked_slide_board(tmp_path, extra=""):
+    source = Path(__file__).parent / "fixtures/via_relocation/blocked_slide.kicad_pcb"
+    return _write(tmp_path, source.read_text().rstrip().removesuffix(")") + extra + ")")
+
+
+@pytest.mark.parametrize("net", [0, 2])
+def test_alternative_rejects_entire_foreign_stub(tmp_path, net):
+    # The nearest +Y landing is clear, but its stub crosses foreign copper.
+    obstacle = f"""(segment (start 9.6 10.42) (end 10.4 10.42)
+        (width .1) (layer "B.Cu") (net {net}))"""
+    pcb = PCB.load(_blocked_slide_board(tmp_path, obstacle))
+    result = relocate_in_pad_vias(
+        pcb, get_mfr_design_rules("jlcpcb", 4, 1.0), search_alternatives=True
+    )
+    assert len(result.moved) == 1
+    # Next cardinal direction (-X) is safe; the old via/track are retained.
+    assert result.moved[0].new_x < 10
+    assert result.moved[0].new_y == pytest.approx(10)
+    assert pcb.segments[1].net_number == net
+
+
+@pytest.mark.parametrize(
+    "obstacles",
+    [
+        # All directions blocked by same-net drill ring.
+        "".join(
+            f'(via (at {x} {y}) (size .45) (drill .2) (layers "F.Cu" "B.Cu") (net 1))'
+            for x, y in [
+                (10.7, 10),
+                (10, 10.7),
+                (9.3, 10),
+                (10, 9.3),
+                (10.7, 10.7),
+                (9.3, 10.7),
+                (9.3, 9.3),
+                (10.7, 9.3),
+                (11.2, 10),
+                (10, 11.2),
+                (8.8, 10),
+                (10, 8.8),
+            ]
+        ),
+        # Four foreign tracks fence the entire swept copper, even far landings.
+        "".join(
+            f'(segment (start {x1} {y1}) (end {x2} {y2}) (width .2) (layer "B.Cu") (net 0))'
+            for x1, y1, x2, y2 in [
+                (9.6, 9.6, 10.4, 9.6),
+                (10.4, 9.6, 10.4, 10.4),
+                (10.4, 10.4, 9.6, 10.4),
+                (9.6, 10.4, 9.6, 9.6),
+            ]
+        ),
+    ],
+)
+def test_alternative_boxed_in_is_atomic(tmp_path, obstacles):
+    pcb = PCB.load(_blocked_slide_board(tmp_path, obstacles))
+    original = pcb._sexp.to_string()
+    result = relocate_in_pad_vias(
+        pcb, get_mfr_design_rules("jlcpcb", 4, 1.0), search_alternatives=True
+    )
+    assert not result.moved
+    assert len(result.skipped) == 1
+    assert "no safe bounded alternative" in result.skipped[0].reason
+    assert pcb._sexp.to_string() == original
+
+
+@pytest.mark.parametrize(
+    "outline",
+    [
+        '(gr_rect (start 0 0) (end 20 10.5) (layer "Edge.Cuts"))',
+        '(gr_rect (start 0 0) (end 20 20) (layer "Edge.Cuts"))'
+        '(gr_rect (start 9.8 10.35) (end 10.2 10.55) (layer "Edge.Cuts"))',
+        "(gr_poly (pts (xy 0 0) (xy 20 0) (xy 20 20) (xy 10.3 20)"
+        ' (xy 10.3 10.5) (xy 9.7 10.5) (xy 9.7 20) (xy 0 20)) (layer "Edge.Cuts"))',
+    ],
+)
+def test_alternative_checks_actual_outline_and_stub_cutout(tmp_path, outline):
+    from kicad_tools.cli.relocate_in_pad_vias import _alternative_board_region
+
+    pcb = PCB.load(_blocked_slide_board(tmp_path))
+    node = next(n for n in pcb._sexp.children if n.name == "gr_rect")
+    pcb._sexp.remove(node)
+    from kicad_tools.sexp import parse_string
+
+    # Read directly from S-expression to avoid stale cached geometry.
+    pcb._sexp.children.extend(
+        n for n in parse_string("(root " + outline + ")").children if not n.is_atom
+    )
+    result = relocate_in_pad_vias(
+        pcb, get_mfr_design_rules("jlcpcb", 4, 1.0), search_alternatives=True
+    )
+    assert len(result.moved) == 1
+    assert result.moved[0].new_y == pytest.approx(10)
+    assert result.moved[0].new_x < 10
+    from shapely.geometry import Point
+
+    assert _alternative_board_region(pcb).contains(Point(pcb.vias[0].position))
+
+
+@pytest.mark.parametrize(
+    "outline",
+    [
+        '(gr_circle (center 8 8) (end 8.1 8) (layer "Edge.Cuts"))',
+        '(gr_line (start 8 8) (end 9 8) (layer "Edge.Cuts"))',
+        '(gr_poly (layer "Edge.Cuts"))',
+    ],
+)
+def test_alternative_unproven_outline_refuses_atomically(tmp_path, outline):
+    pcb = PCB.load(_blocked_slide_board(tmp_path, outline))
+    original = pcb._sexp.to_string()
+    result = relocate_in_pad_vias(
+        pcb, get_mfr_design_rules("jlcpcb", 4, 1.0), search_alternatives=True
+    )
+    assert not result.moved
+    assert pcb._sexp.to_string() == original
+
+
+def test_alternative_dry_run_filters_capability_and_cli(tmp_path):
+    import copy
+    from dataclasses import replace
+
+    board = _blocked_slide_board(tmp_path)
+    pcb = PCB.load(board)
+    original = pcb._sexp.to_string()
+    rules = get_mfr_design_rules("jlcpcb", 4, 1.0)
+    dry = relocate_in_pad_vias(pcb, rules, search_alternatives=True, dry_run=True)
+    live = relocate_in_pad_vias(copy.deepcopy(pcb), rules, search_alternatives=True)
+    assert dry == live
+    assert pcb._sexp.to_string() == original
+    assert not relocate_in_pad_vias(pcb, rules, search_alternatives=True, nets={"OTHER"}).changed
+    assert relocate_in_pad_vias(
+        pcb, replace(rules, via_in_pad_supported=True), search_alternatives=True
+    ).supported_noop
+    assert pcb._sexp.to_string() == original
+    before = board.read_bytes()
+    assert (
+        main(
+            [
+                str(board),
+                "--relocate-in-pad",
+                "--search-alternatives",
+                "--dry-run",
+                "--layers",
+                "4",
+                "--quiet",
+            ]
+        )
+        == 0
+    )
+    assert board.read_bytes() == before
+    assert (
+        main([str(board), "--relocate-in-pad", "--search-alternatives", "--layers", "4", "--quiet"])
+        == 0
+    )
+    assert PCB.load(board).vias[0].position == pytest.approx(
+        (dry.moved[0].new_x, dry.moved[0].new_y)
+    )
+
+
+def test_alternative_project_floor_gates_every_stub(tmp_path):
+    import json
+
+    extra = '(via (at 10.45 10.8) (size .45) (drill .2) (layers "F.Cu" "B.Cu") (net 0))'
+    board = _blocked_slide_board(tmp_path, extra)
+    rules = get_mfr_design_rules("jlcpcb", 4, 1.0)
+    assert relocate_in_pad_vias(PCB.load(board), rules, search_alternatives=True).moved
+    board.with_suffix(".kicad_pro").write_text(
+        json.dumps({"board": {"design_settings": {"rules": {"min_hole_clearance": 0.7}}}})
+    )
+    pcb = PCB.load(board)
+    original = pcb._sexp.to_string()
+    result = relocate_in_pad_vias(pcb, rules, search_alternatives=True, min_hole_clearance_mm=0.25)
+    assert not result.moved
+    assert pcb._sexp.to_string() == original
+
+
+def test_alternative_preserves_offset_pad_and_all_layers(tmp_path):
+    from shapely.geometry import LineString, box
+
+    board = _blocked_slide_board(tmp_path)
+    text = board.read_text().replace(
+        '(31 "B.Cu" signal)', '(1 "In1.Cu" signal) (2 "In2.Cu" signal) (31 "B.Cu" signal)'
+    )
+    text = text.replace(
+        "(via (at 10 10) (size .45) (drill .2)", "(via (at 10.65 10) (size .6) (drill .4)"
+    )
+    text = text.replace("(start 10 10)", "(start 10.65 10)")
+    text = text.replace("(at 10.7016 10.3)", "(at 11.1 10.3)")
+    board.write_text(text)
+    pcb = PCB.load(board)
+    result = relocate_in_pad_vias(
+        pcb, get_mfr_design_rules("jlcpcb", 4, 1.0), search_alternatives=True
+    )
+    assert len(result.moved) == 1
+    stubs = pcb.segments[1:]
+    assert {s.layer for s in stubs} == {"F.Cu", "In1.Cu", "In2.Cu", "B.Cu"}
+    surface_stub = next(s for s in stubs if s.layer == "F.Cu")
+    # The old drill overlaps the pad, but a .2-wide perpendicular stub misses
+    # it because the via center sits .15 beyond the pad. Full land survives.
+    assert surface_stub.start == (10.65, 10)
+    assert surface_stub.width >= 0.6
+    assert (
+        LineString([surface_stub.start, surface_stub.end])
+        .buffer(surface_stub.width / 2)
+        .intersects(box(9.5, 9.5, 10.5, 10.5))
+    )
+
+
+def test_alternative_native_roundtrip(tmp_path):
+    import json
+    import shutil
+    import subprocess
+
+    native = shutil.which("kicad-cli")
+    if native is None:
+        pytest.skip("native KiCad CLI unavailable")
+    board = _blocked_slide_board(tmp_path)
+
+    def drc(name):
+        output = tmp_path / f"{name}.json"
+        subprocess.run(
+            [
+                native,
+                "pcb",
+                "drc",
+                "--refill-zones",
+                "--save-board",
+                "--format",
+                "json",
+                "-o",
+                str(output),
+                str(board),
+            ],
+            check=True,
+            capture_output=True,
+        )
+        return json.loads(output.read_text())
+
+    before = drc("before")
+    pcb = PCB.load(board)
+    result = relocate_in_pad_vias(
+        pcb, get_mfr_design_rules("jlcpcb", 4, 1.0), search_alternatives=True
+    )
+    assert len(result.moved) == 1
+    pcb.save(board)
+    after = drc("after")
+    assert not [
+        v
+        for v in after["violations"]
+        if v["type"]
+        in {
+            "clearance",
+            "hole_clearance",
+            "holes_co_located",
+            "shorting_items",
+            "copper_edge_clearance",
+        }
+    ]
+    assert len(after["unconnected_items"]) <= len(before["unconnected_items"])
+
+
+def test_alternative_does_not_transfer_overlap_to_same_net_pad(tmp_path):
+    extra = """(footprint "Test:Pad" (layer "B.Cu") (at 10 10.83)
+      (pad "1" smd rect (at 0 0) (size .2 .2) (layers "B.Cu") (net 1 "SIG")))"""
+    pcb = PCB.load(_blocked_slide_board(tmp_path, extra))
+    result = relocate_in_pad_vias(
+        pcb, get_mfr_design_rules("jlcpcb", 4, 1.0), search_alternatives=True
+    )
+    assert len(result.moved) == 1
+    assert result.moved[0].new_x < 10
+    assert result.moved[0].new_y == pytest.approx(10)
+
+
 @pytest.mark.parametrize("drill", ["oval .2 1.6", ".2 (offset 0 -.7)"])
 @pytest.mark.parametrize("gate", ["via", "stub"])
 def test_hole_floor_rejects_unmodeled_pad_drills(tmp_path, drill, gate):

--- a/tests/test_fix_vias.py
+++ b/tests/test_fix_vias.py
@@ -3887,3 +3887,17 @@ def test_stub_hole_envelope_checks_new_extent_of_existing_violation(foreign_x):
         assert reason is None
     else:
         assert reason == "stub hole-to-copper to via on net 2"
+
+
+def test_public_cli_search_alternatives_moves_blocked_via(tmp_path):
+    from kicad_tools.cli import main as public_main
+
+    board = _blocked_slide_board(tmp_path)
+    before = board.read_bytes()
+    args = ["fix-vias", str(board), "--relocate-in-pad", "--search-alternatives", "--layers", "4"]
+    assert public_main([*args, "--dry-run"]) == 0
+    assert board.read_bytes() == before
+    assert public_main(args) == 0
+    pcb = PCB.load(board)
+    assert pcb.vias[0].position == pytest.approx((10, 10.8266))
+    assert pcb.vias[0].uuid == "11111111-1111-4111-8111-111111111111"


### PR DESCRIPTION
When an in-pad via’s preferred escape is blocked, opt in to a bounded search for safe alternate positions using `fix-vias --relocate-in-pad --search-alternatives` or `relocate_in_pad_vias(..., search_alternatives=True)`. Defaults remain unchanged.

The search checks up to24 cardinal/45-degree candidates against the entire stub, project hole-clearance floor and physical pad bounds. It retains original tracks and the via’s contact area with sufficiently wide stubs on every spanned layer, preserving nets and via UUID. Candidate containment uses straight Edge.Cuts contours, including concavities and cutouts. Unsupported or malformed outlines refuse the alternate search; legacy outline-free inputs remain supported. Exhausted searches leave the rejected via unchanged and report the reason.

The public CLI accepts and forwards the option. Dry runs simulate the same changes on a copy. Missing, short, nonnumeric and nonfinite outline coordinates are rejected before constructing containment geometry.

Validation at `137f74164f63ce6fd54e91cbbab177dd6d2a2640`:315 tests passed without skips across fix-vias, drill-clearance, safe-repair and public-parser suites with pinned KiCad10.0.5 available. Coverage includes compact native refill/save/reload controls, crowded alternatives, whole-stub obstacles, same-net destination pads, all-layer contacts, project floors, outline containment, dry-run source preservation and real public-CLI relocation. The public CLI regression failed before its wiring fix; four malformed-coordinate controls raised exceptions before the outline repair. Ruff lint/format, whitespace and version gates pass.

Parent #5085 has merged; this PR now targets main. This change adds no Board07-specific repair or manufacturing qualification. Fresh exact-head CI and final review are required. Logs:/tmp/loom-5091-outline-validation.log and /tmp/loom-5091-public-cli-validation.log.

Closes #5068
