### PR TITLE
fix(connectivity): preserve physical duplicate pad occurrences

### DIFF
--- a/src/kicad_tools/analysis/net_status.py
+++ b/src/kicad_tools/analysis/net_status.py
@@ -8,6 +8,10 @@ intersection, matching ``kicad-cli pcb drc`` semantics) by default; pass
 ``strict=False`` to opt into the legacy 0.01mm endpoint-proximity model
 (see ``NetStatusAnalyzer.POSITION_TOLERANCE`` for the trade-offs).
 
+Strict graphs retain each physical pad occurrence, including duplicate pad
+numbers. Reports keep logical ``REF.PAD`` names and board positions. Duplicate
+numbers never imply an internal component jumper in this copper model.
+
 Example:
     >>> from kicad_tools.schema.pcb import PCB
     >>> from kicad_tools.analysis.net_status import NetStatusAnalyzer
@@ -43,6 +47,13 @@ class PadInfo:
     position: tuple[float, float]  # Board coordinates (x, y)
     is_connected: bool  # Whether pad is connected to main routing
     layers: list[str] = field(default_factory=list)  # Layers pad exists on
+
+    # Internal graph identity; display names deliberately remain REF.PAD.
+    node_id: str = field(default="", repr=False)
+
+    @property
+    def connectivity_id(self) -> str:
+        return self.node_id or self.full_name
 
     @property
     def full_name(self) -> str:
@@ -522,7 +533,7 @@ class NetStatusAnalyzer:
         # Strict-mode geometry caches (Issue #4176), keyed by object id.
         self._segment_poly_cache: dict[int, Any] = {}
         self._via_geom_cache: dict[int, Any] = {}
-        # Per-analyzer pad copper polygon cache (keyed ``REF.PAD``); ``None``
+        # Per-analyzer pad copper polygon cache (keyed by physical occurrence); ``None``
         # until first built lazily in :meth:`_pad_polys`.
         self._pad_poly_cache: dict[str, Any] | None = None
         if strict:
@@ -686,7 +697,7 @@ class NetStatusAnalyzer:
         graph = self._build_connectivity_graph(net_number, pad_infos)
 
         # Find connected components (islands)
-        islands = self._find_islands(graph, [p.full_name for p in pad_infos])
+        islands = self._find_islands(graph, [p.connectivity_id for p in pad_infos])
         # Issue #4934: the island COUNT (not just which pads sit in the
         # largest one) is what a ratsnest-style "remaining connections"
         # metric needs, so record it before the largest-island collapse.
@@ -701,7 +712,7 @@ class NetStatusAnalyzer:
 
         # Classify pads
         for pad_info in pad_infos:
-            pad_info.is_connected = pad_info.full_name in connected_names
+            pad_info.is_connected = pad_info.connectivity_id in connected_names
             if pad_info.is_connected:
                 status.connected_pads.append(pad_info)
             else:
@@ -711,6 +722,17 @@ class NetStatusAnalyzer:
         status.unconnected_pads.sort(key=lambda p: (p.reference, p.pad_number))
 
         return status
+
+    def _pad_node_id(self, fp_index: int, pad_index: int, fp: Any, pad: Any) -> str:
+        """Keep physical occurrences separate even with missing/duplicate UUIDs.
+
+        Indices are stable for this analyzer's immutable board snapshot. Legacy
+        mode retains its historical logical-name grouping; names in reports do
+        not change in either mode.
+        """
+        if self.strict:
+            return f"__pad:{fp_index}:{pad_index}"
+        return f"{fp.reference}.{pad.number}"
 
     def _get_net_pads_with_positions(self, net_number: int) -> list[PadInfo]:
         """Get all pads on a net with their board positions.
@@ -722,14 +744,14 @@ class NetStatusAnalyzer:
             List of PadInfo objects
         """
         pads = []
-        for fp in self.pcb.footprints:
+        for fp_index, fp in enumerate(self.pcb.footprints):
             if not fp.reference or fp.reference.startswith("#"):
                 continue
 
             fp_x, fp_y = fp.position
             rotation = fp.rotation
 
-            for pad in fp.pads:
+            for pad_index, pad in enumerate(fp.pads):
                 if pad.net_number == net_number:
                     # Transform pad position to board coordinates
                     board_pos = self._transform_pad_position(pad.position, fp_x, fp_y, rotation)
