### PR TITLE
fix(render): report missing component 3D models

### DIFF
--- a/src/kicad_tools/cli/render_cmd.py
+++ b/src/kicad_tools/cli/render_cmd.py
@@ -20,6 +20,12 @@ logic:
 The routed PCB (``*_routed.kicad_pcb``) is preferred; the command falls back
 to the unrouted ``*.kicad_pcb`` when no routed artifact exists.
 
+Before 3D rendering, referenced model files are checked using native configured
+paths, the render environment, and the PCB directory. Unresolved models identify
+their component and path in text diagnostics and JSON ``model_check``. Images
+are retained, but incomplete model coverage reports ``partial`` and exits
+nonzero. ``--no-3d`` skips this check. File availability does not validate geometry.
+
 This command only writes image files — it makes no assumptions about hosting
 or any website. Generated renders are git-ignored build artifacts.
 
@@ -52,6 +58,7 @@ from kicad_tools.cli.export_cmd import _find_pcb_for_export
 from kicad_tools.cli.runner import (
     find_kicad_cli,
     get_kicad_version,
+    inspect_pcb_models,
     run_pcb_export_svg,
     run_pcb_render,
 )
@@ -154,6 +161,7 @@ def _render_pcb(
         "status": "skipped",
         "outputs": {},
         "errors": [],
+        "model_check": {"status": "not_run", "checked_models": 0, "unresolved_models": []},
     }
 
     renders_dir.mkdir(parents=True, exist_ok=True)
