### PR TITLE
feat(analysis): qualify resistor operating budgets with bound evidence

### DIFF
--- a/docs/guides/resistor-rating.md
+++ b/docs/guides/resistor-rating.md
@@ -1,0 +1,129 @@
+# Resistor operating budgets
+
+Evaluate a user-reviewed JSON sidecar with:
+
+```sh
+uv run python -m kicad_tools.analysis.resistor_rating resistor-budget.json > resistor-report.json
+```
+
+Exit codes: 0 means all supplied envelopes pass, 1 means an envelope is
+exceeded, and 2 means evidence is incomplete or input is invalid. This command
+never changes a schematic or manufacturing readiness. A pass covers only the
+selected operating states and supplied ratings; it does not establish heatsink
+performance or physical qualification.
+
+Use `Budget.model_json_schema()` from `kicad_tools.analysis.resistor_rating`
+to obtain the complete input schema. Unknown fields, nonfinite numbers,
+invalid curves, duplicate references, and invalid sample periods are rejected.
+All field names include their units; resistance tolerance is a fraction.
+
+## Minimal continuous-load sidecar
+
+The following values are **synthetic examples**, not qualified ratings for
+any manufacturer part. Replace every hash with the SHA256 of the exact reviewed
+file. `MPN` must match the corresponding schematic symbol property exactly.
+All evidence paths resolve relative to the sidecar and must stay inside its
+directory (including after symlink resolution).
+
+```json
+{
+  "schema_version": 1,
+  "schematic": {"path": "board.kicad_sch", "sha256": "<64 lowercase hex digits>"},
+  "operating_policy": {"path": "operating-policy.md", "sha256": "<64 lowercase hex digits>"},
+  "active_states": ["balance"],
+  "resistors": [{
+    "reference": "R1",
+    "mpn": "replace-with-reviewed-MPN",
+    "resistance_ohm": 10,
+    "tolerance_fraction": 0.01,
+    "ratings": [{
+      "basis": "ambient",
+      "power_w": 2,
+      "requires_mounting": false,
+      "derating": [[0, 1], [70, 1], [150, 0]],
+      "provenance": {
+        "source": "Reviewed datasheet revision, page and condition",
+        "reviewed_by": "Reviewer name",
+        "reviewed_on": "2026-09-10"
+      }
+    }],
+    "states": {
+      "balance": {
+        "kind": "continuous",
+        "samples": [{"duration_s": 1, "voltage_v": 3}],
+        "temperature_basis": "ambient",
+        "temperature_c": 25,
+        "temperature_evidence": {"path": "conditions.md", "sha256": "<64 lowercase hex digits>"},
+        "assumptions": ["Constant applied voltage; switch drop ignored"]
+      }
+    }
+  }],
+  "simultaneous_groups": {"balance-bank": ["R1"]}
+}
+```
+
+At 3 V, a 10 ohm ±1% resistor is evaluated at 9.9 ohms: about 0.90909 W.
+Ten explicitly listed simultaneous channels produce about 9.0909 W aggregate.
+The aggregate is heat generation, not a temperature prediction; a sum of peak
+powers is an upper bound assuming coincident peaks.
+
+Only names in `active_states` are evaluated. Historical scenarios may remain
+in `states` without becoming current requirements. Missing selected states
+produce incomplete rows. The report includes the sidecar hash (binding all
+MPNs, ratings, assumptions and selected states), schematic/policy hashes, and
+per-reference/per-state results. Changing any evidence requires deliberate
+review and hash replacement; hashes are never updated automatically.
+
+## Rating conditions
+
+Supply the rating basis as `ambient`, `terminal`, or `flange`. The temperature
+basis must match; an ambient temperature cannot qualify a flange rating.
+Derating curves use increasing temperatures and nonincreasing fractions of the
+nameplate power, with piecewise-linear interpolation and no extrapolation.
+Choose only ratings applicable to the intended operating condition. If multiple
+ratings are supplied, **all** are checked independently; any incomplete or
+failed row prevents an overall pass. To assess alternative ambient versus
+terminal installations, use separate budgets with their own evidence.
+
+A terminal/flange rating, or any rating with `requires_mounting: true`, also
+requires `mounting_evidence` and `interface_evidence` in the operating state.
+Both use the same path/hash form as temperature evidence. A load below a
+100 W nameplate remains incomplete without these reviewed installation and
+temperature records. File presence/hash verifies identity, not the scientific
+adequacy of the review; the reviewer must establish actual mounting and thermal
+conditions. No datasheet is scraped and no package-size estimate is promoted
+into a qualified rating.
+
+## Waveforms and pulse envelopes
+
+Each sample is a **piecewise-constant interval**, not a point to interpolate.
+Supply exactly one of `voltage_v`, `current_a`, or nonnegative `power_w` per
+interval, plus positive `duration_s`. Voltage drive uses minimum tolerance
+resistance; current drive uses maximum resistance. Direct dissipation requires
+`reviewed_power_includes_tolerance: true`, otherwise its row is incomplete.
+
+Use `kind: periodic` with `period_s` at least the total interval duration. Any
+remaining time is explicitly zero power. Use `single_pulse` without a period
+for one event. `continuous` accepts exactly one constant interval. Samples for
+one pulse envelope describe **one conservative pulse window**: interspersed
+zero-power intervals do not reset its duration. More detailed multi-pulse or
+frequency-dependent thermal models are outside this report.
+
+The report calculates peak and cycle-average power, mathematical RMS of power,
+window energy, window duration, declared duty, and repetition frequency.
+`rms_power_w` is sqrt(mean(P²)); it is **not** an average heating-power substitute.
+For a single pulse, the reported average is over that pulse window. Continuous
+window energy depends on the declared observation duration.
+
+Every non-continuous state requires an applicable reviewed `pulse_limits`
+envelope on the resistor, with:
+
+- `basis`, `temperature_max_c`, and `provenance`;
+- `duration_max_s`, `peak_max_w`, `energy_max_j`, and `repetition_max_hz`.
+
+All supplied envelopes matching the rating basis are constraints, not alternative
+operating options. They must be reviewed conservative bounds for the sampled
+waveform shape and installation. Temperature applicability must be established;
+missing limits are incomplete. An average-safe waveform can still fail peak,
+energy, duration, or repetition limits. This first version does not interpolate
+manufacturer pulse curves or infer their shape/applicability.

