### PR TITLE
refactor(pcb): share legacy-aware footprint traversal

### DIFF
--- a/src/kicad_tools/drc/repair_clearance.py
+++ b/src/kicad_tools/drc/repair_clearance.py
@@ -25,7 +25,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import TYPE_CHECKING
 
-from ..schema.pcb import _is_footprint_tag
+from ..schema.pcb import _find_all_footprints
 from ..sexp import SExp, parse_file
 from .net_compat import resolve_net_atom
 from .report import DRCReport
@@ -33,19 +33,6 @@ from .violation import DRCViolation, ViolationType, _extract_component_refs
 
 if TYPE_CHECKING:
     from .local_rerouter import LocalRerouter
-
-
-def _find_all_footprints(doc: SExp) -> list[SExp]:
-    """Return every footprint node in *doc*, in document order.
-
-    Matches both the modern ``(footprint ...)`` spelling and the legacy
-    pre-KiCad-6 ``(module ...)`` spelling (issue #4891).  Search semantics
-    match :meth:`SExp.find_all` -- descendants of the root, not the root
-    itself -- so this is a drop-in replacement for ``doc.find_all("footprint")``.
-    """
-    return [
-        node for child in doc.children for node in child.iter_all() if _is_footprint_tag(node.name)
-    ]
 
 
 @dataclass

--- a/src/kicad_tools/drc/repair_silkscreen.py
+++ b/src/kicad_tools/drc/repair_silkscreen.py
@@ -19,7 +19,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 
 from kicad_tools.core.sexp_file import save_pcb
-from kicad_tools.schema.pcb import _is_footprint_tag
+from kicad_tools.schema.pcb import _find_all_footprints
 from kicad_tools.sexp.parser import SExp, parse_file
 
 # Silkscreen layer names recognised by KiCad (pre-8.0 and 8.0+).
@@ -30,19 +30,6 @@ FP_GRAPHIC_TYPES = ("fp_line", "fp_rect", "fp_circle", "fp_arc")
 
 # Graphic element types at board level.
 GR_GRAPHIC_TYPES = ("gr_line", "gr_rect", "gr_circle", "gr_arc")
-
-
-def _find_all_footprints(doc: SExp) -> list[SExp]:
-    """Return every footprint node in *doc*, in document order.
-
-    Matches both the modern ``(footprint ...)`` spelling and the legacy
-    pre-KiCad-6 ``(module ...)`` spelling (issue #4891).  Search semantics
-    match :meth:`SExp.find_all` -- descendants of the root, not the root
-    itself -- so this is a drop-in replacement for ``doc.find_all("footprint")``.
-    """
-    return [
-        node for child in doc.children for node in child.iter_all() if _is_footprint_tag(node.name)
-    ]
 
 
 @dataclass

--- a/src/kicad_tools/lvs/board_lvs.py
+++ b/src/kicad_tools/lvs/board_lvs.py
@@ -37,22 +37,8 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import TypeGuard
 
-from kicad_tools.schema.pcb import _is_footprint_tag
+from kicad_tools.schema.pcb import _find_all_footprints
 from kicad_tools.sexp import SExp, parse_file
-
-
-def _find_all_footprints(doc: SExp) -> list[SExp]:
-    """Return every footprint node in *doc*, in document order.
-
-    Matches both the modern ``(footprint ...)`` spelling and the legacy
-    pre-KiCad-6 ``(module ...)`` spelling (issue #4891).  Search semantics
-    match :meth:`SExp.find_all` -- descendants of the root, not the root
-    itself -- so this is a drop-in replacement for ``doc.find_all("footprint")``.
-    """
-    return [
-        node for child in doc.children for node in child.iter_all() if _is_footprint_tag(node.name)
-    ]
-
 
 # An auto-generated ("placeholder") net name: the synthetic name a netlister
 # invents for a connected component that carries no label or power symbol.

--- a/src/kicad_tools/schema/pcb.py
+++ b/src/kicad_tools/schema/pcb.py
@@ -55,6 +55,19 @@ def _is_footprint_tag(tag: str | None) -> bool:
     return tag in FOOTPRINT_TAGS
 
 
+def _find_all_footprints(doc: SExp) -> list[SExp]:
+    """Return every footprint node in *doc*, in document order.
+
+    Matches both the modern ``(footprint ...)`` spelling and the legacy
+    pre-KiCad-6 ``(module ...)`` spelling (issue #4891).  Search semantics
+    match :meth:`SExp.find_all` -- descendants of the root, not the root
+    itself -- so this is a drop-in replacement for ``doc.find_all("footprint")``.
+    """
+    return [
+        node for child in doc.children for node in child.iter_all() if _is_footprint_tag(node.name)
+    ]
+
+
 # Default regex for detecting power/ground net names.
 # Matches names like GND, +3V3, +5V, VCC, VDD, VBUS, or names starting with '+'.
 _DEFAULT_POWER_NET_PATTERN = re.compile(

--- a/src/kicad_tools/zones/fill_clearance.py
+++ b/src/kicad_tools/zones/fill_clearance.py
@@ -36,21 +36,8 @@ from typing import Any, Protocol
 
 from kicad_tools._shapely import require_shapely
 from kicad_tools.core.layers import via_spans_layer
-from kicad_tools.schema.pcb import _is_footprint_tag
+from kicad_tools.schema.pcb import _find_all_footprints
 from kicad_tools.sexp import SExp
-
-
-def _find_all_footprints(doc: SExp) -> list[SExp]:
-    """Return every footprint node in *doc*, in document order.
-
-    Matches both the modern ``(footprint ...)`` spelling and the legacy
-    pre-KiCad-6 ``(module ...)`` spelling (issue #4891).  Search semantics
-    match :meth:`SExp.find_all` -- descendants of the root, not the root
-    itself -- so this is a drop-in replacement for ``doc.find_all("footprint")``.
-    """
-    return [
-        node for child in doc.children for node in child.iter_all() if _is_footprint_tag(node.name)
-    ]
 
 
 class _Geometry(Protocol):


### PR DESCRIPTION
Closes #4913.

Four DRC, LVS, and zone modules duplicated the same legacy-aware footprint traversal. Move the unchanged helper beside `_is_footprint_tag` in `schema.pcb` and import it at each existing call site. Both `footprint` and legacy `module` descendants retain document order and root-excluding semantics.

Validation: 191 existing repair, zone-fill, and board-LVS tests pass, including the legacy-module regressions. Ruff and `git diff --check` pass. No behavioral change or new test scaffolding; branch rebased against current main before submission.