### PR TITLE
feat(analysis): review weak-source loading and gate-drive budgets

### DIFF
--- a/docs/guides/drive-budget.md
+++ b/docs/guides/drive-budget.md
@@ -1,0 +1,98 @@
+# Weak-source and gate-drive budget review
+
+Run a declared budget without modifying design files:
+
+```sh
+uv run python -m kicad_tools.analysis.drive_budget drive-budget.json > drive-report.json
+```
+
+The report distinguishes nominal shortfalls from shortfalls proved by supplied
+upper/lower bounds. Exit 1 means a guaranteed optimistic voltage ceiling is below
+the target; exit 2 means incomplete evidence, including a nominal shortfall.
+**This screen never returns a qualification pass.** An upper ceiling above the
+target does not establish available current at the loaded operating point,
+current gain, collector headroom, switching performance or hardware readiness.
+
+`DriveBudget.model_json_schema()` in `kicad_tools.analysis.drive_budget` provides
+the full schema. Every electrical quantity carries `value`, `basis`, originating
+`part` and `source`. Basis is explicitly `nominal`, `upper_bound` or `lower_bound`.
+Do not relabel typical values or a minimum short-circuit current as an upper
+bound. Values must be finite, nonnegative and no greater than 1e18; nonzero
+quantities must be at least 1e-18. Resistance and effective capacitance are positive.
+
+## Inputs and outputs
+
+The schema requires `schema_version: 1`, a named `state`, `topology`,
+`target_drive_v`, `duration_s`, explicit `assumptions` and `unmodeled_effects`.
+Electrical quantities (each in the four-field form above) are:
+
+| Field | Meaning |
+|---|---|
+| `source_current_cap_a` | Declared optimistic source-current ceiling, not an assumption that short-circuit current is available at nonzero voltage |
+| `source_voltage_cap_v` | Declared optimistic source-voltage ceiling |
+| `bias_resistance_ohm` | Source/base-node resistance to its floating reference |
+| `follower_drop_v` | Nonnegative base-to-emitter drop for the declared follower |
+| `bleeder_resistance_ohm` | Static gate/source bleeder load |
+| `reservoir_initial_v` | Initial reservoir voltage |
+| `reservoir_effective_f` | Effective capacitance under the stated voltage/temperature conditions |
+| `gate_charge_c` | Total charge drawn at the edge, including all simultaneously driven gates |
+| `additional_static_a` | Additional constant load during the state |
+
+The implemented source screen is an **emitter follower**. It reports an optimistic
+base ceiling `min(I_cap R_bias, V_cap)` and subtracts the declared nonnegative
+drop. Collector reservoir voltage cannot increase this ceiling. Base loading is
+omitted deliberately, so the estimate is optimistic. An unsupported topology is
+explicitly incomplete; no voltage-gain topology is silently mapped to a follower.
+
+For a guaranteed shortfall, only directionally valid inputs participate: an
+upper source-current bound times an upper bias-resistance bound, or an upper
+source-voltage bound. A lower bound on follower drop can tighten that ceiling;
+otherwise zero drop is used optimistically. A source-current minimum alone
+cannot establish a maximum output voltage. Full source I/V curves and nonlinear
+loaded operating-point solutions remain explicit simulation/review work; this
+first screen consumes declared I/V **ceilings**, not inferred curve interpolation.
+
+Outputs also include required bias current at the target, nominal source-current
+headroom, static bleeder current, gate charge voltage step, and charge demand
+versus reservoir charge available above the target. Every originating part and
+source is retained in the report, with the complete input sidecar's SHA256.
+
+## Reservoir models
+
+Two ideal alternatives are reported separately; neither proves the actual
+collector/gate circuit follows that load law:
+
+1. Instant gate-charge loss `Q/C`, then an RC bleeder in parallel with a declared
+   constant additional current. The residual voltage is clamped at zero.
+2. Instant gate-charge loss, then constant current equal to target voltage divided
+   by bleeder resistance plus additional static load.
+
+A regulated emitter output and a freely decaying RC node have different load
+laws. The report does not quietly choose one as verified topology. User-supplied
+bound labels remain visible, but these reservoir calculations are labeled nominal
+model estimates, not guaranteed switching behavior. Base current, minimum gain,
+collector headroom, leakage, dynamic gate charge, MLCC bias loss and transient
+coupling need evidence or remain listed as unmodeled. No post-edge load disappears
+just because the gate has finished charging.
+
+## Reproduction values
+
+[Vishay VOM1271 revision 1.9](https://www.vishay.com/docs/83469/vom1271.pdf)
+identifies 15 µA short-circuit current and 8.4 V open-circuit voltage as typical
+at 10 mA LED current. Its 6 µA minimum short-circuit current is not a guaranteed
+upper bound. With an optimistic 15 µA available and a 100k bias resistor, the base
+ceiling is only 1.5 V before transistor loading. These inputs must remain nominal;
+the report flags a nominal shortfall against a 12 V target, not a guaranteed
+manufacturer limit.
+
+A 10k bleeder at 12 V draws 1.2 mA. A 10 µF reservoir with that ideal RC load loses
+about 0.923 V over 8 ms, even with zero gate charge and zero additional current.
+The constant 1.2 mA alternative loses 0.96 V. Additional charge and current worsen
+both budgets.
+
+Optional `crossing` inputs are `rms_voltage_v`, `frequency_hz`, `threshold_v`.
+For a sinusoid, the full interval around **one** zero crossing below the absolute
+threshold is `asin(threshold / (sqrt(2) Vrms)) / (pi frequency)`. At 120 Vrms,
+60 Hz and 10 V it is about 0.313 ms, with two such intervals per cycle. At or
+above peak voltage, the entire cycle is within the threshold and the report
+returns one full-period interval instead of double-counting it.

--- a/src/kicad_tools/analysis/drive_budget.py
+++ b/src/kicad_tools/analysis/drive_budget.py
@@ -1,0 +1,221 @@
+"""Explicit weak-source and ideal gate-reservoir budget review (#5041).
+
+These checks can disprove a drive target; sufficient current gain, switching
+behavior and nonlinear source loading still require simulation or review.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import math
+from pathlib import Path
+from typing import Any, Literal
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+
+class Record(BaseModel):
+    model_config = ConfigDict(extra="forbid", strict=True, allow_inf_nan=False)
+
+
+class Quantity(Record):
+    value: float = Field(ge=0, le=1e18)
+    basis: Literal["nominal", "upper_bound", "lower_bound"]
+    part: str = Field(min_length=1)
+    source: str = Field(min_length=1)
+
+    @model_validator(mode="after")
+    def numeric_range(self) -> Quantity:
+        if 0 < self.value < 1e-18:
+            raise ValueError("nonzero quantities must be at least 1e-18")
+        return self
+
+
+class Crossing(Record):
+    rms_voltage_v: float = Field(gt=1e-18, le=1e18)
+    frequency_hz: float = Field(gt=1e-18, le=1e18)
+    threshold_v: float = Field(ge=0, le=1e18)
+
+
+class DriveBudget(Record):
+    schema_version: Literal[1]
+    topology: str = Field(min_length=1)
+    state: str = Field(min_length=1)
+    target_drive_v: float = Field(gt=0, le=1e18)
+    duration_s: float = Field(ge=0, le=1e18)
+    source_current_cap_a: Quantity
+    source_voltage_cap_v: Quantity
+    bias_resistance_ohm: Quantity
+    follower_drop_v: Quantity
+    bleeder_resistance_ohm: Quantity
+    reservoir_initial_v: Quantity
+    reservoir_effective_f: Quantity
+    gate_charge_c: Quantity
+    additional_static_a: Quantity
+    assumptions: list[str] = Field(min_length=1)
+    unmodeled_effects: list[str]
+    crossing: Crossing | None = None
+
+    @model_validator(mode="after")
+    def positive_divisors(self) -> DriveBudget:
+        for name in ("bias_resistance_ohm", "bleeder_resistance_ohm", "reservoir_effective_f"):
+            if getattr(self, name).value == 0:
+                raise ValueError(f"{name} must be positive")
+        if 0 < self.duration_s < 1e-18 or self.target_drive_v < 1e-18:
+            raise ValueError("nonzero policy quantities must be at least 1e-18")
+        return self
+
+
+def crossing_window(
+    rms_voltage_v: float, frequency_hz: float, threshold_v: float
+) -> dict[str, float]:
+    """Full interval around ONE zero crossing, and fraction of the whole cycle."""
+    data = Crossing(rms_voltage_v=rms_voltage_v, frequency_hz=frequency_hz, threshold_v=threshold_v)
+    ratio = data.threshold_v / (data.rms_voltage_v * math.sqrt(2))
+    if ratio >= 1:
+        return {"window_s": 1 / data.frequency_hz, "cycle_fraction": 1.0, "windows_per_cycle": 1.0}
+    angle = math.asin(ratio)
+    return {
+        "window_s": angle / (math.pi * data.frequency_hz),
+        "cycle_fraction": 2 * angle / math.pi,
+        "windows_per_cycle": 2.0,
+    }
+
+
+def analyze_drive_budget(budget: DriveBudget) -> dict[str, Any]:
+    """Report nominal estimates and directionally valid bounds separately.
+
+    No successful upper-bound screen proves the operating point is achievable.
+    Reservoir estimates use a declared ideal RC load, instant gate-charge draw,
+    and constant additional load; they are never a switching qualification.
+    """
+    q = budget
+    optimistic_base = min(
+        q.source_voltage_cap_v.value, q.source_current_cap_a.value * q.bias_resistance_ohm.value
+    )
+    optimistic_drive = max(0.0, optimistic_base - q.follower_drop_v.value)
+    bleeder_a = q.target_drive_v / q.bleeder_resistance_ohm.value
+    charge_step_v = q.gate_charge_c.value / q.reservoir_effective_f.value
+    initial_after_charge = max(0.0, q.reservoir_initial_v.value - charge_step_v)
+    resistance = q.bleeder_resistance_ohm.value
+    capacitance = q.reservoir_effective_f.value
+    static = q.additional_static_a.value
+    decay_loss = -math.expm1(-q.duration_s / (resistance * capacitance))
+    # expm1 avoids cancellation when t << RC. Clamp after computing losses;
+    # an exhausted reservoir is reported explicitly, not modeled negative.
+    loss = (initial_after_charge + static * resistance) * decay_loss
+    end_v = max(0.0, initial_after_charge - loss)
+    constant_load_end = max(
+        0.0, initial_after_charge - (bleeder_a + static) * q.duration_s / capacitance
+    )
+    missing = [
+        "Upper-bound source screening does not establish available current at the loaded operating voltage",
+        "Transistor base current, minimum current gain, collector headroom and switching transients require review",
+    ]
+    failures = []
+    nominal_shortfalls = []
+    supported = q.topology == "emitter_follower"
+    if not supported:
+        missing.append(f"Unsupported nonlinear topology: {q.topology}")
+    elif optimistic_drive < q.target_drive_v:
+        nominal_shortfalls.append(
+            "Optimistic emitter-follower drive voltage below target; collector reservoir provides no voltage gain"
+        )
+    guaranteed_candidates = []
+    if (
+        q.source_current_cap_a.basis == "upper_bound"
+        and q.bias_resistance_ohm.basis == "upper_bound"
+    ):
+        guaranteed_candidates.append(q.source_current_cap_a.value * q.bias_resistance_ohm.value)
+    if q.source_voltage_cap_v.basis == "upper_bound":
+        guaranteed_candidates.append(q.source_voltage_cap_v.value)
+    guaranteed_drive_ceiling = None
+    if supported and guaranteed_candidates:
+        # Without a guaranteed minimum drop, zero is the optimistic passive drop.
+        drop = q.follower_drop_v.value if q.follower_drop_v.basis == "lower_bound" else 0.0
+        guaranteed_drive_ceiling = max(0.0, min(guaranteed_candidates) - drop)
+        if guaranteed_drive_ceiling < q.target_drive_v:
+            failures.append("Guaranteed optimistic voltage ceiling is below required drive")
+    if end_v < q.target_drive_v:
+        nominal_shortfalls.append("Ideal RC reservoir voltage falls below target before state ends")
+    if constant_load_end < q.target_drive_v:
+        nominal_shortfalls.append(
+            "Constant target-voltage bleeder model falls below target before state ends"
+        )
+    required_bias_a = (q.target_drive_v + q.follower_drop_v.value) / q.bias_resistance_ohm.value
+    charge_demand = q.gate_charge_c.value + (bleeder_a + static) * q.duration_s
+    available_charge = max(0.0, q.reservoir_initial_v.value - q.target_drive_v) * capacitance
+    if supported and required_bias_a > q.source_current_cap_a.value:
+        nominal_shortfalls.append(
+            "Bias current required at target exceeds declared source current ceiling"
+        )
+    if charge_demand > available_charge:
+        nominal_shortfalls.append(
+            "Gate plus static-load charge exceeds reservoir charge available above target"
+        )
+    quantities = {
+        name: getattr(q, name).model_dump()
+        for name in (
+            "source_current_cap_a",
+            "source_voltage_cap_v",
+            "bias_resistance_ohm",
+            "follower_drop_v",
+            "bleeder_resistance_ohm",
+            "reservoir_initial_v",
+            "reservoir_effective_f",
+            "gate_charge_c",
+            "additional_static_a",
+        )
+    }
+    metrics = {
+        "optimistic_base_v": optimistic_base,
+        "optimistic_drive_v": optimistic_drive if supported else None,
+        "bleeder_current_at_target_a": bleeder_a,
+        "bias_current_at_target_a": required_bias_a,
+        "nominal_source_current_headroom_a": q.source_current_cap_a.value - required_bias_a,
+        "constant_target_charge_demand_c": charge_demand,
+        "reservoir_charge_available_above_target_c": available_charge,
+        "gate_charge_step_v": charge_step_v,
+        "ideal_rc_end_v": end_v,
+        "ideal_rc_droop_v": q.reservoir_initial_v.value - end_v,
+        "constant_target_load_end_v": constant_load_end,
+        "gate_charge_exceeds_initial_reservoir": charge_step_v > q.reservoir_initial_v.value,
+    }
+    if not all(math.isfinite(v) for v in metrics.values() if isinstance(v, (int, float))):
+        raise ValueError("budget arithmetic outside supported range")
+    return {
+        "schema_version": 1,
+        "state": q.state,
+        "topology": q.topology,
+        "status": "fail" if failures else "incomplete",
+        "guaranteed_failures": failures,
+        "guaranteed_drive_ceiling_v": guaranteed_drive_ceiling,
+        "nominal_shortfalls": nominal_shortfalls,
+        "nominal_metrics": metrics,
+        "quantities": quantities,
+        "assumptions": q.assumptions,
+        "unmodeled_effects": missing + q.unmodeled_effects,
+        "crossing": crossing_window(**q.crossing.model_dump()) if q.crossing else None,
+        "scope": "Review of declared weak-source ceilings and ideal reservoir budgets; never manufacturing approval",
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("sidecar", type=Path)
+    args = parser.parse_args(argv)
+    try:
+        raw = args.sidecar.read_bytes()
+        result = analyze_drive_budget(DriveBudget.model_validate_json(raw))
+        result["sidecar_sha256"] = hashlib.sha256(raw).hexdigest()
+        print(json.dumps(result, indent=2, allow_nan=False))
+    except (OSError, ValueError, OverflowError) as exc:
+        print(json.dumps({"status": "incomplete", "error": str(exc)}))
+        return 2
+    return 1 if result["status"] == "fail" else 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_drive_budget.py
+++ b/tests/test_drive_budget.py
@@ -1,0 +1,166 @@
+"""Independent arithmetic and fail-visible evidence controls for drive budgets."""
+
+import json
+import math
+
+import pytest
+
+from kicad_tools.analysis.drive_budget import (
+    DriveBudget,
+    analyze_drive_budget,
+    crossing_window,
+    main,
+)
+
+
+def quantity(value, basis="nominal", part="reviewed-part"):
+    return {
+        "value": value,
+        "basis": basis,
+        "part": part,
+        "source": "Explicit synthetic operating-condition fixture",
+    }
+
+
+@pytest.fixture
+def data():
+    return {
+        "schema_version": 1,
+        "topology": "emitter_follower",
+        "state": "hold",
+        "target_drive_v": 12,
+        "duration_s": 0.008,
+        "source_current_cap_a": quantity(15e-6, part="U10"),
+        "source_voltage_cap_v": quantity(8.4, part="U10"),
+        "bias_resistance_ohm": quantity(100e3, part="R46"),
+        "follower_drop_v": quantity(0, part="Q9"),
+        "bleeder_resistance_ohm": quantity(10e3, part="R_GS"),
+        "reservoir_initial_v": quantity(12, part="C_RES"),
+        "reservoir_effective_f": quantity(10e-6, part="C_RES"),
+        "gate_charge_c": quantity(0, part="Q_SWITCH"),
+        "additional_static_a": quantity(0),
+        "assumptions": ["Optimistically ignore base current"],
+        "unmodeled_effects": ["MLCC effective capacitance must be reviewed at operating bias"],
+        "crossing": {"rms_voltage_v": 120, "frequency_hz": 60, "threshold_v": 10},
+    }
+
+
+def analyze(data):
+    return analyze_drive_budget(DriveBudget.model_validate_json(json.dumps(data)))
+
+
+def test_photovoltaic_current_booster_cannot_supply_voltage_gain(data):
+    report = analyze(data)
+    assert report["nominal_metrics"]["optimistic_base_v"] == pytest.approx(1.5)
+    assert report["nominal_metrics"]["optimistic_drive_v"] == pytest.approx(1.5)
+    assert report["nominal_metrics"]["bias_current_at_target_a"] == pytest.approx(120e-6)
+    assert report["nominal_shortfalls"]
+    assert report["status"] == "incomplete"  # typical is never a guaranteed limit
+    assert report["guaranteed_drive_ceiling_v"] is None
+    data["reservoir_initial_v"]["value"] = 100
+    assert analyze(data)["nominal_metrics"]["optimistic_drive_v"] == pytest.approx(1.5)
+    data["bias_resistance_ohm"]["value"] = 1e9
+    assert analyze(data)["nominal_metrics"]["optimistic_drive_v"] == 8.4
+
+
+def test_bleeder_remains_loaded_after_switching_edge(data):
+    metrics = analyze(data)["nominal_metrics"]
+    assert metrics["bleeder_current_at_target_a"] == pytest.approx(0.0012)
+    assert metrics["ideal_rc_end_v"] == pytest.approx(12 * math.exp(-0.08))
+    assert metrics["ideal_rc_droop_v"] == pytest.approx(0.92260384)
+    assert metrics["constant_target_load_end_v"] == pytest.approx(11.04)
+    assert metrics["constant_target_charge_demand_c"] == pytest.approx(9.6e-6)
+    data["gate_charge_c"]["value"] = 1e-6
+    data["additional_static_a"]["value"] = 0.0001
+    changed = analyze(data)["nominal_metrics"]
+    assert changed["gate_charge_step_v"] == pytest.approx(0.1)
+    assert changed["ideal_rc_end_v"] == pytest.approx((11.9 + 1) * math.exp(-0.08) - 1)
+    assert changed["ideal_rc_end_v"] < metrics["ideal_rc_end_v"]
+
+
+def test_sine_crossing_full_window_not_quarter_window(data):
+    report = analyze(data)["crossing"]
+    assert report["window_s"] == pytest.approx(0.00031278, rel=0.001)
+    assert report["windows_per_cycle"] == 2
+    assert report["cycle_fraction"] == pytest.approx(report["window_s"] * 60 * 2)
+    assert crossing_window(120, 60, 0)["window_s"] == 0
+    assert crossing_window(120, 60, 200)["window_s"] == pytest.approx(1 / 60)
+    assert crossing_window(120, 60, 200)["windows_per_cycle"] == 1
+
+
+def test_only_correct_bound_directions_prove_voltage_shortfall(data):
+    data["source_current_cap_a"]["basis"] = "upper_bound"
+    data["bias_resistance_ohm"]["basis"] = "upper_bound"
+    report = analyze(data)
+    assert report["status"] == "fail"
+    assert report["guaranteed_drive_ceiling_v"] == pytest.approx(1.5)
+    data["source_current_cap_a"]["basis"] = "lower_bound"  # ISC minimum is NOT an upper bound
+    assert analyze(data)["status"] == "incomplete"
+    data["source_voltage_cap_v"]["basis"] = "upper_bound"
+    assert analyze(data)["guaranteed_drive_ceiling_v"] == 8.4
+
+
+def test_wrong_drop_bound_is_not_used_to_prove_failure(data):
+    data["target_drive_v"] = 8
+    data["source_voltage_cap_v"]["basis"] = "upper_bound"
+    data["follower_drop_v"] = quantity(1, "upper_bound")
+    assert analyze(data)["status"] == "incomplete"
+    data["follower_drop_v"]["basis"] = "lower_bound"
+    assert analyze(data)["status"] == "fail"
+
+
+def test_unknown_topology_cannot_inherit_follower_verdict(data):
+    data["topology"] = "nonlinear_boost_converter"
+    data["source_voltage_cap_v"]["basis"] = "upper_bound"
+    report = analyze(data)
+    assert report["status"] == "incomplete"
+    assert report["nominal_metrics"]["optimistic_drive_v"] is None
+    assert any("Unsupported" in x for x in report["unmodeled_effects"])
+
+
+def test_excess_gate_charge_exhausts_reservoir_without_negative_voltage(data):
+    data["gate_charge_c"]["value"] = 1
+    report = analyze(data)
+    assert report["nominal_metrics"]["gate_charge_exceeds_initial_reservoir"]
+    assert report["nominal_metrics"]["ideal_rc_end_v"] == 0
+    assert report["nominal_metrics"]["constant_target_load_end_v"] == 0
+
+
+@pytest.mark.parametrize(
+    "field,value",
+    [
+        ("reservoir_effective_f", 0),
+        ("bleeder_resistance_ohm", 0),
+        ("source_current_cap_a", float("nan")),
+        ("source_voltage_cap_v", 1e308),
+        ("reservoir_effective_f", 1e-300),
+    ],
+)
+def test_invalid_budget_cannot_return_green(data, field, value):
+    data[field]["value"] = value
+    with pytest.raises(ValueError):
+        analyze(data)
+
+
+def test_successful_ceiling_screen_does_not_prove_loaded_operating_point(data):
+    data["source_current_cap_a"]["value"] = 0.1
+    data["source_voltage_cap_v"]["value"] = 20
+    data["source_voltage_cap_v"]["basis"] = "upper_bound"
+    report = analyze(data)
+    assert report["status"] == "incomplete"
+    assert report["guaranteed_drive_ceiling_v"] == 20
+    assert any("loaded operating voltage" in item for item in report["unmodeled_effects"])
+
+
+def test_cli_preserves_input_and_provenance(data, tmp_path, capsys):
+    path = tmp_path / "drive.json"
+    path.write_text(json.dumps(data))
+    raw = path.read_bytes()
+    assert main([str(path)]) == 2
+    result = json.loads(capsys.readouterr().out)
+    assert result["quantities"]["source_current_cap_a"]["part"] == "U10"
+    assert len(result["sidecar_sha256"]) == 64
+    assert path.read_bytes() == raw
+    data["source_voltage_cap_v"]["basis"] = "upper_bound"
+    path.write_text(json.dumps(data))
+    assert main([str(path)]) == 1


### PR DESCRIPTION
A weak current source driving an emitter follower cannot use the collector reservoir to raise its base/emitter voltage, and a gate bleeder continues loading the reservoir after an edge. This adds an explicit, provenance-bearing Python/JSON review report for those voltage/current/charge budgets and sinusoidal crossing windows.

Nominal estimates are separated from directionally valid guaranteed ceilings. Typical values and a successful ceiling screen never produce a qualification pass; unsupported nonlinear topologies stay incomplete. The ideal RC and constant-target-load reservoir models are reported separately, with gate charge, static bleeder load and additional current retained. Input parts, source provenance, state, assumptions and sidecar SHA256 appear in the report.

Validation: 14 controls pass, including15µA/100k→1.5V; increasing collector voltage does not increase follower drive;12V/10k→1.2mA;10µF/8ms idealRCdroop≈.923V;120Vrms/60Hz/10V crossing≈.313ms; correct upper/lower-bound direction, missing loaded-I/V evidence, charge exhaustion and malformed inputs. Ruff, focusedmypy and coldrepositorytypegate pass (1463/1472 unchanged baseline).

Documented first-scope limits: declared I/V ceilings rather than nonlinear curve solving; reservoir alternatives are model estimates, not demonstrated collector/gate dynamics. No device-rating, switching or manufacturing qualification is inferred. Invocation: `python -m kicad_tools.analysis.drive_budget budget.json`; schema and inputs documented in `docs/guides/drive-budget.md`.

Closes #5041