### PR TITLE
fix(stitch): expose DRC results and optional strict validation gate

### DIFF
--- a/docs/reference/machine-output.md
+++ b/docs/reference/machine-output.md
@@ -342,10 +342,21 @@ orchestrators — the leaves that drive many other commands to completion:
 |---|---|
 | `build` | `{"command": "build", "spec", "project_dir", "output_dir", "mfr", "step", "dry_run", "force", "schematic", "pcb", "routed_pcb", "manufacturing_output", "steps": [{step, success, message, output_file, elapsed_s}], "counts": {total, succeeded, failed}, "wall_time_s", "exit_code", "success"}` |
 | `pipeline` | `{"command": "pipeline", "input", "pcb", "project", "schematic", "mfr", "layers", "layer_count", "step", "dry_run", "force", "best_effort", "steps": [{step, success, skipped, warning, message}], "counts": {total, succeeded, skipped, warnings}, "commit": {requested, created}, "exit_code", "success"}` |
-| `stitch` | `{"command": "stitch", "pcb", "output", "mode": "stitch"\|"blanket"\|"thermal", "target_nets", "nets_auto_detected", "manufacturer", "via_size_mm", "drill_mm", "detected_layers", "stackup_inferred_nets", "fallback_nets", "strict_model_error", "pads_found", "already_connected", "vias_added": [...], "vias_added_count", "micro_vias_placed", "traces_added": {total, straight, dogleg, extended_escape}, "via_in_pad_filtered", "hole_to_hole_rejected", "connectivity_fallback": [...], "needs_routed_fanout": [...], "pads_skipped": [...], "obstacle_breakdown", "dry_run", "saved", "drc": {requested, ran}, "exit_code", "success"}` |
+| `stitch` | `{"command": "stitch", "pcb", "output", "mode": "stitch"\|"blanket"\|"thermal", "target_nets", "nets_auto_detected", "manufacturer", "via_size_mm", "drill_mm", "detected_layers", "stackup_inferred_nets", "fallback_nets", "strict_model_error", "pads_found", "already_connected", "vias_added": [...], "vias_added_count", "micro_vias_placed", "traces_added": {total, straight, dogleg, extended_escape}, "via_in_pad_filtered", "hole_to_hole_rejected", "connectivity_fallback": [...], "needs_routed_fanout": [...], "pads_skipped": [...], "obstacle_breakdown", "dry_run", "saved", "drc": {requested, strict, ran, status, passed, error_count, warning_count, unconnected_item_count, reason}, "success_scope": "geometry", "exit_code", "success"}` |
 
 Three conventions this batch adds or reinforces:
 
+- **Stitch geometry and native DRC have separate verdicts.** `success` retains
+  its geometry meaning (vias placed or pads already connected), explicitly
+  identified by `success_scope: "geometry"`. `--drc` remains diagnostic and
+  does not change the geometry exit code. `--drc-strict` implies `--drc` and
+  exits nonzero unless native DRC has zero errors, warnings and unconnected
+  items. Both flags check unchanged boards. Dry runs skip DRC and cannot pass
+  the strict gate. The JSON `exit_code` always matches the process exit code.
+  `drc.ran` means execution and report parsing succeeded; `status` is `passed`,
+  `failed` (findings), or `not_run`. `passed` and all three counts are null when
+  no report was parsed, with `reason` explaining absence, execution/parsing
+  failure or dry-run skipping. A passed DRC is not full manufacturing signoff.
 - **The document is the complete ledger, not the prose's excerpt.** `stitch`'s
   text summary caps via lists at 10 entries and skipped-pad lists at 5 (`...
   (N more)`); the JSON document carries every entry, because a machine caller

--- a/src/kicad_tools/cli/stitch_cmd.py
+++ b/src/kicad_tools/cli/stitch_cmd.py
@@ -14,18 +14,23 @@ Usage:
     kicad-pcb-stitch board.kicad_pcb --net GND --dry-run
     kicad-pcb-stitch board.kicad_pcb --net GND --via-size 0.45 --drill 0.2
 
