### PR TITLE
ci: apply the Board 07 pause to its unit-test module

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -160,8 +160,16 @@ jobs:
         # now gates: if it is red, fix the tests -- do NOT re-add
         # continue-on-error. Known-broken tests must be xfail'd with a
         # tracking issue instead.
-        # The file above already ran in this job; all other tests use xdist.
-        run: uv run pytest -n auto -o addopts= --benchmark-disable --timeout=60 -m "not slow" --ignore=tests/test_board_05_drc_allowlist.py
+        # Match the temporary Board 07 job suspension (#5097, #5160).
+        # Its tests remain runnable locally; the same variable restores them.
+        env:
+          BOARD_07_CI_ENABLED: ${{ vars.BOARD_07_CI_ENABLED }}
+        run: |
+          test_args=(--ignore=tests/test_board_05_drc_allowlist.py)
+          if [[ "$BOARD_07_CI_ENABLED" != "true" ]]; then
+            test_args+=(--ignore=tests/test_board_07_matchgroup_test.py)
+          fi
+          uv run pytest -n auto -o addopts= --benchmark-disable --timeout=60 -m "not slow" "${test_args[@]}"
 
   cpp-build-check:
     # Issue #2501: catch source/.so drift by rebuilding the C++ extension


### PR DESCRIPTION
The temporary Board 07 CI suspension from #5099 skipped its dedicated jobs but left its unit-test module gating the general Test job. Apply the same `BOARD_07_CI_ENABLED` switch to that module so the user-requested pause is consistent. All tests remain available locally; setting the variable to `true` restores both the dedicated jobs and this module.

The existing regressions expose moves into stale copper fills under the stricter relocation checks. They are retained unchanged for a future native refill transaction; no geometric safety check or manufacturing threshold is weakened.

Validation: actionlint and diff checks pass. Executed the workflow's argument selection with unset, false, and true values and verified the parsed workflow differs only in this test step. The Board05 exclusion remains because that module runs separately earlier in the same job.

Closes #5160
Refs #5097, #5065, #5068, #5069