@@ -740,6 +762,7 @@ class NetStatusAnalyzer:
                             position=board_pos,
                             is_connected=False,
                             layers=pad.layers,
+                            node_id=self._pad_node_id(fp_index, pad_index, fp, pad),
                         )
                     )
         return pads
@@ -789,8 +812,8 @@ class NetStatusAnalyzer:
             Adjacency list mapping pad names to connected pad names
         """
         graph: dict[str, set[str]] = defaultdict(set)
-        pad_positions = {p.full_name: p.position for p in pad_infos}
-        pad_layers = {p.full_name: p.layers for p in pad_infos}
+        pad_positions = {p.connectivity_id: p.position for p in pad_infos}
+        pad_layers = {p.connectivity_id: p.layers for p in pad_infos}
 
         # Get segments and vias for this net
         segments = list(self.pcb.segments_in_net(net_number))
@@ -1137,15 +1160,15 @@ class NetStatusAnalyzer:
         # reference validator's geometry so the model matches
         # ``extract_pad_partition`` exactly.
         pad_polys: dict[str, Any] = {}
-        for fp in self.pcb.footprints:
+        for fp_index, fp in enumerate(self.pcb.footprints):
             if not fp.reference or fp.reference.startswith("#"):
                 continue
-            for pad in fp.pads:
+            for pad_index, pad in enumerate(fp.pads):
                 if pad.net_number != net_number:
                     continue
                 if pad.number is None or pad.number == "":
                     continue
-                pad_id = f"{fp.reference}.{pad.number}"
+                pad_id = self._pad_node_id(fp_index, pad_index, fp, pad)
                 if pad_id not in pad_positions:
                     continue
                 poly = cv._pad_copper_polygon(fp, pad)
@@ -1589,7 +1612,7 @@ class NetStatusAnalyzer:
         return geom
 
     def _pad_polys(self) -> dict[str, Any]:
-        """Board-frame copper polygon per pad, keyed by ``REF.PAD`` (strict).
+        """Board-frame copper polygon per physical pad occurrence (strict).
 
         Built once per analyzer over every footprint pad, reusing
         :meth:`ConnectivityValidator._pad_copper_polygon` for shape/rotation
@@ -1600,13 +1623,15 @@ class NetStatusAnalyzer:
             return self._pad_poly_cache
         cache: dict[str, Any] = {}
         cv = self._connectivity_geometry()
-        for fp in self.pcb.footprints:
+        for fp_index, fp in enumerate(self.pcb.footprints):
             if not fp.reference or fp.reference.startswith("#"):
                 continue
-            for pad in fp.pads:
+            for pad_index, pad in enumerate(fp.pads):
                 if pad.number is None or pad.number == "":
                     continue
-                cache[f"{fp.reference}.{pad.number}"] = cv._pad_copper_polygon(fp, pad)
+                cache[self._pad_node_id(fp_index, pad_index, fp, pad)] = cv._pad_copper_polygon(
+                    fp, pad
+                )
         self._pad_poly_cache = cache
         return cache
 

--- a/src/kicad_tools/cli/pcb_query.py
+++ b/src/kicad_tools/cli/pcb_query.py
@@ -213,8 +213,11 @@ def cmd_nets(pcb: PCB, args):
                     island_map[net.number] = []
             else:
                 graph = analyzer._build_connectivity_graph(net.number, pad_infos)
-                islands = analyzer._find_islands(graph, [p.full_name for p in pad_infos])
-                island_map[net.number] = islands
+                islands = analyzer._find_islands(graph, [p.connectivity_id for p in pad_infos])
+                display_names = {p.connectivity_id: p.full_name for p in pad_infos}
+                island_map[net.number] = [
+                    [display_names[node] for node in island] for island in islands
+                ]
 
     if args.format == "json":
         net_stats = []

--- a/tests/test_net_status_duplicate_pads.py
+++ b/tests/test_net_status_duplicate_pads.py
@@ -1,0 +1,141 @@
+"""Physical pad occurrences must not collapse into logical pin names (#5061)."""
+
+from pathlib import Path
+
+import pytest
+
+from kicad_tools.analysis.net_status import NetStatusAnalyzer
+
+
+def _board(*, connected=False, second_layer="F.Cu", reverse=False, duplicate_uuid=False):
+    pads = [
+        f'(pad "SH" smd rect (at {x} 0) (size 1 1) '
+        f'(layers "{layer}") (net 1 "GND")'
+        + (' (uuid "aaaabbbb-0000-4000-8000-000000000001")' if duplicate_uuid else "")
+        + ")"
+        for x, layer in ((0, "F.Cu"), (10, second_layer))
+    ]
+    if reverse:
+        pads.reverse()
+    tracks = (
+        '(segment (start 10 10) (end 20 10) (width 0.3) (layer "F.Cu") (net 1))'
+        if connected
+        else ""
+    )
+    return f"""(kicad_pcb (version 20240108) (generator "test")
+      (general (thickness 1.6)) (paper "A4")
+      (layers (0 "F.Cu" signal) (31 "B.Cu" signal) (44 "Edge.Cuts" user))
+      (net 0 "") (net 1 "GND")
+      (footprint "Test:Shield" (layer "F.Cu") (at 10 10)
+        (property "Reference" "J1" (at 0 -2) (layer "F.SilkS")
+          (effects (font (size 1 1) (thickness 0.15))))
+        (duplicate_pad_numbers_are_jumpers no)
+        {" ".join(pads)})
+      {tracks}
+      (gr_rect (start 0 0) (end 30 20) (stroke (width 0.05) (type solid))
+        (fill none) (layer "Edge.Cuts")))"""
+
+
+@pytest.mark.parametrize("reverse", [False, True])
+@pytest.mark.parametrize("duplicate_uuid", [False, True])
+@pytest.mark.parametrize(
+    "connected,second_layer,islands",
+    [
+        (False, "F.Cu", 2),
+        (True, "F.Cu", 1),
+        (True, "B.Cu", 2),
+    ],
+)
+def test_duplicate_occurrences_keep_physical_connectivity(
+    tmp_path, reverse, duplicate_uuid, connected, second_layer, islands
+):
+    path = tmp_path / "duplicates.kicad_pcb"
+    path.write_text(
+        _board(
+            connected=connected,
+            second_layer=second_layer,
+            reverse=reverse,
+            duplicate_uuid=duplicate_uuid,
+        )
+    )
+    status = NetStatusAnalyzer(path).analyze().get_net("GND")
+    assert status.total_pads == 2
+    assert status.island_count == islands
+    assert status.connected_count == (2 if islands == 1 else 1)
+    assert status.unconnected_count == (0 if islands == 1 else 1)
+    # Public names remain logical names; positions distinguish physical lands.
+    output = status.to_dict()
+    reported = output["connected_pads"] + output["unconnected_pads"]
+    assert {pad["name"] for pad in reported} == {"J1.SH"}
+    assert {tuple(pad["position"]) for pad in reported} == {(10, 10), (20, 10)}
+
+
+def test_board09_all_four_shield_lands_reach_ground_without_source_changes():
+    path = (
+        Path(__file__).resolve().parents[1]
+        / "boards/09-usbc-pd-power/output/usbc_pd_power.kicad_pcb"
+    )
+    original = path.read_bytes()
+    status = NetStatusAnalyzer(path).analyze().get_net("GND")
+    assert status.island_count == 1
+    assert status.connected_count == status.total_pads == 35
+    assert len([p for p in status.connected_pads if p.full_name == "J1.SH"]) == 4
+    assert {"J1.A1", "J1.A12", "J1.B1", "J1.B12"} <= {p.full_name for p in status.connected_pads}
+    assert path.read_bytes() == original
+
+
+def test_legacy_logical_name_behavior_remains_explicit(tmp_path):
+    path = tmp_path / "legacy.kicad_pcb"
+    path.write_text(_board())
+    status = NetStatusAnalyzer(path, strict=False).analyze().get_net("GND")
+    assert status.island_count == 1
+
+
+@pytest.mark.parametrize("connected,islands", [(False, 2), (True, 1)])
+def test_pcb_query_uses_physical_islands_with_logical_display_names(
+    tmp_path, capsys, connected, islands
+):
+    import argparse
+    import json
+
+    from kicad_tools.cli.pcb_query import cmd_nets
+    from kicad_tools.schema.pcb import PCB
+
+    path = tmp_path / "query.kicad_pcb"
+    path.write_text(_board(connected=connected))
+    cmd_nets(
+        PCB.load(str(path)),
+        argparse.Namespace(filter=None, sorted=False, check_connectivity=True, format="json"),
+    )
+    result = json.loads(capsys.readouterr().out)[0]
+    assert result["island_count"] == islands
+    assert result["is_complete"] == connected
+    assert sorted(pad for island in result["islands"] for pad in island) == ["J1.SH", "J1.SH"]
+
+
+@pytest.mark.parametrize("connected", [False, True])
+def test_native_duplicate_number_connectivity_control(tmp_path, connected):
+    import json
+    import subprocess
+
+    from kicad_tools.cli.runner import find_kicad_cli
+
+    cli = find_kicad_cli()
+    if cli is None:
+        pytest.skip("kicad-cli not available")
+    path = tmp_path / "native.kicad_pcb"
+    path.write_text(_board(connected=connected))
+    original = path.read_bytes()
+    report = tmp_path / "drc.json"
+    subprocess.run(
+        [str(cli), "pcb", "drc", "--format", "json", "-o", str(report), str(path)],
+        check=True,
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+    result = json.loads(report.read_text())
+    assert len(result["unconnected_items"]) == (0 if connected else 1)
+    strict = NetStatusAnalyzer(path).analyze().get_net("GND")
+    assert strict.open_connections == len(result["unconnected_items"])
+    assert path.read_bytes() == original


### PR DESCRIPTION
## Summary
Strict net status collapsed repeated pad numbers into a single graph node and retained only the last pad geometry. Board09's four physical J1.SH shield lands therefore lost three contact paths, leaving J1.A1/A12/B1/B12 incorrectly disconnected. Each physical pad now retains its own identity through the existing copper graph.

## Changes
- Key strict pad geometry, positions, layers, pour bonds, island discovery and classification by board occurrence. Missing or duplicated UUIDs cannot collapse occurrences.
- Preserve public REF.PAD names and positions, plus explicit legacy-mode behavior.
- Update the PCB nets query's graph consumer to use physical identities internally and restore logical names in its existing output.
- Keep copper-contact and fill-island policies unchanged. No new pad-to-pad contact rule was needed. Coordinate the narrow identity hunk with peer #5031 (comment5627374039).

## Acceptance Criteria Verification
| Criterion | Verification |
|---|---|
| Board09 false ground opens recovered | Before:35 pads,31 connected,3 islands; after:35 connected,1 island, including all four SH occurrences and A1/A12/B1/B12 |
| Duplicate numbers cannot hide physical opens | Disconnected occurrences remain two islands; connecting copper yields one |
| Layer and identity safety | Opposite-layer negative controls, reordered pads and missing/duplicated UUIDs |
| Existing output compatibility | REF.PAD names/positions preserved; PCB query integration controls and legacy opt-out control |
| Native agreement without changing hardware | KiCad10.0.6 synthetic controls report1/0 opens; Board09 copied source reports0 opens,0 errors and47 footprint-library warnings; source bytes unchanged |

## Test Plan
TDD: no — measured the existing Board09 failure before the identity change, then added explicit positive/negative regression controls.

- Duplicate-pad, strict-net-status, existing net-status and query suites:134 passed.
- Final duplicate suite with KiCad10.0.6 on PATH:18 passed, including two native open/connected controls.
- Ruff lint/format and git diff --check pass.
- Focused mypy: net_status clean. pcb_query has12 pre-existing diagnostics, reproduced identically against its parent using --shadow-file (only line offsets differ); no ledger or type suppression changed.
- Independent temporary Board09 native control preserves both source and copied PCB bytes. SHA256:39bf81159243f6827792cc0ce1fa23d907a419595d200edf478f25819905bdc7. Native warnings concern unavailable footprint-library tables and are not suppressed or reported as clean DRC.

Physical copper connectivity does not infer an internal component jumper from duplicate numbering. KiCad's explicit jumper semantics are separate: https://docs.kicad.org/10.0/en/pcbnew/pcbnew.html#_jumper_pads . No manufacturing/readiness artifacts are refreshed or new release qualification claimed. Fresh CI and independent Judge review remain required.

Closes #5061