-    # Stitch and run DRC (fills zones automatically via kicad-cli)
+    # Stitch and report native DRC findings (diagnostic; geometry exit status)
     kicad-pcb-stitch board.kicad_pcb --drc
 
 Exit Codes:
-    0 - Success
-    1 - Error or no work to do
+    0 - Geometry success, and strict DRC passed if requested
+    1 - Error, no work to do, or strict DRC did not pass
+
+--drc-strict implies --drc and gates on zero errors, warnings and unconnected
+items. Both flags check unchanged boards too. Dry runs skip DRC, so a strict
+dry run exits nonzero. JSON success describes geometry only; exit_code also
+includes the strict gate. Native DRC is not a complete manufacturing signoff.
 
 Machine output (``--format json``, issue #4674): one document describing the
 run -- the resolved input/output paths, the resolved via geometry, and the
 full (untruncated) per-pad ledger of placed vias, skipped pads, connectivity
 fallbacks and pads needing a routed fanout -- or ``{"error": ..., "success":
-false}`` on failure.  Exit codes are unchanged.  See
+false}`` on failure. See
 ``docs/reference/machine-output.md``.
 """
 
@@ -5594,15 +5599,24 @@ def _carve_foreign_copper_after_stitch(pcb_path: Path) -> None:
         )
 
 
-def run_post_stitch_drc(pcb_path: Path) -> int:
+def _drc_not_run(reason: str) -> dict:
+    return {
+        "ran": False,
+        "status": "not_run",
+        "passed": None,
+        "error_count": None,
+        "warning_count": None,
+        "unconnected_item_count": None,
+        "reason": reason,
+    }
+
+
+def run_post_stitch_drc(pcb_path: Path) -> dict:
     """Run DRC on the PCB after stitching and display summary.
 