--- a/docs/guides/resistor-rating.md
+++ b/docs/guides/resistor-rating.md
@@ -16,6 +16,10 @@ Use `Budget.model_json_schema()` from `kicad_tools.analysis.resistor_rating`
 to obtain the complete input schema. Unknown fields, nonfinite numbers,
 invalid curves, duplicate references, and invalid sample periods are rejected.
 All field names include their units; resistance tolerance is a fraction.
+Nonzero numeric inputs must have magnitude between `1e-20` and `1e20`
+(inclusive); zero is allowed where the field permits it. Values outside this
+documented arithmetic range are rejected as incomplete instead of risking
+underflow/overflow false passes. This includes curve coordinates and fractions.
 
 ## Minimal continuous-load sidecar
 

--- a/src/kicad_tools/analysis/resistor_rating.py
+++ b/src/kicad_tools/analysis/resistor_rating.py
@@ -1,0 +1,368 @@
+"""Evaluate explicit, source-bound resistor operating budgets (not thermal simulation).
+
+Run ``python -m kicad_tools.analysis.resistor_rating budget.json``. Ratings and
+operating conditions must be supplied and reviewed by the caller; nothing is
+inferred from package names or nominal nameplate power.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import math
+from pathlib import Path
+from typing import Any, Literal
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+from kicad_tools.schema.schematic import Schematic
+
+
+class Record(BaseModel):
+    model_config = ConfigDict(extra="forbid", allow_inf_nan=False, strict=True)
+
+
+class Evidence(Record):
+    path: str = Field(min_length=1)
+    sha256: str = Field(pattern=r"^[a-f0-9]{64}$")
+
+
+class Provenance(Record):
+    source: str = Field(min_length=1)
+    reviewed_by: str = Field(min_length=1)
+    reviewed_on: str = Field(pattern=r"^\d{4}-\d{2}-\d{2}$")
+
+
+class Rating(Record):
+    basis: Literal["ambient", "terminal", "flange"]
+    power_w: float = Field(gt=0)
+    # Piecewise-linear [temperature C, fraction of power_w]. No extrapolation.
+    derating: list[tuple[float, float]] = Field(min_length=2)
+    requires_mounting: bool
+    provenance: Provenance
+
+    @model_validator(mode="after")
+    def valid_curve(self) -> Rating:
+        if any(not 0 <= fraction <= 1 for _, fraction in self.derating):
+            raise ValueError("derating fractions must be between zero and one")
+        if any(
+            b[0] <= a[0] or b[1] > a[1]
+            for a, b in zip(self.derating, self.derating[1:], strict=False)
+        ):
+            raise ValueError("derating temperatures must increase and fractions not increase")
+        return self
+
+
+class PulseLimit(Record):
+    """Reviewed envelope applicable to this precise rating and temperature basis."""
+
+    duration_max_s: float = Field(gt=0)
+    peak_max_w: float = Field(gt=0)
+    energy_max_j: float = Field(gt=0)
+    repetition_max_hz: float = Field(ge=0)
+    temperature_max_c: float
+    basis: Literal["ambient", "terminal", "flange"]
+    provenance: Provenance
+
+
+class Sample(Record):
+    duration_s: float = Field(gt=0)
+    voltage_v: float | None = None
+    current_a: float | None = None
+    power_w: float | None = Field(default=None, ge=0)
+
+    @model_validator(mode="after")
+    def one_quantity(self) -> Sample:
+        if sum(v is not None for v in (self.voltage_v, self.current_a, self.power_w)) != 1:
+            raise ValueError("each interval requires exactly one of voltage_v/current_a/power_w")
+        return self
+
+
+class OperatingState(Record):
+    kind: Literal["continuous", "single_pulse", "periodic"]
+    samples: list[Sample] = Field(min_length=1)
+    # Samples are piecewise constant; periodic unsampled remainder is explicitly off.
+    period_s: float | None = Field(default=None, gt=0)
+    temperature_basis: Literal["ambient", "terminal", "flange"] | None = None
+    temperature_c: float | None = None
+    temperature_evidence: Evidence | None = None
+    mounting_evidence: Evidence | None = None
+    interface_evidence: Evidence | None = None
+    reviewed_power_includes_tolerance: bool = False
+    assumptions: list[str] = Field(min_length=1)
+
+    @model_validator(mode="after")
+    def valid_period(self) -> OperatingState:
+        duration = sum(s.duration_s for s in self.samples)
+        if self.kind == "periodic":
+            if self.period_s is None or self.period_s < duration:
+                raise ValueError("periodic period_s must cover every sample interval")
+        elif self.period_s is not None:
+            raise ValueError("period_s is only valid for periodic states")
+        if self.kind == "continuous" and len(self.samples) != 1:
+            raise ValueError("continuous state requires one constant interval")
+        return self
+
+
+class Resistor(Record):
+    reference: str = Field(min_length=1)
+    mpn: str = Field(min_length=1)
+    resistance_ohm: float = Field(gt=0)
+    tolerance_fraction: float = Field(ge=0, lt=1)
+    ratings: list[Rating] = Field(min_length=1)
+    pulse_limits: list[PulseLimit] = Field(default_factory=list)
+    states: dict[str, OperatingState]
+
+
+class Budget(Record):
+    schema_version: Literal[1]
+    schematic: Evidence
+    operating_policy: Evidence
+    active_states: list[str] = Field(min_length=1)
+    resistors: list[Resistor] = Field(min_length=1)
+    simultaneous_groups: dict[str, list[str]] = Field(default_factory=dict)
+
+    @model_validator(mode="after")
+    def unique_subjects(self) -> Budget:
+        refs = [p.reference for p in self.resistors]
+        if len(refs) != len(set(refs)) or len(self.active_states) != len(set(self.active_states)):
+            raise ValueError("references and active states must be unique")
+        for members in self.simultaneous_groups.values():
+            if not members or len(set(members)) != len(members) or not set(members) <= set(refs):
+                raise ValueError("groups require unique, declared resistor references")
+        return self
+
+
+def _bound_path(evidence: Evidence, base: Path) -> Path:
+    path = (base / evidence.path).resolve()
+    if Path(evidence.path).is_absolute() or not path.is_relative_to(base.resolve()):
+        raise ValueError(f"evidence must remain relative to the sidecar: {evidence.path}")
+    if hashlib.sha256(path.read_bytes()).hexdigest() != evidence.sha256:
+        raise ValueError(f"stale evidence: {evidence.path}")
+    return path
+
+
+def _status(failures: list[str], missing: list[str]) -> str:
+    return "fail" if failures else "incomplete" if missing else "pass"
+
+
+def _power(part: Resistor, state: OperatingState) -> dict[str, float]:
+    powers = []
+    for sample in state.samples:
+        if sample.voltage_v is not None:
+            power = sample.voltage_v**2 / (part.resistance_ohm * (1 - part.tolerance_fraction))
+        elif sample.current_a is not None:
+            power = sample.current_a**2 * part.resistance_ohm * (1 + part.tolerance_fraction)
+        else:
+            assert sample.power_w is not None
+            power = sample.power_w
+        powers.append(power)
+    duration = sum(s.duration_s for s in state.samples)
+    period = state.period_s if state.period_s is not None else duration
+    energy = sum(p * s.duration_s for p, s in zip(powers, state.samples, strict=True))
+    if (
+        not all(math.isfinite(p) for p in powers)
+        or not math.isfinite(energy)
+        or not math.isfinite(period)
+    ):
+        raise ValueError("non-finite power calculation")
+    return {
+        "peak_power_w": max(powers),
+        "average_power_w": energy / period,
+        "rms_power_w": math.sqrt(
+            sum(p * p * s.duration_s for p, s in zip(powers, state.samples, strict=True)) / period
+        ),
+        "window_energy_j": energy,
+        "duration_s": duration,
+        "duty_fraction": duration / period,
+        "repetition_hz": 1 / period if state.kind == "periodic" else 0,
+    }
+
+
+def _rating_power(rating: Rating, temperature: float) -> float | None:
+    if not rating.derating[0][0] <= temperature <= rating.derating[-1][0]:
+        return None
+    for (ta, fa), (tb, fb) in zip(rating.derating, rating.derating[1:], strict=False):
+        if ta <= temperature <= tb:
+            return rating.power_w * (fa + (fb - fa) * (temperature - ta) / (tb - ta))
+    return None
+
+
+def evaluate_budget(sidecar: str | Path) -> dict[str, Any]:
+    """Return pass/fail/incomplete with hashes and per-state, per-rating evidence.
+
+    A pass applies only to supplied rating envelopes and selected states. It
+    does not establish a heatsink design, aggregate temperature or bench result.
+    Malformed schemas raise ValueError; missing/stale evidence returns incomplete.
+    """
+    path = Path(sidecar)
+    raw = path.read_bytes()
+    budget = Budget.model_validate_json(raw)
+    base = path.parent
+    missing: list[str] = []
+    identities: dict[str, str | None] = {}
+    try:
+        schematic_path = _bound_path(budget.schematic, base)
+        sch = Schematic.load(schematic_path)
+        for symbol in sch.symbols:
+            if symbol.reference in identities:
+                raise ValueError(f"ambiguous schematic reference: {symbol.reference}")
+            identities[symbol.reference] = symbol.get_property("MPN")
+        _bound_path(budget.operating_policy, base)
+    except (OSError, ValueError) as exc:
+        missing.append(str(exc))
+    rows: list[dict[str, Any]] = []
+    for part in budget.resistors:
+        binding_missing = list(missing)
+        if identities.get(part.reference) != part.mpn:
+            binding_missing.append(f"schematic MPN missing or mismatched for {part.reference}")
+        for state_name in budget.active_states:
+            state = part.states.get(state_name)
+            common_missing = list(binding_missing)
+            row: dict[str, Any] = {
+                "reference": part.reference,
+                "mpn": part.mpn,
+                "state": state_name,
+            }
+            if state is None:
+                row.update(status="incomplete", missing=common_missing + ["selected state missing"])
+                rows.append(row)
+                continue
+            try:
+                powers = _power(part, state)
+            except (OverflowError, ZeroDivisionError) as exc:
+                raise ValueError("power calculation outside finite numeric range") from exc
+            if not all(math.isfinite(v) for v in powers.values()):
+                raise ValueError("power calculation outside finite numeric range")
+            row.update(powers)
+            row["assumptions"] = state.assumptions
+            if (
+                any(s.power_w is not None for s in state.samples)
+                and not state.reviewed_power_includes_tolerance
+            ):
+                common_missing.append("reviewed dissipation does not declare tolerance coverage")
+            evidence_ok = {}
+            for name in ("temperature_evidence", "mounting_evidence", "interface_evidence"):
+                evidence = getattr(state, name)
+                evidence_ok[name] = False
+                if evidence is not None:
+                    try:
+                        _bound_path(evidence, base)
+                        evidence_ok[name] = True
+                    except (OSError, ValueError) as exc:
+                        common_missing.append(str(exc))
+            ratings = []
+            for rating in part.ratings:
+                absent = list(common_missing)
+                failures: list[str] = []
+                if state.temperature_basis != rating.basis:
+                    absent.append("temperature basis does not match rating basis")
+                if state.temperature_c is None or not evidence_ok["temperature_evidence"]:
+                    absent.append(f"{rating.basis} temperature evidence missing")
+                if rating.requires_mounting or rating.basis in ("terminal", "flange"):
+                    for name in ("mounting_evidence", "interface_evidence"):
+                        if not evidence_ok[name]:
+                            absent.append(name + " missing")
+                limit = (
+                    None
+                    if state.temperature_c is None or state.temperature_basis != rating.basis
+                    else _rating_power(rating, state.temperature_c)
+                )
+                if limit is None:
+                    absent.append("temperature outside rated curve or unknown")
+                elif powers["average_power_w"] > limit:
+                    failures.append("average power exceeds derated rating")
+                if state.kind != "continuous":
+                    envelopes = [p for p in part.pulse_limits if p.basis == rating.basis]
+                    if not envelopes:
+                        absent.append("applicable pulse envelope missing")
+                    for pulse in envelopes:
+                        if (
+                            state.temperature_c is None
+                            or state.temperature_c > pulse.temperature_max_c
+                        ):
+                            absent.append("pulse temperature applicability not established")
+                            continue
+                        for measured, maximum, label in [
+                            (powers["duration_s"], pulse.duration_max_s, "pulse duration"),
+                            (powers["peak_power_w"], pulse.peak_max_w, "pulse peak power"),
+                            (powers["window_energy_j"], pulse.energy_max_j, "pulse energy"),
+                            (powers["repetition_hz"], pulse.repetition_max_hz, "pulse repetition"),
+                        ]:
+                            if measured > maximum:
+                                failures.append(label + " exceeds envelope")
+                ratings.append(
+                    {
+                        "basis": rating.basis,
+                        "provenance": rating.provenance.model_dump(),
+                        "allowed_power_w": limit,
+                        "status": _status(failures, absent),
+                        "failures": failures,
+                        "missing": absent,
+                    }
+                )
+            row["ratings"] = ratings
+            statuses = [r["status"] for r in ratings]
+            row["status"] = (
+                "fail"
+                if "fail" in statuses
+                else "incomplete"
+                if "incomplete" in statuses
+                else "pass"
+            )
+            rows.append(row)
+    groups = []
+    for state_name in budget.active_states:
+        for name, refs in budget.simultaneous_groups.items():
+            members = [r for r in rows if r["state"] == state_name and r["reference"] in refs]
+            complete = all("average_power_w" in r for r in members)
+            groups.append(
+                {
+                    "group": name,
+                    "state": state_name,
+                    "references": refs,
+                    "average_power_w": sum(r["average_power_w"] for r in members)
+                    if complete
+                    else None,
+                    "coincident_peak_upper_bound_w": sum(r["peak_power_w"] for r in members)
+                    if complete
+                    else None,
+                    "temperature_prediction": None,
+                }
+            )
+    statuses = [r["status"] for r in rows]
+    return {
+        "schema_version": 1,
+        "status": "fail"
+        if "fail" in statuses
+        else "incomplete"
+        if "incomplete" in statuses
+        else "pass",
+        "sidecar_sha256": hashlib.sha256(raw).hexdigest(),
+        "bindings": {
+            "schematic": budget.schematic.model_dump(),
+            "operating_policy": budget.operating_policy.model_dump(),
+        },
+        "active_states": budget.active_states,
+        "rows": rows,
+        "simultaneous_groups": groups,
+        "scope": "Supplied rating envelopes only; no aggregate temperature or hardware qualification.",
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("sidecar", type=Path)
+    args = parser.parse_args(argv)
+    try:
+        report = evaluate_budget(args.sidecar)
+    except (OSError, ValueError) as exc:
+        print(json.dumps({"status": "incomplete", "error": str(exc)}))
+        return 2
+    print(json.dumps(report, indent=2, allow_nan=False))
+    return {"pass": 0, "fail": 1, "incomplete": 2}[report["status"]]
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/kicad_tools/analysis/resistor_rating.py
+++ b/src/kicad_tools/analysis/resistor_rating.py
@@ -12,7 +12,7 @@ import hashlib
 import json
 import math
 from pathlib import Path
-from typing import Any, Literal
+from typing import Annotated, Any, Literal
 
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
@@ -21,6 +21,27 @@ from kicad_tools.schema.schematic import Schematic
 
 class Record(BaseModel):
     model_config = ConfigDict(extra="forbid", allow_inf_nan=False, strict=True)
+
+    @model_validator(mode="before")
+    @classmethod
+    def supported_numeric_range(cls, value: Any) -> Any:
+        # Bound every numeric input, including curve coordinates, before any
+        # arithmetic. This is deliberately far wider than physical electronics
+        # budgets while keeping powers/products away from float under/overflow.
+        def check(item: Any) -> None:
+            if isinstance(item, (int, float)) and not isinstance(item, bool):
+                magnitude = abs(item)
+                if magnitude > 1e20 or (0 < magnitude < 1e-20) or not math.isfinite(item):
+                    raise ValueError("nonzero numeric inputs must have magnitude in [1e-20, 1e20]")
+            elif isinstance(item, dict):
+                for child in item.values():
+                    check(child)
+            elif isinstance(item, (list, tuple)):
+                for child in item:
+                    check(child)
+
+        check(value)
+        return value
 
 
 class Evidence(Record):
@@ -38,7 +59,7 @@ class Rating(Record):
     basis: Literal["ambient", "terminal", "flange"]
     power_w: float = Field(gt=0)
     # Piecewise-linear [temperature C, fraction of power_w]. No extrapolation.
-    derating: list[tuple[float, float]] = Field(min_length=2)
+    derating: list[Annotated[tuple[float, float], Field(strict=False)]] = Field(min_length=2)
     requires_mounting: bool
     provenance: Provenance
 

--- a/tests/test_resistor_rating.py
+++ b/tests/test_resistor_rating.py
@@ -259,3 +259,22 @@ def test_numeric_overflow_and_string_review_attestation_are_not_passes(budget):
     data["resistors"][0]["states"]["active"]["reviewed_power_includes_tolerance"] = "false"
     with pytest.raises(ValueError):
         run()
+
+
+@pytest.mark.parametrize("case", ["derating_span_overflow", "voltage_square_underflow"])
+def test_extreme_finite_inputs_cannot_produce_false_pass(budget, case):
+    data, run, path, _ = budget
+    part = data["resistors"][0]
+    state = part["states"]["active"]
+    if case == "derating_span_overflow":
+        part["ratings"][0]["derating"] = [[-1e308, 1], [1e308, 0]]
+        state["temperature_c"] = 1e307
+        state["samples"] = [{"duration_s": 1, "power_w": 1.5}]
+        state["reviewed_power_includes_tolerance"] = True
+    else:
+        part["resistance_ohm"] = 1e-300
+        part["ratings"][0]["power_w"] = 1e-110
+        state["samples"][0]["voltage_v"] = 1e-200
+    with pytest.raises(ValueError, match="numeric inputs"):
+        run()
+    assert main([str(path)]) == 2

--- a/tests/test_resistor_rating.py
+++ b/tests/test_resistor_rating.py
@@ -1,0 +1,261 @@
+"""Source-bound resistor budgets: physical controls, missing evidence and CLI."""
+
+import copy
+import hashlib
+import json
+
+import pytest
+
+from kicad_tools.analysis.resistor_rating import Budget, evaluate_budget, main
+
+
+@pytest.fixture
+def budget(tmp_path):
+    def evidence(name, data):
+        (tmp_path / name).write_text(data)
+        return {"path": name, "sha256": hashlib.sha256(data.encode()).hexdigest()}
+
+    symbols = "".join(
+        f'(symbol (lib_id "Device:R") (at 0 0 0) (uuid "r{i}") '
+        f'(property "Reference" "R{i}") (property "Value" "10") '
+        '(property "MPN" "reviewed-part"))'
+        for i in range(1, 11)
+    )
+    sch = evidence(
+        "board.kicad_sch", '(kicad_sch (version 20250114) (generator "test") ' + symbols + ")"
+    )
+    proof = evidence(
+        "conditions.txt", "Reviewed ambient at 25 C; mounting/interface installation record."
+    )
+    source = {
+        "source": "user-reviewed fixture, not manufacturer qualification",
+        "reviewed_by": "engineer",
+        "reviewed_on": "2026-09-10",
+    }
+    state = {
+        "kind": "continuous",
+        "samples": [{"duration_s": 1, "voltage_v": 3}],
+        "temperature_basis": "ambient",
+        "temperature_c": 25,
+        "temperature_evidence": proof,
+        "assumptions": ["constant 3V, switch drop ignored"],
+    }
+    part = {
+        "reference": "R1",
+        "mpn": "reviewed-part",
+        "resistance_ohm": 10,
+        "tolerance_fraction": 0.01,
+        "ratings": [
+            {
+                "basis": "ambient",
+                "power_w": 2,
+                "derating": [[0, 1], [70, 1], [150, 0]],
+                "requires_mounting": False,
+                "provenance": source,
+            }
+        ],
+        "states": {"active": state},
+    }
+    data = {
+        "schema_version": 1,
+        "schematic": sch,
+        "operating_policy": evidence(
+            "policy.txt", "active selected; historical zero-bank startup excluded"
+        ),
+        "active_states": ["active"],
+        "resistors": [part],
+        "simultaneous_groups": {},
+    }
+    path = tmp_path / "rating.json"
+
+    def run(value=None):
+        path.write_text(json.dumps(data if value is None else value))
+        return evaluate_budget(path)
+
+    return data, run, path, proof
+
+
+def test_ten_tolerance_channels_have_aggregate_heat_without_temperature_prediction(budget):
+    data, run, _, _ = budget
+    template = data["resistors"][0]
+    data["resistors"] = [dict(copy.deepcopy(template), reference=f"R{i}") for i in range(1, 11)]
+    data["simultaneous_groups"] = {"balance": [f"R{i}" for i in range(1, 11)]}
+    report = run()
+    assert report["status"] == "pass"
+    assert all(r["average_power_w"] == pytest.approx(0.909090909) for r in report["rows"])
+    assert report["simultaneous_groups"][0]["average_power_w"] == pytest.approx(9.09090909)
+    assert report["simultaneous_groups"][0]["temperature_prediction"] is None
+
+
+def test_nameplate_100w_does_not_replace_mounting_or_interface_evidence(budget):
+    data, run, _, proof = budget
+    rating = data["resistors"][0]["ratings"][0]
+    rating.update(basis="flange", power_w=100, requires_mounting=True)
+    state = data["resistors"][0]["states"]["active"]
+    state["temperature_basis"] = "flange"
+    assert run()["status"] == "incomplete"
+    state["mounting_evidence"] = proof
+    assert run()["status"] == "incomplete"
+    state["interface_evidence"] = proof
+    assert run()["status"] == "pass"
+    state["temperature_basis"] = "ambient"
+    assert run()["status"] == "incomplete"
+
+
+def test_derating_range_and_interpolation(budget):
+    data, run, _, _ = budget
+    state = data["resistors"][0]["states"]["active"]
+    state["temperature_c"] = 110
+    assert run()["rows"][0]["ratings"][0]["allowed_power_w"] == 1
+    state["temperature_c"] = 130
+    assert run()["status"] == "fail"
+    state["temperature_c"] = -10
+    assert run()["status"] == "incomplete"
+
+
+def test_average_safe_pulse_exceeding_energy_fails(budget):
+    data, run, _, _ = budget
+    part = data["resistors"][0]
+    state = part["states"]["active"]
+    state.update(kind="periodic", samples=[{"duration_s": 0.01, "voltage_v": 10}], period_s=1)
+    report = run()
+    assert report["status"] == "incomplete"
+    assert report["rows"][0]["average_power_w"] < 2
+    part["pulse_limits"] = [
+        {
+            "duration_max_s": 0.02,
+            "peak_max_w": 11,
+            "energy_max_j": 0.05,
+            "repetition_max_hz": 1,
+            "temperature_max_c": 70,
+            "basis": "ambient",
+            "provenance": part["ratings"][0]["provenance"],
+        }
+    ]
+    report = run()
+    assert report["status"] == "fail"
+    assert "pulse energy exceeds envelope" in report["rows"][0]["ratings"][0]["failures"]
+    part["pulse_limits"][0]["energy_max_j"] = 0.2
+    assert run()["status"] == "pass"
+    part["pulse_limits"][0]["repetition_max_hz"] = 0.5
+    assert run()["status"] == "fail"
+
+
+def test_piecewise_constant_waveform_integral_and_rms(budget):
+    data, run, _, _ = budget
+    state = data["resistors"][0]["states"]["active"]
+    state.update(
+        kind="periodic",
+        samples=[{"duration_s": 1, "power_w": 4}, {"duration_s": 1, "power_w": 0}],
+        period_s=4,
+        reviewed_power_includes_tolerance=True,
+    )
+    row = run()["rows"][0]
+    assert row["window_energy_j"] == 4
+    assert row["average_power_w"] == 1
+    assert row["rms_power_w"] == 2
+    assert row["duty_fraction"] == 0.5
+    assert row["repetition_hz"] == 0.25
+
+
+def test_current_drive_uses_high_resistance_tolerance(budget):
+    data, run, _, _ = budget
+    data["resistors"][0]["states"]["active"]["samples"] = [{"duration_s": 1, "current_a": 0.3}]
+    assert run()["rows"][0]["average_power_w"] == pytest.approx(0.909)
+
+
+@pytest.mark.parametrize("target", ["board.kicad_sch", "policy.txt", "conditions.txt"])
+def test_stale_evidence_never_passes(budget, target):
+    _, run, path, _ = budget
+    (path.parent / target).write_text("changed")
+    assert run()["status"] == "incomplete"
+
+
+def test_mpn_change_and_state_selection_are_explicit(budget):
+    data, run, _, _ = budget
+    part = data["resistors"][0]
+    historical = copy.deepcopy(part["states"]["active"])
+    historical["samples"][0]["voltage_v"] = 1000
+    part["states"]["historical_zero_bank"] = historical
+    assert run()["status"] == "pass"
+    data["active_states"] = ["historical_zero_bank"]
+    assert run()["status"] == "fail"
+    data["active_states"] = ["not_declared"]
+    assert run()["status"] == "incomplete"
+    data["active_states"] = ["active"]
+    part["mpn"] = "different-part"
+    assert run()["status"] == "incomplete"
+
+
+def test_reviewed_dissipation_requires_tolerance_attestation(budget):
+    data, run, _, _ = budget
+    state = data["resistors"][0]["states"]["active"]
+    state["samples"] = [{"duration_s": 1, "power_w": 0.5}]
+    assert run()["status"] == "incomplete"
+    state["reviewed_power_includes_tolerance"] = True
+    assert run()["status"] == "pass"
+
+
+@pytest.mark.parametrize(
+    "mutation",
+    [
+        lambda d: d.update(active_states=[]),
+        lambda d: d.update(simultaneous_groups={"x": ["R1", "R1"]}),
+        lambda d: d["resistors"][0].update(tolerance_fraction=1),
+        lambda d: d["resistors"][0].update(resistance_ohm=float("nan")),
+        lambda d: d["resistors"][0]["states"]["active"]["samples"][0].update(current_a=1),
+        lambda d: d["resistors"][0]["states"]["active"].update(kind="periodic", period_s=0.5),
+        lambda d: d["resistors"][0]["ratings"][0].update(derating=[[70, 1], [0, 0]]),
+    ],
+)
+def test_malformed_policy_is_rejected(budget, mutation):
+    data, _, _, _ = budget
+    mutation(data)
+    with pytest.raises(ValueError):
+        Budget.model_validate(data)
+
+
+def test_cli_exit_codes_and_invalid_schema(budget, capsys):
+    data, run, path, _ = budget
+    run()
+    assert main([str(path)]) == 0
+    data["resistors"][0]["mpn"] = "wrong"
+    run()
+    assert main([str(path)]) == 2
+    data["resistors"][0]["mpn"] = "reviewed-part"
+    data["resistors"][0]["states"]["active"]["samples"][0]["voltage_v"] = 100
+    run()
+    assert main([str(path)]) == 1
+    path.write_text("{bad")
+    assert main([str(path)]) == 2
+    assert "incomplete" in capsys.readouterr().out
+
+
+def test_wrong_temperature_basis_does_not_invent_derating_failure(budget):
+    data, run, _, _ = budget
+    state = data["resistors"][0]["states"]["active"]
+    state.update(temperature_basis="flange", temperature_c=149)
+    report = run()
+    assert report["status"] == "incomplete"
+    assert report["rows"][0]["ratings"][0]["allowed_power_w"] is None
+
+
+def test_sidecar_binding_changes_and_evidence_path_escape(budget, tmp_path):
+    data, run, _, _ = budget
+    first = run()
+    data["resistors"][0]["states"]["active"]["assumptions"].append("additional reviewed assumption")
+    assert first["sidecar_sha256"] != run()["sidecar_sha256"]
+    data["operating_policy"]["path"] = "../policy.txt"
+    assert run()["status"] == "incomplete"
+
+
+def test_numeric_overflow_and_string_review_attestation_are_not_passes(budget):
+    data, run, path, _ = budget
+    data["resistors"][0]["states"]["active"]["samples"][0]["voltage_v"] = 1e308
+    with pytest.raises(ValueError):
+        run()
+    assert main([str(path)]) == 2
+    data["resistors"][0]["states"]["active"]["samples"][0]["voltage_v"] = 3
+    data["resistors"][0]["states"]["active"]["reviewed_power_includes_tolerance"] = "false"
+    with pytest.raises(ValueError):
+        run()


### PR DESCRIPTION
Resistor nameplate power does not establish the mounting, temperature or pulse conditions needed for qualification. This adds an explicit JSON operating-budget evaluator and report: selected states, exact schematic MPN matching, SHA256-bound schematic/policy/installation evidence, temperature-basis-specific derating, and pass/fail/incomplete results.

Voltage and current samples use opposite resistance-tolerance extremes; reviewed power inputs must declare tolerance coverage. Piecewise-constant waveform reports include peak/average/RMS power, energy, duty and repetition. Reviewed pulse envelopes can fail an average-safe waveform. Simultaneous groups report aggregate heat generation without inventing a temperature prediction. A 100 W flange rating stays incomplete without mounting/interface/temperature evidence.

Usage and complete schema access are documented in `docs/guides/resistor-rating.md`; invoke with `python -m kicad_tools.analysis.resistor_rating budget.json`. No scraped manufacturer ratings, hardware qualification, readiness promotion or source mutation.

Validation:

- 22 new physical/evidence/schema/CLI controls pass, including ten10-ohm±1% channels at3V producing9.0909W total, missing heatsink prerequisites, pulse energy failure despite safe average, exact waveform integral/RMS, stale hashes, MPN mismatch and excluded historical states.
- 94 combined resistor/electrical-rating/thermal tests passed before the final three additional controls, which passed in the final22-test run.
- Ruff passes; module mypy clean; cold repository type gate passes unchanged baseline (1463/1472).

Limits: reviewed rectangular pulse envelopes and piecewise-constant intervals; no manufacturer curve digitization, waveform interpolation, heatsink simulation or bench evidence. Every supplied rating is a required constraint; alternative installations use separate budgets. Review of evidence contents remains explicit human engineering input.

Closes #5066