### PR TITLE
Report explicit analog threshold and hysteresis budgets

### DIFF
--- a/docs/guides/analog-threshold-budgets.md
+++ b/docs/guides/analog-threshold-budgets.md
@@ -1,0 +1,124 @@
+# Analog threshold budgets
+
+The explicit analog threshold sidecar evaluates reviewed ideal linear networks.
+It does not infer topology or certify a protection circuit. It can expose a
+requirement violation under declared assumptions; **vertex sampling cannot prove
+that all interior or physically reachable operating points meet a requirement**.
+
+Run a source-bound report with:
+
+```sh
+python -m kicad_tools.analysis.analog_threshold board.kicad_sch thresholds.json > threshold-report.json
+```
+
+Exit 1 means a sampled model corner violates a requirement. Exit 2 means incomplete
+or merely sampled evidence; there is intentionally no release-qualified exit 0.
+Every report has `release_eligible: false`. A missing sidecar, unknown bound,
+unbound pin, changed MPN/value, stale schematic hash, or unsupported hierarchy
+cannot become a qualified pass. Flat schematics are supported in this first
+implementation; hierarchy is explicitly incomplete.
+
+The policy object has `schema_version: 1`, `schematic_sha256`, `bindings`, and a
+nonempty `networks` array. Bind each used resistor and active device by reference:
+
+```json
+{
+  "R1": {
+    "value": "499k",
+    "mpn": "exact-reviewed-MPN",
+    "pins": {"1": "BANK_POS", "2": "INPUT_SERIES_1"}
+  }
+}
+```
+
+Actual symbol values, exact `MPN` (or `Mfr_Part_Number`) fields, and the extracted
+pin/net connections must match. Modeled resistor ohms must also match the parsed
+schematic value. Missing MPNs remain unresolved, including on resistors. Root
+schematic and exact sidecar bytes are SHA256-bound in JSON. Any schematic-byte
+change invalidates the reviewed bindings; updating the hash is a review action,
+not an automatic refresh. The report includes all checked reference/net bindings.
+
+Each network declares `id`, `kind`, `resistors`, `bounds`, `devices`, `conditions`,
+`requirements`, optional `assumptions`, and `unmodeled_terms`. Topology/role
+assignment is reviewed policy input, **not inferred or independently certified**
+from connectivity. `devices` maps `comparator` (and, for the difference-amplifier
+model, `amplifier` and `buffer`) to exact schematic references.
+
+Each resistor role is a nonempty series list of objects with `reference`, `ohms`,
+`tolerance` (fraction, e.g. 0.001), and `source` provenance. References cannot be
+reused in different roles within a model. A series arm's resistance interval is
+the exact sum of its independent resistor intervals. No resistor datasheet limit
+is invented. Supply and error bounds have `min`, `nominal`, `max`, and `source`.
+Missing semiconductor error terms use zero **only to retain a clearly incomplete,
+partial illustrative calculation**; the omitted terms are listed in the report.
+Missing supply/reference/common-mode ranges prevent calculation.
+
+`conditions.temperature_c` uses the same range/provenance format;
+`conditions.linear_operation` records the reviewed operating-region assumption.
+These are recorded conditions, not an automatic check of an amplifier's common-
+mode or output capability. Error bounds must cover those conditions. List bias-
+current, reference/buffer error, loading, semiconductor temperature effects,
+nonlinearity, transients and any other unmodeled behavior in `unmodeled_terms`.
+Absent temperature or operating-region conditions yield incomplete coverage.
+
+## Difference amplifier and positive-feedback comparator
+
+The `difference_comparator` template uses these resistor roles:
+
+| Role | Meaning |
+|---|---|
+| `input_positive` | Positive terminal to noninverting amplifier input |
+| `input_negative` | Negative terminal to inverting amplifier input |
+| `feedback` | Amplifier output to inverting input |
+| `reference_arm` | Buffered midpoint to noninverting input |
+| `midpoint_top`, `midpoint_bottom` | Supply-to-ground midpoint divider |
+| `comparator_top`, `comparator_bottom` | Supply-to-midpoint comparator reference divider |
+| `signal`, `hysteresis` | Amplifier signal and comparator output to comparator summing input |
+
+The differential input is `Vpositive - Vnegative`; `common_mode` is
+`(Vpositive + Vnegative)/2`. This convention matters when input resistor ratios
+are mismatched. Required bounds are `supply`, `common_mode`, `amplifier_offset`,
+`buffer_offset`, `comparator_offset`, `output_low`, and `output_high_drop`.
+The offset signs are positive additive input-referred errors (buffer offset adds
+to midpoint; comparator offset adds to reference). Comparator output high equals
+the **same sampled supply** minus `output_high_drop`; low is `output_low` above
+ground. This keeps reference, midpoint, and output swing correlated.
+
+For each resistor corner, with P/N the input arms, F the feedback and T the
+reference arm, positive gain is `(1 + F/N) * T/(P + T)`, negative gain is `F/N`,
+and differential gain is their average. The nominal amplifier baseline includes
+the gain mismatch times common mode and the buffered-midpoint contribution.
+Comparator trip solves the summing-node KCL with output low for rising and output
+high for falling. Hysteresis is computed **at the same corner** as rising minus
+falling, rather than subtracting unrelated extrema.
+
+The included [partial softstart model](../../tests/fixtures/analog_threshold/softstart_partial.json)
+reproduces the #5064 illustrative fixture. Evaluate an unbound math model using
+`evaluate_network(json.load(...))`; its result explicitly says
+`source_binding: unbound_math_model` and grants no schematic-backed approval.
+Four 499k resistors per arm, ±0.1% resistors, supply 3.234–3.366 V and common mode
+−250…250 V give 4,096 reduced-arm vertices:
+
+| Threshold | Nominal | Sampled minimum | Sampled maximum |
+|---|---:|---:|---:|
+| Rising | 70.24398 V | 67.66329 V | 72.83212 V |
+| Falling | 60.33902 V | 57.96032 V | 62.72502 V |
+
+The falling samples violate the declared 60 V minimum. Coverage is still
+incomplete because semiconductor limits and reachable corner constraints are
+missing. These numbers are not approved design limits or factory guarantees.
+
+## Divider template and requirements
+
+The `divider` template has resistor roles `top` and `bottom`, and bounds
+`reference` and `comparator_offset`. Its input trip is
+`(reference + comparator_offset) * (1 + top/bottom)`. Rising and falling are equal
+and hysteresis is zero. This simple template has no feedback/output-state model.
+
+`requirements` can constrain `rising`, `falling`, and `hysteresis` with `min` /
+`max` volts and a reviewed `source`. Reports provide nominal values, sampled
+extrema, the corner attaining each extremum, assumptions and omitted terms.
+Missing requirements or provenance remain incomplete. Vertices are bounded to
+262,144; larger models fail visibly rather than silently truncating the sweep.
+The 1e-9 V comparison tolerance is a numerical rounding allowance, not component
+or manufacturing tolerance. No geometrical DRC waiver is consulted.