-    kicad-cli pcb drc automatically fills zones before checking,
-    so this handles both zone fill and DRC validation in one step.
-
-    Returns:
-        0 if DRC ran successfully (regardless of violations),
-        1 if DRC could not be run.
+    ``ran`` means a native report was successfully parsed, independently of
+    findings. ``passed`` requires zero errors, warnings and unconnected items.
+    Unavailable/failed checks have null counts, never invented zero counts.
     """
     from .runner import find_kicad_cli, run_drc
 
@@ -5620,24 +5634,39 @@ def run_post_stitch_drc(pcb_path: Path) -> int:
             f"\nRun DRC manually: kicad-cli pcb drc {pcb_path}",
             file=sys.stderr,
         )
-        return 1
+        return _drc_not_run("kicad-cli not found")
 
-    print(f"\nRunning DRC on {pcb_path.name} (zones will be filled automatically)...")
+    print(f"\nRunning DRC on {pcb_path.name}...")
 
     result = run_drc(pcb_path, format="json", kicad_cli=kicad_cli)
 
-    if not result.success:
+    if not result.success or result.return_code != 0:
         print(f"\nDRC failed to run: {result.stderr}", file=sys.stderr)
-        return 1
+        if result.output_path:
+            result.output_path.unlink(missing_ok=True)
+        return _drc_not_run(result.stderr or "DRC subprocess failed")
 
-    # Parse the report
-    from ..drc import DRCReport
+    # The subprocess was asked for JSON. Do not let auto-detection interpret
+    # an empty/error text response as a clean text-format report.
+    import json
+
+    from ..drc.report import parse_json_report
 
     try:
-        report = DRCReport.load(result.output_path)
+        if result.output_path is None:
+            raise ValueError("DRC produced no report")
+        content = result.output_path.read_text()
+        data = json.loads(content)
+        if not isinstance(data, dict) or any(
+            not isinstance(data.get(key), list) for key in ("violations", "unconnected_items")
+        ):
+            raise ValueError(
+                "Native DRC report must include violations and unconnected_items arrays"
+            )
+        report = parse_json_report(content, str(result.output_path))
     except Exception as e:
         print(f"\nError parsing DRC report: {e}", file=sys.stderr)
-        return 1
+        return _drc_not_run(f"Error parsing DRC report: {e}")
     finally:
         # Clean up temp file
         if result.output_path:
@@ -5646,6 +5675,8 @@ def run_post_stitch_drc(pcb_path: Path) -> int:
     # Display summary
     error_count = report.error_count
     warning_count = report.warning_count
+    unconnected_count = report.unconnected_item_count
+    passed = error_count == warning_count == unconnected_count == 0
 
     print(f"\n{'=' * 60}")
     print("POST-STITCH DRC RESULTS")
@@ -5653,7 +5684,9 @@ def run_post_stitch_drc(pcb_path: Path) -> int:
     print(f"  Errors:   {error_count}")
     print(f"  Warnings: {warning_count}")
 
-    if error_count == 0 and warning_count == 0:
+    print(f"  Unconnected items: {unconnected_count}")
+
+    if passed:
         print("\nDRC PASSED - No violations found")
     else:
         # Group by type
@@ -5679,14 +5712,19 @@ def run_post_stitch_drc(pcb_path: Path) -> int:
                 print(f"  ... and {error_count - 10} more errors")
 
         print(f"\n{'=' * 60}")
-        if error_count > 0:
-            print("DRC FAILED - Fix errors before manufacturing")
-        else:
-            print("DRC PASSED with warnings")
+        print("DRC FAILED - Findings remain (including warnings or unconnected items)")
 
         print(f"\nFor detailed results: kicad-drc {pcb_path}")
 
-    return 0
+    return {
+        "ran": True,
+        "status": "passed" if passed else "failed",
+        "passed": passed,
+        "error_count": error_count,
+        "warning_count": warning_count,
+        "unconnected_item_count": unconnected_count,
+        "reason": None,
+    }
 
 
 def output_result(
@@ -5894,7 +5932,8 @@ def result_document(
     manufacturer: dict | None,
     dry_run: bool,
     drc_requested: bool,
-    drc_ran: bool,
+    drc: dict,
+    drc_strict: bool,
 ) -> dict:
     """Build the ``--format json`` document for one stitch run (issue #4674).
 
@@ -5965,18 +6004,16 @@ def result_document(
         # A producer says whether it produced (batch-5 convention): vias are
         # only on disk when the run was not a dry run AND placed something.
         "saved": bool(result.vias_added) and not dry_run,
-        # `--drc` is honoured only for a non-dry run that actually placed
-        # copper, and kicad-cli may be absent, so "requested" and "ran" are
-        # reported separately rather than collapsed into one boolean.
-        "drc": {"requested": drc_requested, "ran": drc_ran},
+        "drc": {"requested": drc_requested, "strict": drc_strict, **drc},
+        "success_scope": "geometry",
     }
     # Parity with the other two orchestrators (`build`, `pipeline`): the
     # document carries the process exit code so a machine caller reading a
     # captured document never has to correlate it with a separate `$?`.
-    # The caller's verdict is exactly this predicate -- vias placed, or the
-    # pads were already connected.
+    # Success remains the geometry predicate; the optional strict gate also
+    # participates in the process exit code.
     success = bool(result.vias_added) or bool(result.already_connected)
-    document["exit_code"] = 0 if success else 1
+    document["exit_code"] = 0 if success and (not drc_strict or drc["passed"] is True) else 1
     document["success"] = success
     return document
 
@@ -6150,7 +6187,12 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument(
         "--drc",
         action="store_true",
-        help="Run DRC after stitching (fills zones automatically via kicad-cli)",
+        help="Report native DRC after stitching, including unchanged boards (diagnostic only)",
+    )
+    parser.add_argument(
+        "--drc-strict",
+        action="store_true",
+        help="Imply --drc; exit nonzero on errors, warnings, unconnected items or unavailable check",
     )
     parser.add_argument(
         "--mfr",
@@ -6178,6 +6220,7 @@ def main(argv: list[str] | None = None) -> int:
     add_format_flag(parser)
 
     args = parser.parse_args(argv)
+    args.drc = args.drc or args.drc_strict
     as_json = getattr(args, "format", FORMAT_TEXT) == FORMAT_JSON
 
     # JSON mode owns stdout: the stitch engine, the post-stitch carve and the
@@ -6355,10 +6398,11 @@ def _run_main(args: argparse.Namespace, as_json: bool) -> tuple[int, dict | None
         if not args.dry_run and result.vias_added:
             _carve_foreign_copper_after_stitch(pcb_path)
 
-        # Run DRC if requested (and not dry run, and vias were actually added)
-        drc_ran = False
-        if args.drc and not args.dry_run and result.vias_added:
-            drc_ran = run_post_stitch_drc(pcb_path) == 0
+        # Explicit checks also validate unchanged boards; dry runs never validate
+        # hypothetical geometry and therefore cannot pass the strict gate.
+        drc = _drc_not_run("dry run" if args.drc and args.dry_run else "not requested")
+        if args.drc and not args.dry_run:
+            drc = run_post_stitch_drc(pcb_path)
 
         document = (
             result_document(
@@ -6372,15 +6416,16 @@ def _run_main(args: argparse.Namespace, as_json: bool) -> tuple[int, dict | None
                 manufacturer=manufacturer,
                 dry_run=args.dry_run,
                 drc_requested=bool(args.drc),
-                drc_ran=drc_ran,
+                drc=drc,
+                drc_strict=args.drc_strict,
             )
             if as_json
             else None
         )
 
-        if result.vias_added:
-            return 0, document
-        return (0 if result.already_connected else 1), document
+        geometry_success = bool(result.vias_added) or bool(result.already_connected)
+        gate_passed = not args.drc_strict or drc["passed"] is True
+        return (0 if geometry_success and gate_passed else 1), document
 
     except Exception as e:
         return fail(str(e))

--- a/tests/test_stitch_cmd.py
+++ b/tests/test_stitch_cmd.py
@@ -2924,7 +2924,7 @@ class TestPostStitchDRC:
         from unittest.mock import patch
 
         # Mock find_kicad_cli to return None so DRC is skipped gracefully
-        with patch("kicad_tools.cli.stitch_cmd.run_post_stitch_drc", return_value=0):
+        with patch("kicad_tools.cli.stitch_cmd.run_post_stitch_drc", return_value={"passed": True}):
             exit_code = main([str(stitch_test_pcb), "--net", "GND", "--drc"])
 
         assert exit_code == 0
@@ -2940,7 +2940,7 @@ class TestPostStitchDRC:
         assert "Run DRC to verify" in captured.out
 
     def test_run_post_stitch_drc_no_kicad_cli(self, tmp_path, capsys):
-        """run_post_stitch_drc should warn and return 1 when kicad-cli is not found."""
+        """run_post_stitch_drc should report not_run when kicad-cli is not found."""
         from unittest.mock import patch
 
         pcb_path = tmp_path / "test.kicad_pcb"
@@ -2949,7 +2949,8 @@ class TestPostStitchDRC:
         with patch("kicad_tools.cli.runner.find_kicad_cli", return_value=None):
             result = run_post_stitch_drc(pcb_path)
 
-        assert result == 1
+        assert result["ran"] is False
+        assert result["passed"] is None
         captured = capsys.readouterr()
         assert "kicad-cli not found" in captured.err
 
@@ -2999,7 +3000,7 @@ class TestPostStitchDRC:
         ):
             result = run_post_stitch_drc(pcb_path)
 
-        assert result == 0
+        assert result["ran"] is True
         captured = capsys.readouterr()
         assert "POST-STITCH DRC RESULTS" in captured.out
 
@@ -3048,7 +3049,8 @@ class TestPostStitchDRC:
         ):
             result = run_post_stitch_drc(pcb_path)
 
-        assert result == 0  # DRC ran successfully, even though there are errors
+        assert result["ran"] is True
+        assert result["passed"] is False
         captured = capsys.readouterr()
         assert "DRC FAILED" in captured.out
         assert "ERRORS (must fix)" in captured.out
@@ -3091,13 +3093,13 @@ class TestPostStitchDRC:
         ):
             result = run_post_stitch_drc(pcb_path)
 
-        assert result == 0
+        assert result["ran"] is True
         captured = capsys.readouterr()
         assert "DRC PASSED" in captured.out
         assert "Errors:   0" in captured.out
 
     def test_run_post_stitch_drc_failure(self, tmp_path, capsys):
-        """run_post_stitch_drc should return 1 when DRC fails to run."""
+        """run_post_stitch_drc should report not_run when DRC fails to run."""
         from unittest.mock import patch
 
         from kicad_tools.cli.runner import KiCadCLIResult
@@ -3123,7 +3125,8 @@ class TestPostStitchDRC:
         ):
             result = run_post_stitch_drc(pcb_path)
 