@@ -176,6 +184,15 @@ def _render_pcb(
 
     # --- 3D ray-traced renders ---
     if do_3d:
+        try:
+            result["model_check"] = inspect_pcb_models(pcb_path, kicad_cli)
+            for missing in result["model_check"]["unresolved_models"]:
+                errors.append(
+                    f"3D model {missing['reference']}: {missing['reason']}: {missing['model']}"
+                )
+        except (OSError, ValueError, RuntimeError) as exc:
+            result["model_check"]["status"] = "failed"
+            errors.append(f"3D model inspection failed: {exc}")
         renders = [
             ("3d-front", "front"),
             ("3d-back", "back"),
@@ -192,7 +209,7 @@ def _render_pcb(
     result["errors"] = errors
 
     expected = 2 + (2 if do_3d else 0)
-    if len(written) == expected:
+    if len(written) == expected and not errors:
         result["status"] = "ok"
     elif written:
         result["status"] = "partial"
@@ -302,7 +319,9 @@ def run_render(args: argparse.Namespace) -> int:
         )
         if args.format == "json":
             print(json.dumps({"boards": [result]}, indent=2))
-        return 1 if result["status"] == "error" else 0
+        return (
+            1 if result["status"] == "error" or result["model_check"]["status"] == "failed" else 0
+        )
 
     boards = _discover_boards(root)
     if not boards:
@@ -317,9 +336,12 @@ def run_render(args: argparse.Namespace) -> int:
     if args.format == "json":
         print(json.dumps({"boards": results}, indent=2))
 
-    # Exit non-zero only if a board with a PCB failed every render. Boards
+    # Incomplete model coverage also fails, even if images were produced. Boards
     # skipped for lack of a PCB are a non-fatal condition (exit 0).
-    has_error = any(r["status"] == "error" for r in results)
+    has_error = any(
+        r["status"] == "error" or r.get("model_check", {}).get("status") == "failed"
+        for r in results
+    )
     return 1 if has_error else 0
 
 

--- a/src/kicad_tools/cli/runner.py
+++ b/src/kicad_tools/cli/runner.py
@@ -4,9 +4,12 @@ Provides functions to locate and run kicad-cli commands for
 ERC validation, DRC validation, netlist export, and more.
 """
 
+import json
 import os
+import re
 import shutil
 import subprocess
+import sys
 import tempfile
 from collections.abc import Callable
 from dataclasses import dataclass
@@ -1785,6 +1788,101 @@ def _render_env(kicad_cli: Path | None) -> dict[str, str] | None:
             env.setdefault(var, str(model_dir))
     env.setdefault(DEFAULT_CACHE_ENV_VAR, str(lcsc_dir))
     return env
+
+
+def _configured_model_variables(kicad_cli: Path | None) -> dict[str, str]:
+    """Read native Configure Paths values without changing KiCad settings.
+
+    KiCad stores these under environment.vars in the active minor version's
+    kicad_common.json. Process variables take precedence at the call site.
+    """
+    version = get_kicad_version(kicad_cli)
+    match = re.search(r"(\d+)\.(\d+)", version or "")
+    if match is None:
+        return {}
+    if override := os.environ.get("KICAD_CONFIG_HOME"):
+        root = Path(override)
+    elif sys.platform == "darwin":
+        root = Path.home() / "Library/Preferences/kicad"
+    elif sys.platform == "win32":
+        root = Path(os.environ.get("APPDATA", str(Path.home() / "AppData/Roaming"))) / "kicad"
+    else:
+        root = Path(os.environ.get("XDG_CONFIG_HOME", str(Path.home() / ".config"))) / "kicad"
+    config = root / f"{match[1]}.{match[2]}" / "kicad_common.json"
+    try:
+        data = json.loads(config.read_text())
+    except (OSError, ValueError):
+        return {}
+    if not isinstance(data, dict) or not isinstance(data.get("environment"), dict):
+        return {}
+    variables = data["environment"].get("vars", {})
+    if not isinstance(variables, dict):
+        return {}
+    return {key: value for key, value in variables.items() if isinstance(value, str)}
+
+
+def inspect_pcb_models(pcb_path: Path, kicad_cli: Path | None = None) -> dict:
+    """Inspect enabled model references with the same environment as rendering.
+
+    This verifies file resolution only, not model geometry or electrical rules.
+    It never rewrites the PCB, substitutes models, or fetches missing resources.
+    """
+    from kicad_tools.sexp import parse_file
+
+    doc = parse_file(pcb_path)
+    if doc.name != "kicad_pcb":
+        raise ValueError("Expected kicad_pcb root for model inspection")
+    env = _configured_model_variables(kicad_cli)
+    env.update(_render_env(kicad_cli) or os.environ)
+    env["KIPRJMOD"] = str(pcb_path.resolve().parent)
+    variable = re.compile(r"\$\{([^}]+)\}|\$\(([^)]+)\)")
+    unresolved: list[dict] = []
+    checked = 0
+    for footprint in doc.children:
+        if not _is_footprint_tag(footprint.name):
+            continue
+        reference = _get_fp_reference(footprint) or "<unknown>"
+        for model in footprint.find_all("model"):
+            hidden = model.get("hide")
+            if hidden is not None and hidden.get_first_atom() != "no":
+                continue
+            checked += 1
+            raw = str(model.get_first_atom() or "")
+            expanded = raw
+            # Bounded expansion permits nested configured variables without
+            # making cyclic/unknown variables look like resolved file paths.
+            for _ in range(8):
+                updated = variable.sub(
+                    lambda match: env.get(match.group(1) or match.group(2), match.group(0)),
+                    expanded,
+                )
+                if updated == expanded:
+                    break
+                expanded = updated
+            path = Path(expanded).expanduser()
+            if not path.is_absolute():
+                path = pcb_path.resolve().parent / path
+            reason = None
+            if not raw:
+                reason = "empty model path"
+            elif variable.search(expanded):
+                reason = "unresolved path variable"
+            elif not path.is_file():
+                reason = "model file not found"
+            if reason:
+                unresolved.append(
+                    {
+                        "reference": reference,
+                        "model": raw,
+                        "resolved_path": str(path) if not variable.search(expanded) else None,
+                        "reason": reason,
+                    }
+                )
+    return {
+        "status": "failed" if unresolved else "passed",
+        "checked_models": checked,
+        "unresolved_models": unresolved,
+    }
 
 
 def run_pcb_render(

--- a/tests/test_render_cmd.py
+++ b/tests/test_render_cmd.py
@@ -580,3 +580,119 @@ class TestEdgeCases:
         board = _make_board(tmp_path, "01-vd", "vd.kicad_pcb")
         rc = render_main([str(board), "--no-3d"])
         assert rc == 0
+
+
+class TestMissingModelDiagnostics:
+    @pytest.mark.parametrize("directory_mode", [False, True])
+    def test_missing_bodies_are_partial_even_when_native_render_succeeds(
+        self, tmp_path, fake_kicad, capsys, directory_mode
+    ):
+        board = _make_board(tmp_path, "05-board", "board.kicad_pcb")
+        pcb = board / "output/board.kicad_pcb"
+        source = """(kicad_pcb
+          (footprint "TSSOP" (property "Reference" "U2")
+            (model "missing-tssop.step"))
+          (module "HVSSOP" (fp_text reference "U3")
+            (model "missing-hvssop.step")))"""
+        pcb.write_text(source)
+        rc = render_main([str(board if directory_mode else pcb), "--format", "json"])
+        captured = capsys.readouterr()
+        result = json.loads(captured.out)["boards"][0]
+        assert rc == 1
+        assert result["status"] == "partial"
+        assert len(result["outputs"]) == 4
+        check = result["model_check"]
+        assert check["status"] == "failed"
+        assert check["checked_models"] == 2
+        assert [m["reference"] for m in check["unresolved_models"]] == ["U2", "U3"]
+        assert all(m["reason"] == "model file not found" for m in check["unresolved_models"])
+        assert "missing-tssop.step" in result["errors"][0]
+        assert pcb.read_text() == source
+        assert captured.err == ""
+
+    def test_text_names_component_and_model(self, tmp_path, fake_kicad, capsys):
+        pcb = tmp_path / "board.kicad_pcb"
+        pcb.write_text(
+            '(kicad_pcb (footprint "x" (property "Reference" "U2") (model "absent.step")))'
+        )
+        assert render_main([str(pcb)]) == 1
+        assert "3D model U2: model file not found: absent.step" in capsys.readouterr().err
+
+    def test_no_3d_does_not_inspect_models(self, tmp_path, fake_kicad, monkeypatch, capsys):
+        def unexpected(*args):
+            raise AssertionError("2D must not inspect models")
+
+        monkeypatch.setattr(render_cmd, "inspect_pcb_models", unexpected)
+        pcb = tmp_path / "board.kicad_pcb"
+        pcb.write_text('(kicad_pcb (footprint "x" (model "absent.step")))')
+        assert render_main([str(pcb), "--no-3d", "--format", "json"]) == 0
+        result = json.loads(capsys.readouterr().out)["boards"][0]
+        assert result["status"] == "ok"
+        assert result["model_check"]["status"] == "not_run"
+        assert len(result["outputs"]) == 2
+        assert fake_kicad["render"] == []
+
+    def test_paths_use_render_environment_and_project_directory(self, tmp_path, monkeypatch):
+        from kicad_tools.cli import runner
+
+        model_dir = tmp_path / "library"
+        model_dir.mkdir()
+        (model_dir / "part.step").touch()
+        (tmp_path / "local.step").touch()
+        monkeypatch.setenv("KICAD9_3DMODEL_DIR", str(model_dir))
+        monkeypatch.setenv("CUSTOM_MODELS", "${KICAD9_3DMODEL_DIR}")
+        pcb = tmp_path / "board.kicad_pcb"
+        pcb.write_text("""(kicad_pcb (footprint "x" (property "Reference" "U1")
+          (model "${KICAD9_3DMODEL_DIR}/part.step")
+          (model "$(CUSTOM_MODELS)/part.step")
+          (model "${KIPRJMOD}/local.step")
+          (model "local.step" (hide no))
+          (model "missing.step" (hide yes))))""")
+        assert runner.inspect_pcb_models(pcb) == {
+            "status": "passed",
+            "checked_models": 4,
+            "unresolved_models": [],
+        }
+
+    def test_unknown_variable_and_directory_are_not_models(self, tmp_path, monkeypatch):
+        from kicad_tools.cli import runner
+
+        monkeypatch.delenv("NONEXISTENT_MODEL_ROOT", raising=False)
+        pcb = tmp_path / "board.kicad_pcb"
+        pcb.write_text("""(kicad_pcb (footprint "x" (property "Reference" "U1")
+          (model "${NONEXISTENT_MODEL_ROOT}/part.step") (model ".")))""")
+        missing = runner.inspect_pcb_models(pcb)["unresolved_models"]
+        assert missing[0]["reason"] == "unresolved path variable"
+        assert missing[0]["resolved_path"] is None
+        assert missing[1]["reason"] == "model file not found"
+
+    def test_inspection_failure_cannot_report_complete(self, tmp_path, fake_kicad, capsys):
+        pcb = tmp_path / "board.kicad_pcb"
+        pcb.write_text("(not_a_board)")
+        assert render_main([str(pcb), "--format", "json"]) == 1
+        result = json.loads(capsys.readouterr().out)["boards"][0]
+        assert result["status"] == "partial"
+        assert result["model_check"]["status"] == "failed"
+        assert "inspection failed" in result["errors"][0]
+
+    def test_native_configured_paths_and_environment_precedence(self, tmp_path, monkeypatch):
+        from kicad_tools.cli import runner
+
+        config = tmp_path / "config/10.0"
+        config.mkdir(parents=True)
+        models = tmp_path / "models"
+        models.mkdir()
+        (models / "part.step").touch()
+        (config / "kicad_common.json").write_text(
+            json.dumps({"environment": {"vars": {"PRIVATE_MODELS": str(models)}}})
+        )
+        monkeypatch.setenv("KICAD_CONFIG_HOME", str(config.parent))
+        monkeypatch.delenv("PRIVATE_MODELS", raising=False)
+        monkeypatch.setattr(runner, "get_kicad_version", lambda *a: "10.0.6")
+        pcb = tmp_path / "board.kicad_pcb"
+        pcb.write_text('(kicad_pcb (footprint "x" (model "${PRIVATE_MODELS}/part.step")))')
+        assert runner.inspect_pcb_models(pcb)["status"] == "passed"
+        monkeypatch.setenv("PRIVATE_MODELS", str(tmp_path / "absent"))
+        missing = runner.inspect_pcb_models(pcb)["unresolved_models"]
+        assert missing[0]["reason"] == "model file not found"
+        assert missing[0]["resolved_path"] == str(tmp_path / "absent/part.step")


### PR DESCRIPTION
Closes #5008.

When KiCad produces images despite missing component models, `kct render` now reports partial output and exits nonzero. Text diagnostics name each affected component and model path; JSON adds `model_check` with checked count, unresolved references, attempted paths, and reasons. Generated images remain available. `--no-3d` bypasses model inspection.

The read-only preflight reuses the render environment and footprint-reference extraction, resolves project-relative paths and native Configure Paths variables, and ignores explicitly hidden models. Process environment takes precedence over configured values. No PCB edits, model substitutions, downloads, or electrical/manufacturing rule changes. File existence does not certify model geometry.

Validation: 123 focused render/export/net-restoration tests pass; Ruff passes. KiCad 10.0.6 packaged STEP resolution control passes, and an absent STEP reports the expected U2 diagnostic. Tests cover direct and directory JSON, text errors, unchanged PCB bytes, configured variables and environment precedence, local paths, hidden models, and --no-3d. Native ray-traced rendering was not repeated. Seven scoped mypy errors are pre-existing in runner.py, reproduced from the unchanged baseline; shared CI repair #5044 / PR #5045 is still pending.

Configuration layout follows [KiCad documentation](https://docs.kicad.org/9.0/en/kicad/kicad.html): version-specific kicad_common.json beneath the platform configuration root or KICAD_CONFIG_HOME.