--- a/src/kicad_tools/analysis/analog_threshold.py
+++ b/src/kicad_tools/analysis/analog_threshold.py
@@ -1,0 +1,352 @@
+"""Reviewed analog-network threshold budgets; vertex samples are not proofs.
+
+No topology inference or semiconductor guarantees. Run as a module with a flat
+schematic and JSON policy to obtain source-bound evidence and nonzero incomplete
+or failed status. Mathematical helpers also support unbound fixture evaluation.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import itertools
+import json
+import math
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+
+DIFFERENCE_ROLES = (
+    "input_positive",
+    "input_negative",
+    "feedback",
+    "reference_arm",
+    "midpoint_top",
+    "midpoint_bottom",
+    "comparator_top",
+    "comparator_bottom",
+    "signal",
+    "hysteresis",
+)
+DIFFERENCE_BOUNDS = (
+    "supply",
+    "common_mode",
+    "amplifier_offset",
+    "buffer_offset",
+    "comparator_offset",
+    "output_low",
+    "output_high_drop",
+)
+MAX_VERTICES = 262144
+
+
+def _number(value: Any, name: str) -> float:
+    if isinstance(value, bool) or not isinstance(value, (float, int)) or not math.isfinite(value):
+        raise ValueError(f"{name}: finite number required")
+    return float(value)
+
+
+def _range(value: dict[str, Any], name: str) -> tuple[float, float, float]:
+    low, nominal, high = (_number(value[key], name) for key in ("min", "nominal", "max"))
+    if not low <= nominal <= high:
+        raise ValueError(f"{name}: require min <= nominal <= max")
+    return low, nominal, high
+
+
+def _thresholds(kind: str, p: dict[str, Any]) -> tuple[Any, Any]:
+    if kind == "divider":
+        trip = (p["reference"] + p["comparator_offset"]) * (1 + p["top"] / p["bottom"])
+        return trip, trip
+    # Difference input = Vpositive - Vnegative. Common mode = their average.
+    positive_gain = (
+        (1 + p["feedback"] / p["input_negative"])
+        * p["reference_arm"]
+        / (p["input_positive"] + p["reference_arm"])
+    )
+    negative_gain = p["feedback"] / p["input_negative"]
+    differential_gain = (positive_gain + negative_gain) / 2
+    midpoint = (
+        p["supply"] * p["midpoint_bottom"] / (p["midpoint_top"] + p["midpoint_bottom"])
+        + p["buffer_offset"]
+    )
+    baseline = (positive_gain - negative_gain) * p["common_mode"] + (1 + negative_gain) * p[
+        "input_positive"
+    ] / (p["input_positive"] + p["reference_arm"]) * midpoint
+    baseline += (1 + negative_gain) * p["amplifier_offset"]
+    reference = (p["supply"] / p["comparator_top"] + midpoint / p["comparator_bottom"]) / (
+        1 / p["comparator_top"] + 1 / p["comparator_bottom"]
+    )
+    reference += p["comparator_offset"]
+    ratio = p["signal"] / p["hysteresis"]
+    # Output high shares the *same* supply sample; do not independently sweep it.
+    rising = (reference * (1 + ratio) - p["output_low"] * ratio - baseline) / differential_gain
+    falling = (
+        reference * (1 + ratio) - (p["supply"] - p["output_high_drop"]) * ratio - baseline
+    ) / differential_gain
+    return rising, falling
+
+
+def evaluate_network(network: dict[str, Any]) -> dict[str, Any]:
+    """Evaluate a declared template without claiming schematic binding or proof."""
+    kind = network["kind"]
+    if kind not in {"divider", "difference_comparator"}:
+        raise ValueError(f"Unsupported network kind: {kind}")
+    roles = ("top", "bottom") if kind == "divider" else DIFFERENCE_ROLES
+    required_bounds = ("reference", "comparator_offset") if kind == "divider" else DIFFERENCE_BOUNDS
+    parameters: dict[str, tuple[float, float, float]] = {}
+    omitted = list(network.get("unmodeled_terms", []))
+    conditions = network.get("conditions", {})
+    if "temperature_c" not in conditions:
+        omitted.append("Operating temperature range absent")
+    else:
+        _range(conditions["temperature_c"], "temperature_c")
+        if not conditions["temperature_c"].get("source"):
+            omitted.append("Temperature range provenance absent")
+    if not conditions.get("linear_operation"):
+        omitted.append("Semiconductor linear-operation/common-mode qualification absent")
+    references: list[str] = []
+    provenance: dict[str, Any] = {}
+    for role in roles:
+        parts = network["resistors"][role]
+        if not isinstance(parts, list) or not parts:
+            raise ValueError(f"{role}: nonempty series resistor list required")
+        low = nominal = high = 0.0
+        for part in parts:
+            ref = part["reference"]
+            if not isinstance(ref, str) or not ref or ref in references:
+                raise ValueError(f"Duplicate/invalid resistor role binding: {ref}")
+            references.append(ref)
+            resistance = _number(part["ohms"], ref)
+            if resistance <= 0:
+                raise ValueError(f"{ref}: resistance must be positive")
+            if "tolerance" not in part or not part.get("source"):
+                omitted.append(f"{ref}: missing tolerance/source; nominal-only partial calculation")
+            tolerance = _number(part.get("tolerance", 0), ref)
+            if not 0 <= tolerance < 1:
+                raise ValueError(f"{ref}: tolerance must be in [0, 1)")
+            low += resistance * (1 - tolerance)
+            nominal += resistance
+            high += resistance * (1 + tolerance)
+        # Every value in a sum of independent intervals is reachable. Collapsing
+        # each series arm retains its exact resistance interval, not its corners.
+        parameters[role] = (low, nominal, high)
+        provenance[role] = parts
+    for key in required_bounds:
+        bound = network.get("bounds", {}).get(key)
+        if bound is None:
+            if key in {"supply", "reference", "common_mode"}:
+                raise ValueError(f"{key}: explicit operating range required")
+            omitted.append(f"{key}: missing bound; zero used only for partial illustration")
+            parameters[key] = (0, 0, 0)
+        else:
+            parameters[key] = _range(bound, key)
+            if not bound.get("source"):
+                omitted.append(f"{key}: missing bound provenance")
+            provenance[key] = bound
+    if kind == "difference_comparator":
+        if parameters["supply"][0] <= 0:
+            raise ValueError("supply: positive operating range required")
+        if parameters["output_low"][0] < 0 or parameters["output_high_drop"][0] < 0:
+            raise ValueError("Output swing bounds must be nonnegative rail drops")
+        if (
+            parameters["output_low"][2] + parameters["output_high_drop"][2]
+            >= parameters["supply"][0]
+        ):
+            raise ValueError("Output swing intervals overlap or exceed supply")
+    choices = [(lo,) if lo == hi else (lo, hi) for lo, _, hi in parameters.values()]
+    count = math.prod(len(values) for values in choices)
+    if count > MAX_VERTICES:
+        raise ValueError(f"{count} vertices exceed bounded evaluator limit {MAX_VERTICES}")
+    corners = np.asarray(list(itertools.product(*choices)), dtype=float)
+    sampled = dict(zip(parameters, corners.T, strict=True))
+    nominal_values = {name: values[1] for name, values in parameters.items()}
+    rising, falling = _thresholds(kind, sampled)
+    nominal_rising, nominal_falling = _thresholds(kind, nominal_values)
+    values = {"rising": rising, "falling": falling, "hysteresis": rising - falling}
+    nominal_results = {
+        "rising": nominal_rising,
+        "falling": nominal_falling,
+        "hysteresis": nominal_rising - nominal_falling,
+    }
+    findings: list[str] = []
+    ranges: dict[str, Any] = {}
+    requirements = network.get("requirements", {})
+    if not requirements:
+        omitted.append("No reviewed threshold requirements supplied")
+    if set(requirements) - values.keys():
+        raise ValueError("Unknown threshold requirement")
+    for key, array in values.items():
+        if not np.isfinite(array).all():
+            raise ValueError("Nonfinite threshold result")
+        low_index, high_index = int(np.argmin(array)), int(np.argmax(array))
+        low, high = float(array[low_index]), float(array[high_index])
+        ranges[key] = {
+            "nominal_v": float(nominal_results[key]),
+            "sample_min_v": low,
+            "sample_max_v": high,
+            "min_corner": {name: float(sampled[name][low_index]) for name in parameters},
+            "max_corner": {name: float(sampled[name][high_index]) for name in parameters},
+        }
+        limits = requirements.get(key, {})
+        if set(limits) - {"min", "max", "source"}:
+            raise ValueError(f"{key}: unknown requirement field")
+        if limits and not limits.get("source"):
+            omitted.append(f"{key}: requirement provenance absent")
+        if "min" in limits and low < _number(limits["min"], key) - 1e-9:
+            findings.append(f"{key}: sampled {low:.8g} V below required {limits['min']} V")
+        if "max" in limits and high > _number(limits["max"], key) + 1e-9:
+            findings.append(f"{key}: sampled {high:.8g} V above required {limits['max']} V")
+    return {
+        "id": network["id"],
+        "source_binding": "unbound_math_model",
+        "conditions": conditions,
+        "kind": kind,
+        "status": "failed" if findings else "incomplete" if omitted else "sampled",
+        "coverage": "incomplete" if omitted else "declared_terms_only",
+        "bound_method": "vertex_sampling_not_a_proven_enclosure",
+        "release_eligible": False,
+        "vertices": count,
+        "thresholds": ranges,
+        "references": references,
+        "devices": network.get("devices", {}),
+        "requirements": requirements,
+        "provenance": provenance,
+        "findings": findings,
+        "omitted_terms": omitted,
+        "assumptions": [
+            "Reviewed ideal linear topology; no automatic topology inference",
+            "Shared supply and buffered midpoint are evaluated once per corner",
+            "Common mode is (Vpositive + Vnegative)/2; differential is Vpositive - Vnegative",
+            "Independent component intervals; vertices need not be physically reachable",
+            "No proof of interior extrema, semiconductor operating region, dynamics or SOA",
+            *network.get("assumptions", []),
+        ],
+    }
+
+
+def analyze_thresholds(schematic: str | Path, policy_path: str | Path) -> dict[str, Any]:
+    """Bind a reviewed flat-schematic sidecar to values, MPNs and connected pins."""
+    from kicad_tools.operations.netlist import build_netlist_from_schematic
+    from kicad_tools.schema.schematic import Schematic
+    from kicad_tools.spec.units import parse_unit_value
+
+    path, sidecar = Path(schematic), Path(policy_path)
+    source = path.read_bytes()
+    policy_bytes = sidecar.read_bytes()
+    policy = json.loads(policy_bytes)
+    if not isinstance(policy, dict):
+        raise ValueError("Policy must be an object")
+    evidence: dict[str, Any] = {
+        "schema_version": 1,
+        "schematic_sha256": hashlib.sha256(source).hexdigest(),
+        "policy_sha256": hashlib.sha256(policy_bytes).hexdigest(),
+        "status": "incomplete",
+        "release_eligible": False,
+        "networks": [],
+        "issues": [],
+    }
+    issues = evidence["issues"]
+    if policy.get("schema_version") != 1:
+        issues.append("Unsupported policy schema")
+        return evidence
+    if policy.get("schematic_sha256") != evidence["schematic_sha256"]:
+        issues.append("Stale schematic binding: topology/value/MPN source hash changed")
+        return evidence
+    sch = Schematic.load(path)
+    if sch.sheets:
+        issues.append("Hierarchical schematic binding is not supported; no partial hierarchy pass")
+        return evidence
+    symbols: dict[str, Any] = {}
+    for symbol in sch.symbols:
+        if symbol.reference in symbols:
+            issues.append(f"Duplicate reference: {symbol.reference}")
+        symbols[symbol.reference] = symbol
+    netlist = build_netlist_from_schematic(path)
+    pins: dict[tuple[str, str], set[str]] = {}
+    for net in netlist.nets:
+        for node in net.nodes:
+            pins.setdefault((node.reference, node.pin), set()).add(net.name)
+    bindings = policy.get("bindings", {})
+    networks = policy.get("networks", [])
+    if not networks:
+        issues.append("No networks declared")
+    needed: set[str] = set()
+    resistor_values: dict[str, float] = {}
+    for network in networks:
+        for parts in network.get("resistors", {}).values():
+            for part in parts:
+                needed.add(part["reference"])
+                resistor_values[part["reference"]] = part["ohms"]
+        devices = network.get("devices", {})
+        required_devices = (
+            {"comparator"}
+            if network.get("kind") == "divider"
+            else {"amplifier", "buffer", "comparator"}
+        )
+        if not required_devices <= devices.keys():
+            issues.append(f"{network.get('id')}: missing active-device role bindings")
+        needed.update(devices.values())
+    for ref in sorted(needed):
+        binding, bound_symbol = bindings.get(ref), symbols.get(ref)
+        if not binding or bound_symbol is None:
+            issues.append(f"{ref}: missing symbol/binding")
+            continue
+        if not binding.get("pins"):
+            issues.append(f"{ref}: pin/net bindings absent")
+        for pin, expected_net in binding.get("pins", {}).items():
+            if pins.get((ref, str(pin))) != {expected_net}:
+                issues.append(f"{ref}.{pin}: unbound/changed/ambiguous net {expected_net}")
+        if binding.get("value") != bound_symbol.value:
+            issues.append(f"{ref}: value binding mismatch")
+        actual_mpn = bound_symbol.get_property("MPN") or bound_symbol.get_property(
+            "Mfr_Part_Number"
+        )
+        if not binding.get("mpn") or binding["mpn"] != actual_mpn:
+            issues.append(f"{ref}: exact MPN binding absent or changed")
+        if ref in resistor_values:
+            try:
+                actual = parse_unit_value(bound_symbol.value)
+                if actual.unit not in {"", "Ω"} or actual.value != resistor_values[ref]:
+                    issues.append(f"{ref}: modeled resistance differs from schematic")
+            except ValueError:
+                issues.append(f"{ref}: cannot resolve schematic resistance")
+    if issues:
+        return evidence
+    for network in networks:
+        try:
+            evidence["networks"].append(evaluate_network(network))
+        except (KeyError, TypeError, ValueError) as exc:
+            issues.append(f"{network.get('id', '<unnamed>')}: {exc}")
+    # A mutation during connectivity extraction invalidates the evidence too.
+    if path.read_bytes() != source:
+        issues.append("Schematic changed while calculating evidence")
+    evidence["bindings"] = bindings
+    for row in evidence["networks"]:
+        row["source_binding"] = "verified" if not issues else "incomplete"
+    evidence["status"] = (
+        "failed"
+        if any(row["status"] == "failed" for row in evidence["networks"])
+        else "incomplete"
+        if issues or any(row["status"] == "incomplete" for row in evidence["networks"])
+        else "sampled"
+    )
+    return evidence
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("schematic", type=Path)
+    parser.add_argument("policy", type=Path)
+    args = parser.parse_args(argv)
+    try:
+        report = analyze_thresholds(args.schematic, args.policy)
+    except (OSError, ValueError, KeyError, TypeError, AttributeError) as exc:
+        report = {"status": "incomplete", "release_eligible": False, "issues": [str(exc)]}
+    print(json.dumps(report, indent=2, allow_nan=False))
+    # Sampling can falsify a requirement, but cannot certify a release bound.
+    return 1 if report["status"] == "failed" else 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/kicad_tools/analysis/analog_threshold.py
+++ b/src/kicad_tools/analysis/analog_threshold.py
@@ -272,12 +272,14 @@ def analyze_thresholds(schematic: str | Path, policy_path: str | Path) -> dict[s
     if not networks:
         issues.append("No networks declared")
     needed: set[str] = set()
-    resistor_values: dict[str, float] = {}
+    resistor_values: dict[str, list[tuple[str, float]]] = {}
     for network in networks:
         for parts in network.get("resistors", {}).values():
             for part in parts:
                 needed.add(part["reference"])
-                resistor_values[part["reference"]] = part["ohms"]
+                resistor_values.setdefault(part["reference"], []).append(
+                    (network.get("id", "<unnamed>"), part["ohms"])
+                )
         devices = network.get("devices", {})
         required_devices = (
             {"comparator"}
@@ -307,8 +309,11 @@ def analyze_thresholds(schematic: str | Path, policy_path: str | Path) -> dict[s
         if ref in resistor_values:
             try:
                 actual = parse_unit_value(bound_symbol.value)
-                if actual.unit not in {"", "Ω"} or actual.value != resistor_values[ref]:
-                    issues.append(f"{ref}: modeled resistance differs from schematic")
+                for network_id, resistance in resistor_values[ref]:
+                    if actual.unit not in {"", "Ω"} or actual.value != resistance:
+                        issues.append(
+                            f"{network_id}: {ref}: modeled resistance differs from schematic"
+                        )
             except ValueError:
                 issues.append(f"{ref}: cannot resolve schematic resistance")
     if issues:

--- a/tests/fixtures/analog_threshold/softstart_partial.json
+++ b/tests/fixtures/analog_threshold/softstart_partial.json
@@ -1,0 +1,150 @@
+{
+  "id": "bank_interlock_partial",
+  "kind": "difference_comparator",
+  "resistors": {
+    "input_positive": [
+      {
+        "reference": "R1",
+        "ohms": 499000.0,
+        "tolerance": 0.001,
+        "source": "Issue #5064 illustrative \u00b10.1% resistor assumption; not supplier qualification"
+      },
+      {
+        "reference": "R2",
+        "ohms": 499000.0,
+        "tolerance": 0.001,
+        "source": "Issue #5064 illustrative \u00b10.1% resistor assumption; not supplier qualification"
+      },
+      {
+        "reference": "R3",
+        "ohms": 499000.0,
+        "tolerance": 0.001,
+        "source": "Issue #5064 illustrative \u00b10.1% resistor assumption; not supplier qualification"
+      },
+      {
+        "reference": "R4",
+        "ohms": 499000.0,
+        "tolerance": 0.001,
+        "source": "Issue #5064 illustrative \u00b10.1% resistor assumption; not supplier qualification"
+      }
+    ],
+    "input_negative": [
+      {
+        "reference": "R5",
+        "ohms": 499000.0,
+        "tolerance": 0.001,
+        "source": "Issue #5064 illustrative \u00b10.1% resistor assumption; not supplier qualification"
+      },
+      {
+        "reference": "R6",
+        "ohms": 499000.0,
+        "tolerance": 0.001,
+        "source": "Issue #5064 illustrative \u00b10.1% resistor assumption; not supplier qualification"
+      },
+      {
+        "reference": "R7",
+        "ohms": 499000.0,
+        "tolerance": 0.001,
+        "source": "Issue #5064 illustrative \u00b10.1% resistor assumption; not supplier qualification"
+      },
+      {
+        "reference": "R8",
+        "ohms": 499000.0,
+        "tolerance": 0.001,
+        "source": "Issue #5064 illustrative \u00b10.1% resistor assumption; not supplier qualification"
+      }
+    ],
+    "feedback": [
+      {
+        "reference": "R9",
+        "ohms": 10000.0,
+        "tolerance": 0.001,
+        "source": "Issue #5064 illustrative \u00b10.1% resistor assumption; not supplier qualification"
+      }
+    ],
+    "reference_arm": [
+      {
+        "reference": "R10",
+        "ohms": 10000.0,
+        "tolerance": 0.001,
+        "source": "Issue #5064 illustrative \u00b10.1% resistor assumption; not supplier qualification"
+      }
+    ],
+    "midpoint_top": [
+      {
+        "reference": "R11",
+        "ohms": 10000.0,
+        "tolerance": 0.001,
+        "source": "Issue #5064 illustrative \u00b10.1% resistor assumption; not supplier qualification"
+      }
+    ],
+    "midpoint_bottom": [
+      {
+        "reference": "R12",
+        "ohms": 10000.0,
+        "tolerance": 0.001,
+        "source": "Issue #5064 illustrative \u00b10.1% resistor assumption; not supplier qualification"
+      }
+    ],
+    "comparator_top": [
+      {
+        "reference": "R13",
+        "ohms": 41200.0,
+        "tolerance": 0.001,
+        "source": "Issue #5064 illustrative \u00b10.1% resistor assumption; not supplier qualification"
+      }
+    ],
+    "comparator_bottom": [
+      {
+        "reference": "R14",
+        "ohms": 10000.0,
+        "tolerance": 0.001,
+        "source": "Issue #5064 illustrative \u00b10.1% resistor assumption; not supplier qualification"
+      }
+    ],
+    "signal": [
+      {
+        "reference": "R15",
+        "ohms": 10000.0,
+        "tolerance": 0.001,
+        "source": "Issue #5064 illustrative \u00b10.1% resistor assumption; not supplier qualification"
+      }
+    ],
+    "hysteresis": [
+      {
+        "reference": "R16",
+        "ohms": 665000.0,
+        "tolerance": 0.001,
+        "source": "Issue #5064 illustrative \u00b10.1% resistor assumption; not supplier qualification"
+      }
+    ]
+  },
+  "bounds": {
+    "supply": {
+      "min": 3.234,
+      "nominal": 3.3,
+      "max": 3.366,
+      "source": "Issue #5064 assumed supply sweep"
+    },
+    "common_mode": {
+      "min": -250,
+      "nominal": 0,
+      "max": 250,
+      "source": "Issue #5064 terminal-average common-mode sweep"
+    }
+  },
+  "requirements": {
+    "falling": {
+      "min": 60,
+      "source": "Issue #5064 owner minimum bank voltage"
+    }
+  },
+  "unmodeled_terms": [
+    "Semiconductor error limits and reachable corner constraints not established"
+  ],
+  "devices": {
+    "amplifier": "U1",
+    "buffer": "U2",
+    "comparator": "U3"
+  }
+}

--- a/tests/test_analog_threshold.py
+++ b/tests/test_analog_threshold.py
@@ -1,0 +1,275 @@
+"""Correlated analog thresholds and source-bound, fail-visible sidecars."""
+
+import copy
+import hashlib
+import json
+from pathlib import Path
+
+import pytest
+
+from kicad_tools.analysis.analog_threshold import analyze_thresholds, evaluate_network, main
+
+FIXTURE = Path(__file__).parent / "fixtures/analog_threshold/softstart_partial.json"
+
+
+@pytest.fixture
+def network():
+    return json.loads(FIXTURE.read_text())
+
+
+def test_documented_partial_fixture(network):
+    result = evaluate_network(network)
+    assert result["vertices"] == 4096
+    rising, falling = result["thresholds"]["rising"], result["thresholds"]["falling"]
+    assert rising["nominal_v"] == pytest.approx(70.24398, abs=0.00001)
+    assert falling["nominal_v"] == pytest.approx(60.33902, abs=0.00001)
+    assert (rising["sample_min_v"], rising["sample_max_v"]) == pytest.approx(
+        (67.66329, 72.83212), abs=0.00001
+    )
+    assert (falling["sample_min_v"], falling["sample_max_v"]) == pytest.approx(
+        (57.96032, 62.72502), abs=0.00001
+    )
+    assert result["status"] == "failed"
+    assert result["coverage"] == "incomplete"
+    assert result["omitted_terms"]
+    assert not result["release_eligible"]
+
+
+def bounded(network):
+    network["unmodeled_terms"] = []
+    network["conditions"] = {
+        "temperature_c": {"min": 25, "nominal": 25, "max": 25, "source": "ideal fixture"},
+        "linear_operation": "explicit ideal fixture",
+    }
+    for key in (
+        "amplifier_offset",
+        "buffer_offset",
+        "comparator_offset",
+        "output_low",
+        "output_high_drop",
+    ):
+        network["bounds"][key] = {
+            "min": 0,
+            "nominal": 0,
+            "max": 0,
+            "source": "Explicit ideal fixture assumption",
+        }
+    network["requirements"]["falling"]["min"] = 50
+    return network
+
+
+def test_bounded_vertices_are_never_promoted_to_proof(network):
+    result = evaluate_network(bounded(network))
+    assert result["status"] == "sampled"
+    assert result["bound_method"] == "vertex_sampling_not_a_proven_enclosure"
+    assert not result["release_eligible"]
+
+
+def test_missing_error_bound_cannot_qualify(network):
+    network["requirements"]["falling"]["min"] = 50
+    result = evaluate_network(network)
+    assert result["status"] == "incomplete"
+    assert any("amplifier_offset" in text for text in result["omitted_terms"])
+
+
+def test_common_mode_translation_and_shared_supply(network):
+    # Matched ideal resistor ratios reject arbitrary input common-mode.
+    for parts in network["resistors"].values():
+        for part in parts:
+            part["tolerance"] = 0
+    baseline = evaluate_network(bounded(network))
+    network["bounds"]["common_mode"] = {
+        "min": 200,
+        "nominal": 200,
+        "max": 200,
+        "source": "Translated terminals",
+    }
+    moved = evaluate_network(network)
+    for edge in ("rising", "falling", "hysteresis"):
+        assert moved["thresholds"][edge]["sample_min_v"] == pytest.approx(
+            baseline["thresholds"][edge]["sample_min_v"]
+        )
+        assert moved["thresholds"][edge]["sample_max_v"] == pytest.approx(
+            baseline["thresholds"][edge]["sample_max_v"]
+        )
+    # Same supply sets reference, midpoint AND comparator high output.
+    expected = (10000 / 665000) / (10000 / 1996000)
+    hyst = moved["thresholds"]["hysteresis"]
+    assert hyst["sample_min_v"] == pytest.approx(3.234 * expected)
+    assert hyst["sample_max_v"] == pytest.approx(3.366 * expected)
+
+
+def test_offset_and_output_swing_change_thresholds(network):
+    ideal = evaluate_network(bounded(network))
+    network["bounds"]["comparator_offset"] = {
+        "min": 0.001,
+        "nominal": 0.001,
+        "max": 0.001,
+        "source": "Fixture input offset",
+    }
+    offset = evaluate_network(network)
+    assert offset["thresholds"]["rising"]["nominal_v"] > ideal["thresholds"]["rising"]["nominal_v"]
+    network["bounds"]["output_high_drop"] = {
+        "min": 0.2,
+        "nominal": 0.2,
+        "max": 0.2,
+        "source": "Fixture high-level drop",
+    }
+    swing = evaluate_network(network)
+    assert (
+        swing["thresholds"]["falling"]["nominal_v"] > offset["thresholds"]["falling"]["nominal_v"]
+    )
+    assert (
+        swing["thresholds"]["hysteresis"]["nominal_v"]
+        < offset["thresholds"]["hysteresis"]["nominal_v"]
+    )
+
+
+def divider():
+    return {
+        "id": "divider",
+        "conditions": {
+            "temperature_c": {"min": 25, "nominal": 25, "max": 25, "source": "ideal fixture"},
+            "linear_operation": "ideal test model",
+        },
+        "kind": "divider",
+        "resistors": {
+            "top": [{"reference": "R1", "ohms": 100, "tolerance": 0.01, "source": "fixture"}],
+            "bottom": [{"reference": "R2", "ohms": 220, "tolerance": 0.01, "source": "fixture"}],
+        },
+        "bounds": {
+            "reference": {"min": 1, "nominal": 1, "max": 1, "source": "fixture"},
+            "comparator_offset": {"min": 0, "nominal": 0, "max": 0, "source": "fixture"},
+        },
+        "requirements": {"rising": {"max": 2, "source": "fixture"}},
+        "devices": {"comparator": "D1"},
+    }
+
+
+def test_simple_divider():
+    result = evaluate_network(divider())
+    assert result["thresholds"]["rising"]["nominal_v"] == pytest.approx(1 + 100 / 220)
+    assert result["thresholds"]["rising"]["sample_max_v"] == pytest.approx(1 + 101 / 217.8)
+    assert result["thresholds"]["hysteresis"]["sample_max_v"] == 0
+
+
+@pytest.mark.parametrize("bad", [-1, float("nan"), True, "0.1"])
+def test_invalid_tolerance_rejected(network, bad):
+    network["resistors"]["signal"][0]["tolerance"] = bad
+    with pytest.raises(ValueError):
+        evaluate_network(network)
+
+
+def test_duplicate_role_and_missing_source(network):
+    network["resistors"]["signal"] = copy.deepcopy(network["resistors"]["feedback"])
+    with pytest.raises(ValueError, match="Duplicate"):
+        evaluate_network(network)
+
+
+@pytest.fixture
+def bound_files(tmp_path):
+    # This validates identity/connectivity binding, not the physical topology of
+    # the divider template. The topology itself is explicitly reviewed input.
+    from kicad_tools.operations.netlist import build_netlist_from_schematic
+    from kicad_tools.schema.schematic import Schematic
+    from kicad_tools.sexp import SExp, parse_file
+
+    source = Path(__file__).parent / "fixtures/electrical_rating/leds.kicad_sch"
+    tree = parse_file(source)
+    for symbol in tree.find_all("symbol"):
+        reference = next(
+            (
+                p.get_string(1)
+                for p in symbol.find_all("property")
+                if p.get_string(0) == "Reference"
+            ),
+            None,
+        )
+        if reference in {"R1", "R2", "D1"}:
+            symbol.children.append(SExp.list("property", "MPN", f"FIXTURE-{reference}"))
+    path = tmp_path / "bound.kicad_sch"
+    path.write_text(tree.to_string())
+    sch = Schematic.load(path)
+    nets = build_netlist_from_schematic(path)
+    bindings = {}
+    for symbol in sch.symbols:
+        if symbol.reference not in {"R1", "R2", "D1"}:
+            continue
+        bindings[symbol.reference] = {
+            "value": symbol.value,
+            "mpn": f"FIXTURE-{symbol.reference}",
+            "pins": {
+                node.pin: net.name
+                for net in nets.nets
+                for node in net.nodes
+                if node.reference == symbol.reference
+            },
+        }
+    policy = {
+        "schema_version": 1,
+        "schematic_sha256": hashlib.sha256(path.read_bytes()).hexdigest(),
+        "bindings": bindings,
+        "networks": [divider()],
+    }
+    sidecar = tmp_path / "thresholds.json"
+    sidecar.write_text(json.dumps(policy))
+    return path, sidecar, policy
+
+
+def test_source_bound_report_and_cli(bound_files, capsys):
+    path, sidecar, _ = bound_files
+    report = analyze_thresholds(path, sidecar)
+    assert report["status"] == "sampled", report
+    assert report["policy_sha256"] == hashlib.sha256(sidecar.read_bytes()).hexdigest()
+    assert main([str(path), str(sidecar)]) == 2
+    assert not json.loads(capsys.readouterr().out)["release_eligible"]
+
+
+@pytest.mark.parametrize("field", ["value", "mpn", "pins"])
+def test_binding_mismatch_is_incomplete(bound_files, field):
+    path, sidecar, policy = bound_files
+    policy["bindings"]["R1"][field] = {"1": "wrong"} if field == "pins" else "changed"
+    sidecar.write_text(json.dumps(policy))
+    result = analyze_thresholds(path, sidecar)
+    assert result["status"] == "incomplete" and result["issues"]
+    assert not result["networks"]
+
+
+def test_source_hash_change_invalidates_bindings(bound_files):
+    path, sidecar, _ = bound_files
+    path.write_text(path.read_text() + "\n")
+    result = analyze_thresholds(path, sidecar)
+    assert result["status"] == "incomplete"
+    assert "Stale" in result["issues"][0]
+
+
+def test_missing_operating_condition_is_incomplete(network):
+    bounded(network)
+    del network["conditions"]["temperature_c"]
+    result = evaluate_network(network)
+    assert result["status"] == "incomplete"
+    assert any("temperature" in item for item in result["omitted_terms"])
+
+
+def test_missing_resistor_tolerance_is_incomplete(network):
+    bounded(network)
+    del network["resistors"]["signal"][0]["tolerance"]
+    assert evaluate_network(network)["status"] == "incomplete"
+
+
+def test_bad_policy_is_json_incomplete(tmp_path, capsys):
+    source, policy = tmp_path / "test.kicad_sch", tmp_path / "policy.json"
+    source.write_text("(kicad_sch)")
+    policy.write_text("[]")
+    assert main([str(source), str(policy)]) == 2
+    assert json.loads(capsys.readouterr().out)["status"] == "incomplete"
+
+
+def test_failed_declared_requirement_cli(bound_files, capsys):
+    path, sidecar, policy = bound_files
+    policy["networks"][0]["requirements"]["rising"]["max"] = 1
+    sidecar.write_text(json.dumps(policy))
+    assert main([str(path), str(sidecar)]) == 1
+    result = json.loads(capsys.readouterr().out)
+    assert result["status"] == "failed"
+    assert result["networks"][0]["source_binding"] == "verified"

--- a/tests/test_analog_threshold.py
+++ b/tests/test_analog_threshold.py
@@ -273,3 +273,31 @@ def test_failed_declared_requirement_cli(bound_files, capsys):
     result = json.loads(capsys.readouterr().out)
     assert result["status"] == "failed"
     assert result["networks"][0]["source_binding"] == "verified"
+
+
+@pytest.mark.parametrize("conflict_first", [True, False])
+def test_cross_network_resistance_conflict_is_incomplete(bound_files, conflict_first):
+    path, sidecar, policy = bound_files
+    conflicting = copy.deepcopy(policy["networks"][0])
+    conflicting["id"] = "conflicting-network"
+    conflicting["resistors"]["top"][0]["ohms"] = 10
+    policy["networks"].insert(0 if conflict_first else 1, conflicting)
+    sidecar.write_text(json.dumps(policy))
+    report = analyze_thresholds(path, sidecar)
+    assert report["status"] == "incomplete"
+    assert not report["networks"]
+    assert any("conflicting-network: R1: modeled resistance" in issue for issue in report["issues"])
+
+
+def test_consistent_resistor_reuse_across_networks_is_bound(bound_files):
+    path, sidecar, policy = bound_files
+    repeated = copy.deepcopy(policy["networks"][0])
+    repeated["id"] = "second-network"
+    policy["networks"].append(repeated)
+    sidecar.write_text(json.dumps(policy))
+    report = analyze_thresholds(path, sidecar)
+    assert report["status"] == "sampled", report
+    assert not report["issues"]
+    assert len(report["networks"]) == 2
+    assert all(row["source_binding"] == "verified" for row in report["networks"])
+    assert report["networks"][0]["thresholds"] == report["networks"][1]["thresholds"]


### PR DESCRIPTION
A nominal comparator threshold can meet a voltage floor while tolerance corners violate it. Add an explicit analog-network sidecar and JSON report that preserves shared-source correlations and separates sampled violations from incomplete or unproven evidence.

The bounded evaluator supports a divider and a difference-amplifier/positive-feedback comparator template. It computes nominal and vertex-sampled rising/falling thresholds and same-corner hysteresis, with resistor tolerances, supply/common-mode ranges, offsets and output swing. It records extrema corners, references/nets, requirements, provenance, operating conditions and omitted terms. Missing bounds and conditions remain incomplete; sampled coverage never becomes a proven bound or release approval.

The module CLI binds flat-schematic source bytes and policy hashes, exact values/MPNs and declared pin/net connections. Stale or unresolved bindings stop calculation; hierarchical source binding is explicitly incomplete. Role/topology assignment remains reviewed sidecar input, not automatic inference. No native/supplier hardware guarantees or automatic circuit qualification are claimed.

Validation:
- 56 focused and existing electrical-rating tests passed; Ruff check/format and focused mypy passed.
- The included illustrative #5064 fixture reproduces nominal rising/falling 70.24398/60.33902 V and the 4,096-vertex ranges 67.66329–72.83212 / 57.96032–62.72502 V. The sampled falling floor violates 60 V while missing semiconductor bounds remain visible.
- Tests cover simple divider math, shared-supply and common-mode controls, offsets/output swing, missing temperature/error/tolerance bounds, malformed policy, stale source/MPN/value/pin bindings and CLI nonzero states.
- Actual cold baseline gate exited 0: 1,463 diagnostics, all within 1,472 allowed.
- Source and policy sidecars are read-only; no baseline/configuration/dependency changes.

TDD: no — implementation and regression fixtures developed together from the issue's supplied equations and numerical example. The fixture is an illustrative partial model, not a sourced semiconductor limit or proven operating envelope.

Closes #5064