-        assert result == 1
+        assert result["ran"] is False
+        assert result["passed"] is None
         captured = capsys.readouterr()
         assert "DRC failed to run" in captured.err
 
@@ -8287,3 +8290,103 @@ def test_explicit_micro_via_preserves_adjacent_span():
     add_via_to_pcb(pcb, placement)
     assert pcb.get("via").get("layers").get_atoms() == ["F.Cu", "In1.Cu"]
     assert "micro" in pcb.get("via").get_atoms()
+
+
+class TestStrictDrcContract:
+    @pytest.mark.parametrize("strict", [False, True])
+    @pytest.mark.parametrize(
+        "finding", ["clean", "error", "warning", "unconnected", "missing", "crash", "malformed"]
+    )
+    def test_json_no_change_native_report(self, tmp_path, monkeypatch, capsys, strict, finding):
+        import json
+
+        from kicad_tools.cli import runner, stitch_cmd
+
+        pcb = tmp_path / "unchanged.kicad_pcb"
+        pcb.write_text("(kicad_pcb)")
+        monkeypatch.setattr(
+            stitch_cmd,
+            "run_stitch",
+            lambda **kw: stitch_cmd.StitchResult(
+                pcb_name=pcb.name, target_nets=["GND"], already_connected=2
+            ),
+        )
+        monkeypatch.setattr(
+            runner, "find_kicad_cli", lambda: None if finding == "missing" else Path("kicad-cli")
+        )
+        calls = []
+        report = tmp_path / "report.json"
+
+        def native(*args, **kwargs):
+            calls.append(args[0])
+            entry = {
+                "type": "clearance",
+                "severity": finding,
+                "description": "native finding",
+                "items": [],
+            }
+            report.write_text(
+                "invalid JSON"
+                if finding == "malformed"
+                else json.dumps(
+                    {
+                        "violations": [entry] if finding in {"error", "warning"} else [],
+                        "unconnected_items": [
+                            {**entry, "type": "unconnected_items", "severity": "error"}
+                        ]
+                        if finding == "unconnected"
+                        else [],
+                        "schematic_parity": [],
+                    }
+                )
+            )
+            return runner.KiCadCLIResult(
+                success=True,
+                output_path=report,
+                return_code=1 if finding == "crash" else 0,
+                stderr="crashed" if finding == "crash" else "",
+            )
+
+        monkeypatch.setattr(runner, "run_drc", native)
+        rc = main(
+            [str(pcb), "--net", "GND", "--format", "json", "--drc-strict" if strict else "--drc"]
+        )
+        doc = json.loads(capsys.readouterr().out)
+        assert rc == doc["exit_code"] == (1 if strict and finding != "clean" else 0)
+        assert doc["success"] is True and doc["success_scope"] == "geometry"
+        assert doc["vias_added_count"] == 0 and doc["saved"] is False
+        assert pcb.read_text() == "(kicad_pcb)"
+        assert len(calls) == (0 if finding == "missing" else 1)
+        assert not report.exists()
+        drc = doc["drc"]
+        assert drc["requested"] and drc["strict"] == strict
+        if finding in {"missing", "crash", "malformed"}:
+            assert drc["status"] == "not_run" and drc["ran"] is False
+            assert drc["passed"] is None and drc["reason"]
+            assert all(
+                drc[k] is None for k in ("error_count", "warning_count", "unconnected_item_count")
+            )
+        else:
+            assert drc["ran"] is True
+            assert drc["passed"] == (finding == "clean")
+            assert drc["status"] == ("passed" if finding == "clean" else "failed")
+            assert drc["error_count"] == (finding == "error")
+            assert drc["warning_count"] == (finding == "warning")
+            assert drc["unconnected_item_count"] == (finding == "unconnected")
+
+    def test_strict_dry_run_cannot_pass(self, stitch_test_pcb, monkeypatch, capsys):
+        import json
+
+        from kicad_tools.cli import stitch_cmd
+
+        monkeypatch.setattr(
+            stitch_cmd, "run_post_stitch_drc", lambda *a: pytest.fail("dry run invoked DRC")
+        )
+        rc = main(
+            [str(stitch_test_pcb), "--net", "GND", "--dry-run", "--drc-strict", "--format", "json"]
+        )
+        doc = json.loads(capsys.readouterr().out)
+        assert rc == doc["exit_code"] == 1
+        assert doc["success"] is True
+        assert doc["drc"]["reason"] == "dry run"
+        assert doc["drc"]["passed"] is None


