### PR TITLE
fix: carry authored DRC constraints across routed output renames

### DIFF
--- a/docs/guides/routing.md
+++ b/docs/guides/routing.md
@@ -907,3 +907,23 @@ downstream).
 - [Placement Optimization Guide](placement-optimization.md)
 - [DRC & Validation Guide](drc-and-validation.md)
 - [Example: Autorouter](https://github.com/rjwalters/kicad-tools/tree/main/examples/04-autorouter)
+
+### Project rules when changing the output name
+
+When post-route DRC writes a renamed PCB, it carries the source board's
+`.kicad_pro` and `.kicad_dru` into the destination before merging manufacturer
+floors. The source files remain unchanged. Authored project settings, netclass
+assignments, custom DRU text, and `KCT_PRESERVE_BOARD_RULES=1` follow the output;
+with that flag, stricter authored minima remain active while manufacturer
+limits can tighten weaker minima.
+
+An existing destination sidecar must match either the corresponding authored
+source or the result of applying the current manufacturer floors to it. JSON
+project formatting does not matter; custom DRU text must match exactly.
+Conflicting destination sidecars cause a visible error and exit code 1, even
+with `--quiet` or `--auto-fix`. Neither project nor DRU is replaced on a conflict.
+Choose a fresh output name or reconcile the authored files explicitly before
+retrying. Identical repeated exports are accepted. If a source sidecar is
+absent, an existing destination sidecar retains the usual preserve-and-merge
+behavior. This propagation belongs to post-route DRC; `--skip-drc` does not
+perform it.

--- a/src/kicad_tools/cli/route_cmd.py
+++ b/src/kicad_tools/cli/route_cmd.py
@@ -2398,12 +2398,17 @@ def _write_fab_profile_sidecar(
         print(f"  Fab-profile sidecar: {sidecar_path}")
 
 
+class DRCConstraintPropagationError(ValueError):
+    """Authored source constraints could not safely reach the routed output."""
+
+
 def _write_drc_constraint_sidecars(
     output_path: Path,
     manufacturer: str,
     layers: int,
     copper_oz: float = 1.0,
     quiet: bool = False,
+    source_pcb_path: Path | None = None,
 ) -> None:
     """Emit ``.kicad_pro`` + ``.kicad_dru`` next to the routed PCB.
 
@@ -2442,6 +2447,8 @@ def _write_drc_constraint_sidecars(
         copper_oz: Copper weight in oz (defaults to 1.0, the system default
             and the correct value for all 8 demo boards).
         quiet: If True, suppress the confirmation line.
+        source_pcb_path: Original PCB for renamed outputs. Source propagation
+            failures are blocking and printed even in quiet mode.
     """
     try:
         from kicad_tools.manufacturers import get_profile, write_drc_constraints
@@ -2454,8 +2461,13 @@ def _write_drc_constraint_sidecars(
             manufacturer_id=profile.id,
             layers=layers,
             copper_oz=copper_oz,
+            source_pcb_path=source_pcb_path,
         )
     except (ValueError, OSError, KeyError) as e:
+        if source_pcb_path is not None:
+            raise DRCConstraintPropagationError(
+                f"cannot preserve source DRC constraints: {e}"
+            ) from e
         # Non-fatal: an unknown manufacturer (ValueError) or a read-only /
         # blocked output directory (OSError) must not fail the route.
         if not quiet:
@@ -2475,11 +2487,15 @@ def run_post_route_drc(
     strict_drc: bool = False,
     net_class_map_input_path: Path | None = None,
     loaded_net_class_map: dict | None = None,
+    source_pcb_path: Path | None = None,
 ) -> tuple[int, int]:
     """Run DRC validation on the routed PCB.
 
     Args:
         output_path: Path to the routed PCB file
+        source_pcb_path: Original PCB before staging/renaming; carry authored
+            project and DRU into the destination before native DRC. Conflicting
+            destination constraints raise DRCConstraintPropagationError before DRC.
         manufacturer: Manufacturer profile for DRC rules (e.g., "jlcpcb")
         layers: Number of PCB layers
         quiet: If True, suppress output
@@ -2546,7 +2562,12 @@ def run_post_route_drc(
     # route flow -- makes the verdict deterministic and independent of any
     # sidecars a prior run may have left behind.
     _write_drc_constraint_sidecars(
-        output_path, manufacturer, layers, copper_oz=copper_oz, quiet=quiet
+        output_path,
+        manufacturer,
+        layers,
+        copper_oz=copper_oz,
+        quiet=quiet,
+        source_pcb_path=source_pcb_path,
     )
 
     try:
@@ -6785,6 +6806,7 @@ def route_with_layer_escalation(
     if not args.skip_drc and final_result.nets_routed > 0:
         drc_errors, _ = run_post_route_drc(
             output_path=output_path,
+            source_pcb_path=Path(args.pcb),
             manufacturer=args.manufacturer,
             layers=final_result.layer_count,
             quiet=quiet,
@@ -7590,6 +7612,7 @@ def route_with_rule_relaxation(
     if not args.skip_drc and final_result.nets_routed > 0:
         drc_errors, _ = run_post_route_drc(
             output_path=output_path,
+            source_pcb_path=Path(args.pcb),
             manufacturer=args.manufacturer,
             layers=final_result.layer_count,
             quiet=quiet,
@@ -9897,6 +9920,7 @@ def route_with_combined_escalation(
     if not args.skip_drc and final_result.nets_routed > 0:
         drc_errors, _ = run_post_route_drc(
             output_path=output_path,
+            source_pcb_path=Path(args.pcb),
             manufacturer=args.manufacturer,
             layers=final_result.layer_count,
             quiet=quiet,
@@ -11594,7 +11618,13 @@ def main(argv: list[str] | None = None) -> int:
     invocation; only the outermost exit (return *or* raise) restores it.
     """
     with _process_state_guard():
-        return _main_impl(argv)
+        try:
+            return _main_impl(argv)
+        except DRCConstraintPropagationError as exc:
+            # A rule conflict is not a copper violation that --auto-fix may
+            # clear. Abort every route flow before its ordinary DRC handling.
+            print(f"Error: {exc}", file=sys.stderr)
+            return 1
 
 
 def _main_impl(argv: list[str] | None = None) -> int:
@@ -15996,6 +16026,7 @@ def _main_impl(argv: list[str] | None = None) -> int:
         drc_ran = True
         drc_errors, drc_warnings = run_post_route_drc(
             output_path=output_path,
+            source_pcb_path=Path(args.pcb),
             manufacturer=args.manufacturer,
             layers=layer_stack.num_layers,
             quiet=quiet,

--- a/src/kicad_tools/manufacturers/project_generator.py
+++ b/src/kicad_tools/manufacturers/project_generator.py
@@ -39,6 +39,8 @@ Usage::
 from __future__ import annotations
 
 import json
+import shutil
+import tempfile
 from dataclasses import replace
 from pathlib import Path
 from typing import TYPE_CHECKING, Sequence
@@ -373,6 +375,7 @@ def write_drc_constraints(
     copper_oz: float | None = None,
     write_dru: bool = True,
     net_classes: Sequence[NetClassRouting] | None = None,
+    source_pcb_path: str | Path | None = None,
 ) -> list[Path]:
     """Emit DRC-constraint sources next to a routed ``.kicad_pcb``.
 
@@ -393,6 +396,9 @@ def write_drc_constraints(
 
     Args:
         pcb_path: Path to the routed board.
+        source_pcb_path: Original board when routing to a renamed destination.
+            Copy authored project/DRU before merging floors; reject conflicting
+            destination files before writing either sidecar. Source is read-only.
         rules: Manufacturer design rules to translate.
         manufacturer_id: Optional manufacturer id (for ``.kicad_pro`` meta
             and ``.kicad_dru`` labels).
@@ -411,6 +417,53 @@ def write_drc_constraints(
         List of paths written.
     """
     pcb_path = Path(pcb_path)
+    if source_pcb_path is not None and Path(source_pcb_path).resolve() != pcb_path.resolve():
+        # Render from authored source in isolation, then validate BOTH destination
+        # sidecars before changing either. Existing source copies and identical
+        # prior outputs are accepted; unrelated destination content is a conflict.
+        source = Path(source_pcb_path)
+        suffixes = [".kicad_pro", ".kicad_dru"] if write_dru else [".kicad_pro"]
+        with tempfile.TemporaryDirectory(prefix="kct-route-rules-") as temporary:
+            staged = Path(temporary) / pcb_path.name
+            for suffix in suffixes:
+                authored, destination = source.with_suffix(suffix), pcb_path.with_suffix(suffix)
+                if authored.exists():
+                    if destination.exists() and destination.samefile(authored):
+                        raise ValueError(
+                            f"DRC sidecar conflict: {destination} aliases source {authored}"
+                        )
+                    if suffix == ".kicad_pro":
+                        data = json.loads(authored.read_text(encoding="utf-8"))
+                        if not isinstance(data, dict):
+                            raise ValueError(f"Invalid source project: {authored}")
+                    shutil.copyfile(authored, staged.with_suffix(suffix))
+                elif destination.exists():
+                    shutil.copyfile(destination, staged.with_suffix(suffix))
+            rendered = write_drc_constraints(
+                staged,
+                rules,
+                manufacturer_id=manufacturer_id,
+                layers=layers,
+                copper_oz=copper_oz,
+                write_dru=write_dru,
+                net_classes=net_classes,
+            )
+            for result in rendered:
+                authored = source.with_suffix(result.suffix)
+                destination = pcb_path.with_suffix(result.suffix)
+                if authored.exists() and destination.exists():
+                    read = (
+                        (lambda p: json.loads(p.read_text(encoding="utf-8")))
+                        if result.suffix == ".kicad_pro"
+                        else (lambda p: p.read_bytes())
+                    )
+                    if read(destination) not in (read(authored), read(result)):
+                        raise ValueError(
+                            f"DRC sidecar conflict: {destination} differs from source {authored} and its merged rules"
+                        )
+            for result in rendered:
+                shutil.copyfile(result, pcb_path.with_suffix(result.suffix))
+            return [pcb_path.with_suffix(result.suffix) for result in rendered]
     project_name = pcb_path.stem
     pro_path = pcb_path.with_suffix(".kicad_pro")
     written: list[Path] = []

--- a/tests/test_drc_constraints_export.py
+++ b/tests/test_drc_constraints_export.py
@@ -866,3 +866,164 @@ def test_route_emits_sibling_kicad_pro(monkeypatch, tmp_path: Path):
     defaults = data["board"]["design_settings"]["defaults"]
     assert defaults["clearance_min"] == rules.min_clearance_mm
     assert defaults["track_min_width"] == rules.min_trace_width_mm
+
+
+@pytest.fixture
+def authored_route_source(tmp_path):
+    source = tmp_path / "source.kicad_pcb"
+    source.write_text("(kicad_pcb)")
+    source.with_suffix(".kicad_pro").write_text(
+        json.dumps(
+            {
+                "text_variables": {"KCT_PRESERVE_BOARD_RULES": "1"},
+                "board": {
+                    "design_settings": {
+                        "rules": {
+                            "min_clearance": 0.15,
+                            "min_track_width": 0.15,
+                            "min_via_hole": 0.1,
+                        }
+                    }
+                },
+                "net_settings": {
+                    "classes": [
+                        {"name": "Default", "clearance": 0.15},
+                        {"name": "HV", "clearance": 0.8},
+                    ],
+                    "netclass_assignments": {"VCC": "HV"},
+                },
+            }
+        )
+    )
+    source.with_suffix(".kicad_dru").write_text(
+        '(version 1)\n(rule "Custom width" (constraint track_width (min 0.2mm)))\n'
+    )
+    return source
+
+
+@pytest.mark.parametrize("subdir", ["", "fresh"])
+def test_renamed_route_preserves_source_rules(authored_route_source, subdir):
+    source = authored_route_source
+    before = {
+        suffix: source.with_suffix(suffix).read_bytes() for suffix in (".kicad_pro", ".kicad_dru")
+    }
+    output = source.parent / subdir / "renamed.kicad_pcb"
+    output.parent.mkdir(exist_ok=True)
+    rules = get_profile("jlcpcb").get_design_rules(layers=4)
+    write_drc_constraints(output, rules, manufacturer_id="jlcpcb", source_pcb_path=source)
+    data = json.loads(output.with_suffix(".kicad_pro").read_text())
+    assert data["text_variables"]["KCT_PRESERVE_BOARD_RULES"] == "1"
+    assert data["board"]["design_settings"]["rules"]["min_clearance"] == 0.15
+    assert data["board"]["design_settings"]["rules"]["min_via_hole"] == rules.min_via_drill_mm
+    assert data["net_settings"]["netclass_assignments"] == {"VCC": "HV"}
+    dru = output.with_suffix(".kicad_dru").read_text()
+    assert '"Custom width"' in dru and "(min 0.15mm)" in dru and "(min 0.8mm)" in dru
+    first = {suffix: output.with_suffix(suffix).read_bytes() for suffix in before}
+    write_drc_constraints(output, rules, manufacturer_id="jlcpcb", source_pcb_path=source)
+    assert first == {suffix: output.with_suffix(suffix).read_bytes() for suffix in before}
+    assert before == {suffix: source.with_suffix(suffix).read_bytes() for suffix in before}
+
+
+@pytest.mark.parametrize("suffix", [".kicad_pro", ".kicad_dru"])
+def test_renamed_route_conflicts_leave_both_sidecars_untouched(authored_route_source, suffix):
+    source = authored_route_source
+    output = source.with_name("renamed.kicad_pcb")
+    target = output.with_suffix(suffix)
+    target.write_text("{}" if suffix == ".kicad_pro" else "(version 1)\n# other rules\n")
+    before = target.read_bytes()
+    with pytest.raises(ValueError, match="conflict"):
+        write_drc_constraints(
+            output, get_profile("jlcpcb").get_design_rules(layers=4), source_pcb_path=source
+        )
+    assert target.read_bytes() == before
+    other = ".kicad_dru" if suffix == ".kicad_pro" else ".kicad_pro"
+    assert not output.with_suffix(other).exists()
+
+
+def test_post_route_conflict_blocks_even_quiet(authored_route_source, capsys, monkeypatch):
+    from kicad_tools.cli import route_cmd
+
+    output = authored_route_source.with_name("renamed.kicad_pcb")
+    output.with_suffix(".kicad_pro").write_text("{}")
+
+    def route_then_auto_fix(argv):
+        route_cmd.run_post_route_drc(
+            output, "jlcpcb", 4, quiet=True, source_pcb_path=authored_route_source
+        )
+        pytest.fail("constraint conflicts must abort before auto-fix can erase the failure")
+
+    monkeypatch.setattr(route_cmd, "_main_impl", route_then_auto_fix)
+    assert route_cmd.main([]) == 1
+    assert "conflict" in capsys.readouterr().err
+
+
+@pytest.mark.skipif(_kicad_cli() is None, reason="kicad-cli not installed")
+def test_renamed_native_drc_uses_authored_clearance(authored_route_source, tmp_path):
+    import shutil
+    import subprocess
+
+    source = authored_route_source
+    source.write_text("""(kicad_pcb (version 20240108) (generator pcbnew)
+      (general (thickness 1.6)) (paper "A4")
+      (layers (0 "F.Cu" signal) (31 "B.Cu" signal) (44 "Edge.Cuts" user))
+      (setup (pad_to_mask_clearance 0)) (net 0 "") (net 1 "A") (net 2 "B")
+      (gr_rect (start 0 0) (end 20 20) (stroke (width 0.1) (type default))
+        (fill none) (layer "Edge.Cuts"))
+      (segment (start 5 5) (end 10 5) (width 0.2) (layer "F.Cu") (net 1))
+      (segment (start 5 5.34) (end 10 5.34) (width 0.2) (layer "F.Cu") (net 2)))""")
+    output = tmp_path / "renamed.kicad_pcb"
+    shutil.copyfile(source, output)
+    rules = get_profile("jlcpcb").get_design_rules(layers=2)
+
+    def clearance_findings(board):
+        report = board.with_suffix(".json")
+        proc = subprocess.run(
+            [str(_kicad_cli()), "pcb", "drc", "--format", "json", "-o", str(report), str(board)],
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        assert proc.returncode == 0, proc.stderr
+        data = json.loads(report.read_text())
+        return [v for v in data["violations"] if v["type"] == "clearance"]
+
+    # At the ordinary factory minimum the exact same 0.14mm gap passes.
+    control = tmp_path / "factory.kicad_pcb"
+    shutil.copyfile(source, control)
+    write_drc_constraints(control, rules, manufacturer_id="jlcpcb")
+    assert clearance_findings(control) == []
+    write_drc_constraints(output, rules, manufacturer_id="jlcpcb", source_pcb_path=source)
+    findings = clearance_findings(output)
+    assert findings
+    assert any("0.1500" in v["description"] for v in findings), findings
+
+
+def test_renamed_source_alias_is_not_modified(authored_route_source):
+    source = authored_route_source
+    target = source.with_name("alias.kicad_pcb")
+    project = source.with_suffix(".kicad_pro")
+    before = project.read_bytes()
+    target.with_suffix(".kicad_pro").symlink_to(project)
+    with pytest.raises(ValueError, match="aliases source"):
+        write_drc_constraints(
+            target, get_profile("jlcpcb").get_design_rules(layers=4), source_pcb_path=source
+        )
+    assert project.read_bytes() == before
+
+
+def test_renamed_identical_authored_destination_is_accepted(authored_route_source):
+    import shutil
+
+    source = authored_route_source
+    target = source.with_name("copy.kicad_pcb")
+    for suffix in (".kicad_pro", ".kicad_dru"):
+        shutil.copyfile(source.with_suffix(suffix), target.with_suffix(suffix))
+    write_drc_constraints(
+        target, get_profile("jlcpcb").get_design_rules(layers=4), source_pcb_path=source
+    )
+    assert (
+        json.loads(target.with_suffix(".kicad_pro").read_text())["text_variables"][
+            "KCT_PRESERVE_BOARD_RULES"
+        ]
+        == "1"
+    )


### PR DESCRIPTION
## Summary

Routing to a renamed output previously lost the source project's preservation flag and authored constraints. The shared post-route gate now carries the original project and custom DRU into the destination before applying manufacturer floors, and stops on conflicting destination constraints.

## Changes

- Pass the original `args.pcb` through all four post-route DRC call sites, rather than an auto-pour or placement staging path.
- Render destination constraints in an isolated temporary directory using the existing preserve-and-merge implementation. Read the source only; preflight both destination files before replacing either.
- Accept destination files equal to the authored source or its merged result (JSON formatting is ignored). Reject differing authored content and aliases of the source. Where no source sidecar exists, retain the destination's existing merge behavior.
- Raise a dedicated propagation error that exits the route command with code 1, including quiet mode. This aborts before auto-fix or escalation success handling can erase the failure.
- Document conflict resolution and the post-route/`--skip-drc` boundary.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Fresh directory and renamed same-directory outputs retain authored constraints | Passed | Both output locations preserve the flag, 0.15mm clearance, named classes/assignments and custom DRU text |
| Manufacturer may tighten weaker minima | Passed | Authored 0.1mm via-hole minimum becomes the selected manufacturer minimum |
| Deterministic existing-destination behavior and repeatability | Passed | Identical authored destination accepted; repeated generated bytes unchanged; conflicting project/DRU rejected before either changes |
| Source remains unchanged | Passed | Source byte comparisons and source-alias rejection |
| Native DRC uses preserved 0.15mm threshold | Passed | KiCad 10.0.6 sees the same 0.14mm track gap pass the manufacturer-only control (0.127mm) and fail the renamed authored project with a reported 0.1500mm clearance rule |
| All post-route flows carry the original source | Passed | Reviewed wiring in layer escalation, rule relaxation, combined escalation and default routing; existing route auto-fix regression suite passes |

## Test Plan

TDD: yes — five source-relocation/conflict tests failed for missing propagation support before implementation, then passed. Additional native and alias controls were added during implementation.

- `uv run pytest tests/test_route_auto_fix.py tests/test_drc_constraints_export.py -q --no-cov`: **74 passed, 3 skipped** (native tests require explicit PATH in this session).
- With mounted KiCad on PATH, `pytest tests/test_drc_constraints_export.py -q --no-cov -k 'renamed or post_route_conflict or route_emits'`: **9 passed**, including the bounded native threshold comparison (30-second subprocess cap).
- Native executable: `/tmp/kicad-native-sweep-20260910T212252Z-2790-0e0161a0/KiCad/KiCad.app/Contents/MacOS/kicad-cli`, version 10.0.6.
- Ruff lint/format and `git diff --check`: passed.
- Cold focused mypy: project generator clean; route command retains **30 identical pre-existing errors** compared with base source through `--shadow-file`, no new signatures. No ledger/configuration changes.
- Rebased onto `5e3da0d3` after three unrelated site dependency merges. Tested source is unchanged by that rebase. Main-clean check passes against the sweep's pre-existing dirt baseline.

CI is pending. Independent main Type Check repair #5044 / PR #5045 remains outside this change. Native evidence exercises the actual constraint writer and KiCad on a minimal real board; it does not claim a full board09 reroute.

Closes #5032