### PR DESCRIPTION
## Summary
`kct stitch --drc --format json` now reports the native DRC verdict and error, warning and unconnected-item counts. `success` retains its geometry meaning, identified by `success_scope: "geometry"`; `--drc` remains diagnostic. New `--drc-strict` implies DRC and exits nonzero on any findings or an unavailable check, while retaining the geometry result.

Explicit DRC requests now check unchanged boards. Dry runs skip validation and cannot pass the strict gate. Missing tools, subprocess failures and invalid native JSON produce `not_run`, null counts and an explanation. A malformed text response can no longer be mistaken for a clean report through parser auto-detection. The public contract is documented in CLI help and the machine-output reference.

## Acceptance Criteria Verification

| Criterion | Evidence |
|---|---|
| Separate native execution and findings | JSON `ran`, `status`, `passed`, three counts and reason; parsed findings retain `ran: true` |
| Preserve geometry success | Existing geometry predicate retained; `success_scope` and exact process `exit_code` documented/tested |
| Optional strict gate | `--drc-strict` rejects errors, warnings, unconnected items, missing CLI, failed subprocess and malformed report |
| Check unchanged boards | 14 parameterized cases use already-connected geometry, zero new vias, and verify the native call |
| Clean, negative and unavailable controls | Unit coverage and native controls below; dry-run skip explicitly tested |

## Test Plan

- `uv run --frozen --extra dev pytest tests/test_stitch_cmd.py tests/test_machine_output_idiom.py tests/test_stitch_mfr.py -q --no-cov --timeout=120`: **352 passed**, one existing pytest fixture warning.
- Ruff check/format and `git diff --check`: passed.
- Scoped mypy shadow-file comparison: **16 existing errors, zero new**, versus 17 in unchanged HEAD; the removed error was the now-guarded optional report path. Shared repository CI repair #5044 / PR #5045 remains external.
- Native KiCad 10.0.6 at `/tmp/kicad-native-sweep-20260910T212252Z-2790-0e0161a0/KiCad/KiCad.app/Contents/MacOS/kicad-cli`, using temporary copies of Board00 PCB/project/rules: original report **0 errors / 3 footprint warnings / 0 unconnected**, correctly failed under the all-findings policy; removing segments reported **0 / 3 / 1**, also failed. An empty-geometry control (footprints/copper removed from that temporary copy) reported **0 / 0 / 0**, passed. These exercise native report interpretation; no full reroute, new manufacturing qualification or committed board changes are claimed.
- TDD: no — tests were added alongside the implementation; the malformed-report case failed and drove the explicit native JSON guard before the final passing run.

Closes #4973