### PR TITLE
feat: prepare immutable offline assembly submission handoffs

### DIFF
--- a/docs/guides/manufacturing-export.md
+++ b/docs/guides/manufacturing-export.md
@@ -484,3 +484,11 @@ export_pnp(pcb, "cpl.csv", manufacturer="jlcpcb", config=config)
 
 - **[Query API](query-api.md)** - Advanced filtering for design analysis
 - **[Schematic Analysis](schematic-analysis.md)** - Deep dive into schematic parsing
+
+## Offline submission preparation
+
+For exact-byte, locally verified Gerber/BOM/CPL handoffs, see
+[Offline assembly submission preparation](submission-preparation.md). This Python
+API produces a deterministic plan and expected reference matching list without
+supplier access, uploads, approval, or orders. Live inventory composition remains
+milestone B of #5142.

--- a/docs/guides/submission-preparation.md
+++ b/docs/guides/submission-preparation.md
@@ -1,0 +1,185 @@
+# Offline assembly submission preparation
+
+`kicad_tools.export.submission_plan` implements milestone A of #5142: a local,
+read-only handoff of an existing manufacturing bundle. It does not export a
+board again, choose parts, contact a supplier, or submit an order. Local integrity
+means the supplied evidence matches the input bytes; it does **not** establish
+board readiness, human approval, factory matching, available inventory, reserved
+stock, or feeder/attrition requirements.
+
+Milestone B (exact-ID inventory observations) remains outstanding and depends on
+#5033/#5034, tracked by PRs #5115/#5090. `refresh_inventory(plan)` currently raises
+`NotImplementedError` before accessing anything. Preparation has no client,
+credential, or transport argument, and does not read supplier environment
+variables. No live availability evidence is produced.
+
+## Python API
+
+```python
+from pathlib import Path
+from kicad_tools.export.submission_plan import (
+    FactorySettings,
+    SourceEvidence,
+    prepare_submission,
+    verify_submission,
+)
+
+# Obtain these hashes/sizes from your independently retained frozen-source
+# evidence. Do not silently recompute trusted evidence from changed inputs.
+source_records = {
+    "pcb": SourceEvidence("board.kicad_pcb", expected_pcb_sha256, expected_pcb_size),
+    "schematic": SourceEvidence("board.kicad_sch", expected_sch_sha256, expected_sch_size),
+}
+plan = prepare_submission(
+    bundle_root=Path("release/manufacturing"),
+    manifest_path="manifest.json",
+    # Explicit complete set: include every file in manifest['files'], not only
+    # the three selected uploads. The manifest itself must not list itself.
+    bundle_files=("gerbers/gerbers.zip", "assembly/bom.csv", "assembly/cpl.csv"),
+    artifacts={
+        "gerber": "gerbers/gerbers.zip",
+        "bom": "assembly/bom.csv",
+        "cpl": "assembly/cpl.csv",
+    },
+    source_root=Path("release/source"),
+    source_evidence=source_records,
+    board_quantity=10,
+    settings=FactorySettings(factory="jlcpcb", board_layers=4, assembly_sides=("top",)),
+    destination=Path("handoffs/board-run-1"),  # Parent exists; destination does not.
+    exclusions={"J1": "tht", "R99": "dnp"},  # Optional explicit absent population.
+)
+print(plan.sha256)
+verified = verify_submission(plan.directory, plan.sha256)
+assert verified.plan_bytes == plan.plan_bytes
+```
+
+All three `FactorySettings` fields are required. Factory is currently `jlcpcb`,
+layer count is a positive integer (at most 64), and sides are an explicit tuple
+containing `top`, `bottom`, or both, without duplicates. These are planning intent,
+not vendor API enum values. Other order settings, such as finish, assembly class,
+shipping, previews and quotes, are not represented or guessed. This module cannot
+produce a complete factory order payload. Quantity must be a positive integer;
+booleans, strings and fractional values are rejected.
+
+Both PCB and schematic evidence are required and mapped explicitly relative to
+`source_root`, including when source files live outside the fabrication bundle.
+The API binds their exact bytes, not their file modification times. It does not
+assert that an untrusted manifest/source record is an approval or that a Gerber
+ZIP was generated from those sources; the caller supplies the frozen provenance.
+
+## Strict inputs
+
+Use the current export manifest's `files` mapping, with canonical bundle-relative
+POSIX paths as keys and **both** lowercase SHA256 and integer byte `size` in each
+record. Every declared file is verified, including unselected reports or images.
+The declared allowlist must equal the manifest file keys. The only additional file
+permitted in the bundle is the selected manifest. Its subdirectories must be
+implied by listed paths. Missing/changed/extra files, extra directories, self-listed
+manifests, duplicate JSON keys and case aliases fail validation. Legacy basename
+search is intentionally unsupported: migrate the manifest paths explicitly,
+without changing the fabrication bytes, before preparing a submission.
+
+Relative artifact/source paths cannot contain `.`/`..`, empty components, backslash,
+colon, control characters, or non-NFC Unicode. Symlinks anywhere in the root's
+ancestry or the selected paths are rejected, even if they point inside the root.
+Every entry in the bundle must be a regular file or an implied directory; source
+roots may contain other files because their binding is an explicit role mapping.
+All selected artifacts must be different declared files. Destination must be
+outside both input roots, with an existing nonsymlink parent.
+
+The supported CSV dialect is the existing JLCPCB export:
+
+- BOM: `Comment`, `Designator`, `Footprint`, `LCSC Part #`; optional `Quantity`.
+- CPL: `Designator`, `Val`, `Package`, `Mid X`, `Mid Y`, `Rotation`, `Layer`.
+
+Header order is flexible, but duplicate/unknown headers and inconsistent row
+lengths are errors. Files must be UTF-8, optionally with a UTF-8 BOM. BOM references
+are comma-separated within the quoted designator field. Each reference belongs to
+one row only, and every row requires an explicit `C` plus positive integer catalog
+ID. Ranges such as `R1-R4` are not expanded. A supplied row quantity must equal the
+number of listed distinct references. Empty populations are rejected.
+
+CPL references must match the BOM exactly, once each, and value/footprint fields
+must agree. Coordinates accept decimal millimeters with or without `mm`; rotation
+is decimal degrees. Finite numeric fields are bounded to an absolute value of one
+million. Layers must be `Top`/`Bottom` and included in the explicit assembly sides.
+Parsed coordinates are normalized only in the expected matching list; the copied
+CSV bytes are unchanged.
+
+The assembly population is exactly the frozen BOM/CPL reference set. Optional
+exclusions map references to `dnp` or `tht`; each must **already be absent from both
+CSVs**. A populated row cannot be filtered out while leaving it in the byte-exact
+upload. No automatic DNP/THT inference or part substitution occurs. Repeated catalog
+IDs across different rows are aggregated by distinct references first:
+
+```text
+per_board[id] = number of included references assigned to id
+required[id]  = per_board[id] * board_quantity
+```
+
+There is no extra allowance and no second quantity multiplication.
+
+## Published layout and identity
+
+By default the destination contains exactly:
+
+```text
+board-run-1/
+  gerbers.zip             # Exact selected input bytes
+  bom.csv                 # Exact selected input bytes
+  cpl.csv                 # Exact selected input bytes
+  bundle-manifest.json    # Exact original manifest bytes
+  expected-matches.json   # Sorted planning list; NOT factory-selected evidence
+  plan.json               # Canonical versioned core
+  plan.sha256             # External SHA256 of plan.json
+```
+
+An explicit `output_names={"gerber": ..., "bom": ..., "cpl": ...}` can change the
+three artifact filenames. They must be distinct single filenames and cannot use
+any of the four reserved metadata names. No glob selection or filename guessing
+occurs. The Gerber ZIP is copied as opaque bytes; its contents are not regenerated
+or certified by this module. Source files are verified and bound, not copied into
+the upload directory. Inputs must be nonsecret manufacturing documents; the
+module adds no credentials or raw supplier envelopes to them.
+
+`plan.json` uses UTF-8, sorted object keys, compact separators and a final newline.
+Its identity binds exact selected artifacts, every declared bundle file, source
+bytes and relative mappings, original manifest bytes, quantity, explicit settings,
+exclusions and the deterministic reference/ID/placement list. Input directory
+locations and wall-clock timestamps are not part of identity. Reordering settings
+or parsed records does not alter their semantic lists; changing the raw CSV bytes
+still changes identity because the original byte hash is bound. Reordering the
+raw manifest also changes its bound hash. No statement of present-day supplier
+availability follows from deterministic replay.
+
+The plan records hashes/sizes of its payload files, **not its own hash**.
+`plan.sha256` and `SubmissionPlan.sha256` supply the external digest. Retain the
+expected digest outside the directory and use `verify_submission` before reuse;
+an attacker replacing both a plan and its adjacent digest cannot satisfy an
+independently retained digest. Read-only permissions are accidental-write
+protection, not filesystem WORM storage: the owner can change permissions. A
+verified handoff never updates in place; changed inputs require a new destination.
+
+## Failure and publication boundary
+
+The implementation requires POSIX descriptor-relative file operations
+(`O_NOFOLLOW` and directory file descriptors), supported on Linux and macOS.
+Windows is not currently supported. All input bytes are held in memory for the
+validation/copy interval, so provision memory for the complete declared bundle.
+
+Preparation opens files without following symlinks, checks identity before/after
+reading, verifies hashes/sizes, parses CSVs and validates intent before staging.
+It writes a private sibling staging directory, verifies destination bytes, then
+rereads all input snapshots and inventories the bundle again. A detected mutation,
+write failure or mismatch removes staging and publishes no destination. After
+verification, files become read-only and the directory is published with a single
+rename on the same filesystem. Concurrent cooperating preparers are fenced by an
+exclusive destination lock; an existing destination is rejected, not rewritten.
+A process crash may leave a hidden lock/staging directory for explicit inspection
+and removal, but not a successfully published partial handoff. The input roots and
+destination parent must remain controlled by the caller; this is not protection
+against an attacker renaming the filesystem namespace during publication.
+
+Refreshing future stock observations must use separate files outside the frozen
+bundle and bind plan/BOM/quantity/demand hashes. That behavior is not implemented
+by milestone A. #5142 remains open for milestone B.

--- a/src/kicad_tools/export/submission_plan.py
+++ b/src/kicad_tools/export/submission_plan.py
@@ -19,7 +19,7 @@ import unicodedata
 from collections import Counter
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
-from decimal import Decimal, InvalidOperation
+from decimal import Context, Decimal, InvalidOperation
 from pathlib import Path, PurePosixPath
 from typing import Any
 
@@ -265,12 +265,36 @@ def _number(value: str, *, mm: bool = False) -> str:
     if mm and value.endswith("mm"):
         value = value[:-2]
     try:
-        number = Decimal(value)
+        # String construction is exact; its explicit context contains any
+        # conversion-error flags instead of mutating the caller context.
+        number = Decimal(value, context=Context())
     except InvalidOperation as exc:
         raise SubmissionError("Invalid CPL numeric field") from exc
-    if not number.is_finite() or abs(number) > 1_000_000:
+    if not number.is_finite() or number.copy_abs() > 1_000_000:
         raise SubmissionError("Nonfinite or out-of-range CPL numeric field")
-    return str(number.normalize()) if number else "0"
+    if not number:
+        return "0"
+    # normalize(), abs(), and Decimal.__str__ depend on ambient precision,
+    # rounding or capitalization. Canonicalize the exact tuple using only
+    # integer/string operations, without allocating huge exponent padding.
+    sign, digits, exponent = number.as_tuple()
+    assert isinstance(exponent, int)  # Nonfinite values were rejected above.
+    coefficient = "".join(str(digit) for digit in digits)
+    trimmed = coefficient.rstrip("0")
+    exponent += len(coefficient) - len(trimmed)
+    adjusted = exponent + len(trimmed) - 1
+    if exponent <= 0 and adjusted >= -6:
+        point = len(trimmed) + exponent
+        if point <= 0:
+            result = "0." + "0" * (-point) + trimmed
+        elif point < len(trimmed):
+            result = trimmed[:point] + "." + trimmed[point:]
+        else:
+            result = trimmed
+    else:
+        result = trimmed[0] + ("." + trimmed[1:] if len(trimmed) > 1 else "")
+        result += "E" + ("+" if adjusted >= 0 else "") + str(adjusted)
+    return ("-" if sign else "") + result
 
 
 def _population(

--- a/src/kicad_tools/export/submission_plan.py
+++ b/src/kicad_tools/export/submission_plan.py
@@ -1,0 +1,537 @@
+"""Offline, exact-byte assembly handoffs. No supplier clients or transaction APIs.
+
+See docs/guides/submission-preparation.md for the strict input dialect and
+publication contract. Inventory composition is a separate, unfinished milestone.
+"""
+
+from __future__ import annotations
+
+import csv
+import hashlib
+import io
+import json
+import os
+import re
+import shutil
+import stat
+import tempfile
+import unicodedata
+from collections import Counter
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from decimal import Decimal, InvalidOperation
+from pathlib import Path, PurePosixPath
+from typing import Any
+
+from .bom_formats import JLCPCBBOMFormatter
+from .pnp import JLCPCBPnPFormatter
+
+_ROLES = {"gerber", "bom", "cpl"}
+_RESERVED = {"plan.json", "plan.sha256", "expected-matches.json", "bundle-manifest.json"}
+_DEFAULT_NAMES = {"gerber": "gerbers.zip", "bom": "bom.csv", "cpl": "cpl.csv"}
+_REF = re.compile(r"[A-Za-z][A-Za-z0-9_.+-]*\Z")
+_SHA = re.compile(r"[0-9a-f]{64}\Z")
+
+
+class SubmissionError(ValueError):
+    """The supplied frozen inputs or handoff fail the local integrity contract."""
+
+
+@dataclass(frozen=True)
+class SourceEvidence:
+    """Caller-supplied content binding for a path relative to source_root."""
+
+    path: str
+    sha256: str
+    size: int
+
+
+@dataclass(frozen=True)
+class FactorySettings:
+    """Explicit planning intent, NOT a vendor order payload or vendor enum mapping."""
+
+    factory: str
+    board_layers: int
+    assembly_sides: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class SubmissionPlan:
+    """Immutable core bytes and external digest; directory is published read-only."""
+
+    directory: Path
+    plan_bytes: bytes
+
+    @property
+    def sha256(self) -> str:
+        return _digest(self.plan_bytes)
+
+
+@dataclass(frozen=True)
+class _Snapshot:
+    root: Path
+    path: str
+    data: bytes
+    identity: tuple[int, ...]
+
+
+def _digest(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+def _json(data: Any) -> bytes:
+    return (
+        json.dumps(data, sort_keys=True, separators=(",", ":"), ensure_ascii=False, allow_nan=False)
+        + "\n"
+    ).encode("utf-8")
+
+
+def _unique_object(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    result: dict[str, Any] = {}
+    for key, value in pairs:
+        if key in result:
+            raise SubmissionError("Duplicate JSON key")
+        result[key] = value
+    return result
+
+
+def _load_json(data: bytes) -> Any:
+    try:
+        return json.loads(data, object_pairs_hook=_unique_object)
+    except (ValueError, UnicodeError) as exc:
+        raise SubmissionError("Invalid JSON manifest") from exc
+
+
+def _path(value: str) -> str:
+    if not isinstance(value, str) or not value or "\\" in value or ":" in value:
+        raise SubmissionError("Paths must be canonical relative POSIX paths")
+    parts = value.split("/")
+    if any(p in ("", ".", "..") or any(ord(c) < 32 or ord(c) == 127 for c in p) for p in parts):
+        raise SubmissionError("Paths must be canonical relative POSIX paths")
+    if unicodedata.normalize("NFC", value) != value or PurePosixPath(value).is_absolute():
+        raise SubmissionError("Noncanonical path")
+    return value
+
+
+def _paths(values: Sequence[str]) -> list[str]:
+    result = [_path(value) for value in values]
+    if len({name.casefold() for name in result}) != len(result):
+        raise SubmissionError("Duplicate canonical path or case alias")
+    return result
+
+
+def _root_fd(root: Path) -> int:
+    """Open every absolute directory component without following symlinks."""
+    fd = os.open(root.anchor, os.O_RDONLY | os.O_DIRECTORY)
+    try:
+        for part in root.parts[1:]:
+            nxt = os.open(part, os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW, dir_fd=fd)
+            os.close(fd)
+            fd = nxt
+        return fd
+    except OSError as exc:
+        os.close(fd)
+        raise SubmissionError("Root must be an existing directory without symlinks") from exc
+
+
+def _root(path: Path) -> Path:
+    # abspath canonicalizes '.' and '..'; _root_fd rejects symlink ancestors.
+    root = Path(os.path.abspath(path))
+    fd = _root_fd(root)
+    os.close(fd)
+    return root
+
+
+def _identity(info: os.stat_result) -> tuple[int, ...]:
+    return info.st_dev, info.st_ino, info.st_mode, info.st_size, info.st_mtime_ns, info.st_ctime_ns
+
+
+def _read(root: Path, name: str) -> _Snapshot:
+    name = _path(name)
+    fd = _root_fd(root)
+    file_fd = None
+    try:
+        parts = name.split("/")
+        for part in parts[:-1]:
+            nxt = os.open(part, os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW, dir_fd=fd)
+            os.close(fd)
+            fd = nxt
+        file_fd = os.open(parts[-1], os.O_RDONLY | os.O_NOFOLLOW | os.O_NONBLOCK, dir_fd=fd)
+        before = os.fstat(file_fd)
+        if not stat.S_ISREG(before.st_mode):
+            raise SubmissionError("Input must be a regular file")
+        with os.fdopen(file_fd, "rb", closefd=False) as stream:
+            data = stream.read()
+        after = os.fstat(file_fd)
+        if _identity(before) != _identity(after):
+            raise SubmissionError("Input changed while reading")
+        return _Snapshot(root, name, data, _identity(after))
+    except OSError as exc:
+        raise SubmissionError("Input missing, inaccessible, or symlinked") from exc
+    finally:
+        if file_fd is not None:
+            os.close(file_fd)
+        os.close(fd)
+
+
+def _inventory(root: Path, expected: set[str]) -> None:
+    """Check exact files and implied directories; never traverse symlinks."""
+    found: set[str] = set()
+    directories = {
+        str(parent)
+        for name in expected
+        for parent in PurePosixPath(name).parents
+        if str(parent) != "."
+    }
+
+    def walk(fd: int, prefix: str) -> None:
+        with os.scandir(fd) as entries:
+            for entry in entries:
+                name = _path(prefix + entry.name)
+                if entry.is_symlink():
+                    raise SubmissionError("Bundle contains a symlink")
+                if entry.is_dir(follow_symlinks=False):
+                    if name not in directories:
+                        raise SubmissionError("Unexpected bundle directory")
+                    child = os.open(
+                        entry.name, os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW, dir_fd=fd
+                    )
+                    try:
+                        walk(child, name + "/")
+                    finally:
+                        os.close(child)
+                elif entry.is_file(follow_symlinks=False):
+                    found.add(name)
+                else:
+                    raise SubmissionError("Bundle contains a nonregular entry")
+
+    fd = _root_fd(root)
+    try:
+        walk(fd, "")
+    except OSError as exc:
+        raise SubmissionError("Bundle changed during inventory") from exc
+    finally:
+        os.close(fd)
+    if found != expected:
+        raise SubmissionError("Bundle file set differs from declared allowlist")
+
+
+def _record(data: bytes) -> dict[str, Any]:
+    return {"sha256": _digest(data), "size": len(data)}
+
+
+def _check_record(data: bytes, record: Any) -> None:
+    if (
+        not isinstance(record, dict)
+        or not isinstance(record.get("sha256"), str)
+        or not _SHA.fullmatch(record["sha256"])
+    ):
+        raise SubmissionError("Complete SHA256/size evidence is required")
+    size = record.get("size")
+    if type(size) is not int or size < 0:
+        raise SubmissionError("Complete SHA256/size evidence is required")
+    if record["sha256"] != _digest(data) or size != len(data):
+        raise SubmissionError("Hash or size mismatch")
+
+
+def _csv(
+    data: bytes, required: list[str], optional: set[str] | None = None
+) -> list[dict[str, str]]:
+    try:
+        rows = list(csv.reader(io.StringIO(data.decode("utf-8-sig"), newline=""), strict=True))
+    except (csv.Error, UnicodeError) as exc:
+        raise SubmissionError("Invalid UTF-8 CSV") from exc
+    if not rows:
+        raise SubmissionError("Empty CSV")
+    header = rows.pop(0)
+    if (
+        len(set(header)) != len(header)
+        or not set(required) <= set(header)
+        or set(header) - set(required) - (optional or set())
+    ):
+        raise SubmissionError("Unsupported or duplicate CSV columns")
+    if not rows or any(len(row) != len(header) for row in rows):
+        raise SubmissionError("Empty CSV population or inconsistent row length")
+    return [dict(zip(header, row, strict=True)) for row in rows]
+
+
+def _reference(value: str) -> str:
+    if not isinstance(value, str) or not _REF.fullmatch(value):
+        raise SubmissionError("Invalid or empty reference")
+    return value
+
+
+def _number(value: str, *, mm: bool = False) -> str:
+    if mm and value.endswith("mm"):
+        value = value[:-2]
+    try:
+        number = Decimal(value)
+    except InvalidOperation as exc:
+        raise SubmissionError("Invalid CPL numeric field") from exc
+    if not number.is_finite() or abs(number) > 1_000_000:
+        raise SubmissionError("Nonfinite or out-of-range CPL numeric field")
+    return str(number.normalize()) if number else "0"
+
+
+def _population(
+    bom: bytes, cpl: bytes, sides: tuple[str, ...], exclusions: Mapping[str, str]
+) -> list[dict[str, str]]:
+    assignments: dict[str, dict[str, str]] = {}
+    for row in _csv(bom, JLCPCBBOMFormatter().get_headers(), {"Quantity"}):
+        refs = [_reference(ref.strip()) for ref in row["Designator"].split(",")]
+        if not re.fullmatch(r"C[1-9][0-9]*", row["LCSC Part #"]):
+            raise SubmissionError("Every BOM row needs an explicit exact catalog ID")
+        if not row["Comment"].strip() or not row["Footprint"].strip():
+            raise SubmissionError("BOM value and footprint must be explicit")
+        if "Quantity" in row and (
+            not re.fullmatch(r"[1-9][0-9]*", row["Quantity"]) or int(row["Quantity"]) != len(refs)
+        ):
+            raise SubmissionError("BOM row quantity disagrees with reference count")
+        for ref in refs:
+            if ref in assignments:
+                raise SubmissionError("Duplicate BOM reference or conflicting ID")
+            assignments[ref] = {
+                "reference": ref,
+                "catalog_id": row["LCSC Part #"],
+                "value": row["Comment"],
+                "footprint": row["Footprint"],
+            }
+    matches = []
+    seen: set[str] = set()
+    for row in _csv(cpl, JLCPCBPnPFormatter().get_headers()):
+        ref = _reference(row["Designator"])
+        if ref in seen or ref not in assignments:
+            raise SubmissionError("Duplicate or extra CPL reference")
+        seen.add(ref)
+        assignment = assignments[ref]
+        if row["Val"] != assignment["value"] or row["Package"] != assignment["footprint"]:
+            raise SubmissionError("BOM/CPL value or footprint disagrees")
+        side = {"Top": "top", "Bottom": "bottom"}.get(row["Layer"])
+        if side not in sides:
+            raise SubmissionError("CPL layer differs from explicit assembly sides")
+        matches.append(
+            assignment
+            | {
+                "x_mm": _number(row["Mid X"], mm=True),
+                "y_mm": _number(row["Mid Y"], mm=True),
+                "rotation_degrees": _number(row["Rotation"]),
+                "side": str(side),
+            }
+        )
+    if seen != assignments.keys():
+        raise SubmissionError("Missing CPL references")
+    for ref, reason in exclusions.items():
+        _reference(ref)
+        if reason not in ("dnp", "tht") or ref in seen:
+            raise SubmissionError(
+                "Explicit exclusion must already be absent from both frozen uploads"
+            )
+    return sorted(matches, key=lambda match: match["reference"])
+
+
+def _settings(settings: FactorySettings) -> dict[str, Any]:
+    if not isinstance(settings, FactorySettings) or settings.factory != "jlcpcb":
+        raise SubmissionError("Only explicit jlcpcb planning intent is supported")
+    if type(settings.board_layers) is not int or not 1 <= settings.board_layers <= 64:
+        raise SubmissionError("Explicit positive board layer count required")
+    sides = settings.assembly_sides
+    if (
+        not isinstance(sides, tuple)
+        or not sides
+        or len(set(sides)) != len(sides)
+        or any(side not in ("top", "bottom") for side in sides)
+    ):
+        raise SubmissionError("Explicit unique top/bottom assembly sides required")
+    return {
+        "factory": settings.factory,
+        "board_layers": settings.board_layers,
+        "assembly_sides": sorted(sides),
+    }
+
+
+def _write_bytes(path: Path, data: bytes) -> None:
+    with path.open("xb") as stream:
+        stream.write(data)
+        stream.flush()
+        os.fsync(stream.fileno())
+
+
+def prepare_submission(
+    *,
+    bundle_root: Path,
+    source_root: Path,
+    source_evidence: Mapping[str, SourceEvidence],
+    bundle_files: Sequence[str],
+    artifacts: Mapping[str, str],
+    board_quantity: int,
+    settings: FactorySettings,
+    destination: Path,
+    manifest_path: str = "manifest.json",
+    output_names: Mapping[str, str] | None = None,
+    exclusions: Mapping[str, str] | None = None,
+) -> SubmissionPlan:
+    """Validate frozen inputs and atomically publish a new read-only handoff.
+
+    All input bytes are read and verified before staging. Revalidation after
+    copying rejects mutation; existing destinations are never updated. No
+    credentials, supplier clients, or network calls occur on any path.
+    """
+    if type(board_quantity) is not int or board_quantity <= 0:
+        raise SubmissionError("Board quantity must be a positive integer")
+    intent = _settings(settings)
+    exclusions = dict(exclusions or {})
+    bundle, source = _root(bundle_root), _root(source_root)
+    manifest_path = _path(manifest_path)
+    allowed = _paths(bundle_files)
+    if not allowed or manifest_path.casefold() in {name.casefold() for name in allowed}:
+        raise SubmissionError("Manifest cannot list itself; explicit file allowlist required")
+    if (
+        set(artifacts) != _ROLES
+        or len(set(_paths(list(artifacts.values())))) != 3
+        or not set(artifacts.values()) <= set(allowed)
+    ):
+        raise SubmissionError("Select exactly one distinct listed artifact per role")
+    names = dict(_DEFAULT_NAMES if output_names is None else output_names)
+    if set(names) != _ROLES:
+        raise SubmissionError("Output names must specify all artifact roles")
+    _paths(list(names.values()))
+    if any("/" in name or name.casefold() in _RESERVED for name in names.values()):
+        raise SubmissionError("Output names must be distinct nonreserved filenames")
+    if set(source_evidence) != {"pcb", "schematic"} or any(
+        not isinstance(e, SourceEvidence) for e in source_evidence.values()
+    ):
+        raise SubmissionError("Explicit PCB and schematic source evidence required")
+    _paths([e.path for e in source_evidence.values()])
+    destination = Path(os.path.abspath(destination))
+    parent = _root(destination.parent)
+    _path(destination.name)
+    if destination.is_relative_to(bundle) or destination.is_relative_to(source):
+        raise SubmissionError("Handoff must be outside frozen bundle and source roots")
+    if os.path.lexists(destination):
+        raise SubmissionError("Destination already exists")
+    expected = set(allowed) | {manifest_path}
+    _inventory(bundle, expected)
+    manifest = _read(bundle, manifest_path)
+    metadata = _load_json(manifest.data)
+    if not isinstance(metadata, dict) or not isinstance(metadata.get("files"), dict):
+        raise SubmissionError("Manifest requires complete file records")
+    _paths(list(metadata["files"]))
+    if set(metadata["files"]) != set(allowed):
+        raise SubmissionError("Manifest and declared file allowlist differ")
+    snapshots = {name: _read(bundle, name) for name in allowed}
+    for name, snap in snapshots.items():
+        _check_record(snap.data, metadata["files"][name])
+    sources = {role: _read(source, evidence.path) for role, evidence in source_evidence.items()}
+    for role, snap in sources.items():
+        evidence = source_evidence[role]
+        _check_record(snap.data, {"sha256": evidence.sha256, "size": evidence.size})
+    matches = _population(
+        snapshots[artifacts["bom"]].data,
+        snapshots[artifacts["cpl"]].data,
+        settings.assembly_sides,
+        exclusions,
+    )
+    counts = Counter(match["catalog_id"] for match in matches)
+    outputs = {names[role]: snapshots[path].data for role, path in artifacts.items()}
+    outputs["expected-matches.json"] = _json(matches)
+    outputs["bundle-manifest.json"] = manifest.data
+    core = {
+        "schema_version": 1,
+        "board_quantity": board_quantity,
+        "settings": intent,
+        "population": "exact-frozen-bom-cpl-reference-set",
+        "exclusions": exclusions,
+        "bundle_manifest": {"path": manifest_path, **_record(manifest.data)},
+        "bundle_files": {name: _record(snap.data) for name, snap in snapshots.items()},
+        "sources": {
+            role: {"path": snap.path, **_record(snap.data)} for role, snap in sources.items()
+        },
+        "artifacts": {
+            role: {"input_path": path, "output_name": names[role]}
+            for role, path in artifacts.items()
+        },
+        "outputs": {name: _record(data) for name, data in outputs.items()},
+        "demand": [
+            {
+                "catalog_id": code,
+                "per_board": counts[code],
+                "required": counts[code] * board_quantity,
+            }
+            for code in sorted(counts)
+        ],
+        "states": {
+            "preparation": "local-integrity-valid",
+            "inventory": "unknown",
+            "human_approval": "not-established",
+            "factory_matching": "not-observed",
+            "upload": "not-performed",
+            "order": "not-performed",
+        },
+    }
+    plan_bytes = _json(core)
+    outputs["plan.json"] = plan_bytes
+    outputs["plan.sha256"] = (_digest(plan_bytes) + "  plan.json\n").encode("ascii")
+    # Exclusive cooperative lock protects two callers publishing the same path.
+    lock = parent / ("." + destination.name + ".prepare-lock")
+    try:
+        lock_fd = os.open(lock, os.O_CREAT | os.O_EXCL | os.O_WRONLY | os.O_NOFOLLOW, 0o600)
+    except OSError as exc:
+        raise SubmissionError("Destination publication is already claimed") from exc
+    stage: Path | None = None
+    try:
+        if os.path.lexists(destination):
+            raise SubmissionError("Destination already exists")
+        stage = Path(tempfile.mkdtemp(prefix="." + destination.name + ".stage-", dir=parent))
+        for name, data in outputs.items():
+            _write_bytes(stage / name, data)
+        for name, data in outputs.items():
+            if _read(stage, name).data != data:
+                raise SubmissionError("Destination bytes differ from verified input")
+        for snap in [manifest, *snapshots.values(), *sources.values()]:
+            current = _read(snap.root, snap.path)
+            if current.data != snap.data or current.identity != snap.identity:
+                raise SubmissionError("Input changed between validation and copying")
+        _inventory(bundle, expected)
+        for name in outputs:
+            (stage / name).chmod(0o444)
+        stage.chmod(0o555)
+        if os.path.lexists(destination):
+            raise SubmissionError("Destination already exists")
+        os.rename(stage, destination)
+        stage = None
+        return SubmissionPlan(destination, plan_bytes)
+    finally:
+        os.close(lock_fd)
+        lock.unlink()
+        if stage is not None:
+            stage.chmod(0o700)
+            shutil.rmtree(stage)
+
+
+def verify_submission(directory: Path, expected_sha256: str) -> SubmissionPlan:
+    """Recheck a published handoff against an externally retained plan digest."""
+    directory = _root(directory)
+    plan = _read(directory, "plan.json").data
+    if _digest(plan) != expected_sha256:
+        raise SubmissionError("Plan digest mismatch")
+    core = _load_json(plan)
+    if (
+        not isinstance(core, dict)
+        or core.get("schema_version") != 1
+        or not isinstance(core.get("outputs"), dict)
+    ):
+        raise SubmissionError("Unsupported plan")
+    names = _paths(list(core["outputs"]))
+    if {"plan.json", "plan.sha256"} & set(names):
+        raise SubmissionError("Plan cannot hash itself")
+    _inventory(directory, set(names) | {"plan.json", "plan.sha256"})
+    for name, evidence in core["outputs"].items():
+        _check_record(_read(directory, name).data, evidence)
+    if _read(directory, "plan.sha256").data != (expected_sha256 + "  plan.json\n").encode("ascii"):
+        raise SubmissionError("External digest file mismatch")
+    return SubmissionPlan(directory, plan)
+
+
+def refresh_inventory(plan: SubmissionPlan) -> None:
+    """Live exact-ID observations belong to milestone B; never imply availability."""
+    raise NotImplementedError("Live inventory composition is pending milestone B of #5142")

--- a/tests/test_submission_plan.py
+++ b/tests/test_submission_plan.py
@@ -446,3 +446,74 @@ def test_claimed_destination_is_not_touched(inputs):
         sp.prepare_submission(**inputs)
     assert lock.read_bytes() == b"peer owns publication"
     assert not inputs["destination"].exists()
+
+
+def _context_signature(context):
+    return (
+        context.prec,
+        context.rounding,
+        context.Emin,
+        context.Emax,
+        context.capitals,
+        context.clamp,
+        dict(context.traps),
+        dict(context.flags),
+    )
+
+
+@pytest.mark.parametrize("rounding", ["ROUND_DOWN", "ROUND_UP", "ROUND_HALF_EVEN"])
+def test_public_plan_ignores_decimal_context(inputs, tmp_path, rounding):
+    from decimal import localcontext
+
+    # More significant digits than even the default 28-digit context, plus
+    # an exponent outside the deliberately hostile caller context.
+    exact_x = "10.5000000000000000000000000000000000000000000001"
+    rewrite_csv(inputs, "cpl", lambda rows: rows[1].__setitem__(3, exact_x + "mm"))
+    rewrite_csv(inputs, "cpl", lambda rows: rows[1].__setitem__(4, "1e-1000mm"))
+    normal = sp.prepare_submission(**inputs)
+    matches = json.loads((normal.directory / "expected-matches.json").read_bytes())
+    assert matches[0]["x_mm"] == exact_x
+    assert matches[0]["y_mm"] == "1E-1000"
+    with localcontext() as context:
+        context.prec = 2
+        context.rounding = rounding
+        context.Emin, context.Emax = -1, 1
+        context.capitals, context.clamp = 0, 1
+        for signal in context.traps:
+            context.traps[signal] = True
+        before = _context_signature(context)
+        other = sp.prepare_submission(**(inputs | {"destination": tmp_path / "hostile"}))
+        assert _context_signature(context) == before
+    assert other.plan_bytes == normal.plan_bytes
+    assert other.sha256 == normal.sha256
+    assert (other.directory / "expected-matches.json").read_bytes() == (
+        normal.directory / "expected-matches.json"
+    ).read_bytes()
+
+
+@pytest.mark.parametrize("value", ["1000001", "-1000001", "1000000.000000000000000000000000000001"])
+def test_numeric_limit_is_exact_under_rounding(inputs, value):
+    from decimal import localcontext
+
+    rewrite_csv(inputs, "cpl", lambda rows: rows[1].__setitem__(3, value))
+    with localcontext() as context:
+        context.prec = 2
+        context.rounding = "ROUND_DOWN"
+        before = _context_signature(context)
+        with pytest.raises(sp.SubmissionError, match="out-of-range"):
+            sp.prepare_submission(**inputs)
+        assert _context_signature(context) == before
+    assert not inputs["destination"].exists()
+
+
+def test_invalid_decimal_does_not_change_caller_flags(inputs):
+    from decimal import localcontext
+
+    rewrite_csv(inputs, "cpl", lambda rows: rows[1].__setitem__(3, "not-a-number"))
+    with localcontext() as context:
+        for signal in context.traps:
+            context.traps[signal] = False
+        before = _context_signature(context)
+        with pytest.raises(sp.SubmissionError):
+            sp.prepare_submission(**inputs)
+        assert _context_signature(context) == before

--- a/tests/test_submission_plan.py
+++ b/tests/test_submission_plan.py
@@ -1,0 +1,448 @@
+"""Synthetic offline handoffs; no supplier responses or private board data."""
+
+import csv
+import hashlib
+import io
+import json
+
+import pytest
+
+from kicad_tools.export import submission_plan as sp
+
+
+def digest(data):
+    return hashlib.sha256(data).hexdigest()
+
+
+def csv_bytes(headers, rows):
+    stream = io.StringIO(newline="")
+    writer = csv.writer(stream, lineterminator="\r\n")
+    writer.writerow(headers)
+    writer.writerows(rows)
+    return b"\xef\xbb\xbf" + stream.getvalue().encode()
+
+
+@pytest.fixture
+def inputs(tmp_path):
+    bundle = tmp_path / "bundle"
+    bundle.mkdir()
+    source = tmp_path / "source"
+    source.mkdir()
+    # 24 rows, 21 exact IDs, 85 unique placements. Last three rows repeat IDs.
+    rows, placements = [], []
+    cursor = 1
+    for row in range(24):
+        refs = [f"R{i}" for i in range(cursor, cursor + (4 if row < 13 else 3))]
+        cursor += len(refs)
+        rows.append(["10k", ",".join(refs), "R_0402", f"C{row % 21 + 1}", len(refs)])
+        placements.extend(
+            [[ref, "10k", "R_0402", "10.5000mm", "20mm", "90.0", "Top"] for ref in refs]
+        )
+    (bundle / "bom.csv").write_bytes(
+        csv_bytes(["Comment", "Designator", "Footprint", "LCSC Part #", "Quantity"], rows)
+    )
+    (bundle / "cpl.csv").write_bytes(
+        csv_bytes(
+            ["Designator", "Val", "Package", "Mid X", "Mid Y", "Rotation", "Layer"], placements
+        )
+    )
+    (bundle / "gerbers.zip").write_bytes(b"PK\x03\x04\x00synthetic-exact-zip-bytes\xff\r\n")
+    (source / "board.kicad_pcb").write_bytes(b"synthetic PCB\r\n")
+    (source / "board.kicad_sch").write_bytes(b"synthetic schematic\n")
+    sources = {
+        role: sp.SourceEvidence(
+            name, digest((source / name).read_bytes()), (source / name).stat().st_size
+        )
+        for role, name in [("pcb", "board.kicad_pcb"), ("schematic", "board.kicad_sch")]
+    }
+    args = {
+        "bundle_root": bundle,
+        "source_root": source,
+        "source_evidence": sources,
+        "bundle_files": ("gerbers.zip", "bom.csv", "cpl.csv"),
+        "artifacts": {"gerber": "gerbers.zip", "bom": "bom.csv", "cpl": "cpl.csv"},
+        "board_quantity": 1,
+        "settings": sp.FactorySettings("jlcpcb", 4, ("top",)),
+        "destination": tmp_path / "handoff",
+    }
+    refresh_manifest(args)
+    return args
+
+
+def refresh_manifest(args):
+    bundle = args["bundle_root"]
+    files = {
+        name: {
+            "sha256": digest((bundle / name).read_bytes()),
+            "size": (bundle / name).stat().st_size,
+        }
+        for name in args["bundle_files"]
+    }
+    (bundle / "manifest.json").write_text(json.dumps({"version": "1.0", "files": files}))
+
+
+def rewrite_csv(args, role, edit):
+    path = args["bundle_root"] / args["artifacts"][role]
+    rows = list(csv.reader(io.StringIO(path.read_bytes().decode("utf-8-sig"))))
+    edit(rows)
+    path.write_bytes(csv_bytes(rows[0], rows[1:]))
+    refresh_manifest(args)
+
+
+def test_exact_bytes_demand_and_determinism(inputs, tmp_path):
+    before = {p.name: p.read_bytes() for p in inputs["bundle_root"].iterdir()}
+    plan = sp.prepare_submission(**inputs)
+    core = json.loads(plan.plan_bytes)
+    assert plan.sha256 == digest(plan.plan_bytes)
+    assert core["schema_version"] == 1
+    assert core["states"] == {
+        "preparation": "local-integrity-valid",
+        "inventory": "unknown",
+        "human_approval": "not-established",
+        "factory_matching": "not-observed",
+        "upload": "not-performed",
+        "order": "not-performed",
+    }
+    assert len(core["demand"]) == 21
+    assert sum(item["per_board"] for item in core["demand"]) == 85
+    assert {item["catalog_id"]: item["per_board"] for item in core["demand"]} == {
+        f"C{i}": (7 if i <= 3 else 4 if i <= 13 else 3) for i in range(1, 22)
+    }
+    assert all(item["required"] == item["per_board"] for item in core["demand"])
+    matches = json.loads((plan.directory / "expected-matches.json").read_bytes())
+    assert len(matches) == 85
+    assert len({r["reference"] for r in matches}) == 85
+    for role, name in inputs["artifacts"].items():
+        assert (plan.directory / name).read_bytes() == before[name]
+    assert before == {p.name: p.read_bytes() for p in inputs["bundle_root"].iterdir()}
+    assert not (plan.directory / "bom.csv").stat().st_mode & 0o222
+    again = sp.prepare_submission(**(inputs | {"destination": tmp_path / "again"}))
+    assert again.plan_bytes == plan.plan_bytes
+    assert sp.verify_submission(plan.directory, plan.sha256) == plan
+    ten = sp.prepare_submission(
+        **(inputs | {"destination": tmp_path / "ten", "board_quantity": 10})
+    )
+    assert ten.sha256 != plan.sha256
+    assert sum(d["required"] for d in json.loads(ten.plan_bytes)["demand"]) == 850
+    assert all(d["required"] == d["per_board"] * 10 for d in json.loads(ten.plan_bytes)["demand"])
+    with pytest.raises(sp.SubmissionError, match="exists"):
+        sp.prepare_submission(**inputs)
+
+
+@pytest.mark.parametrize("quantity", [True, False, 0, -1, 1.5, "10", None])
+def test_quantity_is_positive_integer(inputs, quantity):
+    with pytest.raises(sp.SubmissionError):
+        sp.prepare_submission(**(inputs | {"board_quantity": quantity}))
+    assert not inputs["destination"].exists()
+
+
+@pytest.mark.parametrize(
+    "mutation", ["missing", "changed", "extra", "hash", "size", "source", "source-evidence"]
+)
+def test_integrity_failures_do_not_publish(inputs, mutation):
+    bundle = inputs["bundle_root"]
+    if mutation == "missing":
+        (bundle / "gerbers.zip").unlink()
+    elif mutation == "changed":
+        (bundle / "bom.csv").write_bytes(b"modified")
+    elif mutation == "extra":
+        (bundle / "unexpected.txt").write_bytes(b"extra")
+    elif mutation in ("hash", "size"):
+        path = bundle / "manifest.json"
+        data = json.loads(path.read_text())
+        del data["files"]["bom.csv"]["sha256" if mutation == "hash" else "size"]
+        path.write_text(json.dumps(data))
+    elif mutation == "source":
+        (inputs["source_root"] / "board.kicad_pcb").write_bytes(b"changed")
+    else:
+        inputs["source_evidence"] = {}
+    with pytest.raises(sp.SubmissionError):
+        sp.prepare_submission(**inputs)
+    assert not inputs["destination"].exists()
+
+
+@pytest.mark.parametrize(
+    "edit",
+    [
+        lambda rows: rows.append(rows[1]),
+        lambda rows: rows[1].__setitem__(1, "R1,R1,R2,R3"),
+        lambda rows: rows[1].__setitem__(1, ""),
+        lambda rows: rows[1].__setitem__(3, "C0"),
+        lambda rows: rows[1].__setitem__(4, "5"),
+        lambda rows: rows.append(["x", "R1", "R_0402", "C999", "1"]),
+        lambda rows: rows[0].append("Unknown"),
+    ],
+)
+def test_strict_bom_rejects_ambiguity(inputs, edit):
+    rewrite_csv(inputs, "bom", edit)
+    with pytest.raises(sp.SubmissionError):
+        sp.prepare_submission(**inputs)
+    assert not inputs["destination"].exists()
+
+
+@pytest.mark.parametrize(
+    "edit",
+    [
+        lambda rows: rows.pop(),
+        lambda rows: rows.append(rows[1]),
+        lambda rows: rows.append(["R999", "10k", "R_0402", "10mm", "20mm", "90", "Top"]),
+        lambda rows: rows[1].__setitem__(3, "nan"),
+        lambda rows: rows[1].__setitem__(6, "Bottom"),
+        lambda rows: rows[1].__setitem__(1, "different value"),
+    ],
+)
+def test_strict_cpl_coverage_and_fields(inputs, edit):
+    rewrite_csv(inputs, "cpl", edit)
+    with pytest.raises(sp.SubmissionError):
+        sp.prepare_submission(**inputs)
+
+
+def test_exclusions_cannot_silently_filter_frozen_uploads(inputs):
+    with pytest.raises(sp.SubmissionError, match="exclusion"):
+        sp.prepare_submission(**(inputs | {"exclusions": {"R1": "dnp"}}))
+    plan = sp.prepare_submission(**(inputs | {"exclusions": {"J1": "tht", "R999": "dnp"}}))
+    assert json.loads(plan.plan_bytes)["exclusions"] == {"J1": "tht", "R999": "dnp"}
+    assert len(json.loads((plan.directory / "expected-matches.json").read_bytes())) == 85
+
+
+@pytest.mark.parametrize(
+    "path", ["../bom.csv", "./bom.csv", "x/../bom.csv", "/bom.csv", "x//bom.csv", "x\\bom.csv"]
+)
+def test_noncanonical_paths(inputs, path):
+    inputs["artifacts"]["bom"] = path
+    with pytest.raises(sp.SubmissionError):
+        sp.prepare_submission(**inputs)
+
+
+def test_duplicate_and_ambiguous_names(inputs):
+    with pytest.raises(sp.SubmissionError):
+        sp.prepare_submission(**(inputs | {"bundle_files": (*inputs["bundle_files"], "bom.csv")}))
+    with pytest.raises(sp.SubmissionError):
+        sp.prepare_submission(
+            **(inputs | {"output_names": {"gerber": "same", "bom": "same", "cpl": "cpl.csv"}})
+        )
+    with pytest.raises(sp.SubmissionError):
+        sp.prepare_submission(
+            **(
+                inputs
+                | {"output_names": {"gerber": "plan.json", "bom": "bom.csv", "cpl": "cpl.csv"}}
+            )
+        )
+
+
+@pytest.mark.parametrize("kind", ["file", "directory", "source", "root"])
+def test_symlinks_rejected(inputs, tmp_path, kind):
+    if kind == "root":
+        link = tmp_path / "bundle-link"
+        link.symlink_to(inputs["bundle_root"], target_is_directory=True)
+        inputs["bundle_root"] = link
+    elif kind == "directory":
+        (inputs["bundle_root"] / "outside").symlink_to(
+            inputs["source_root"], target_is_directory=True
+        )
+    else:
+        target = (
+            (inputs["source_root"] / "board.kicad_pcb")
+            if kind == "source"
+            else (inputs["bundle_root"] / "gerbers.zip")
+        )
+        outside = tmp_path / "outside"
+        outside.write_bytes(target.read_bytes())
+        target.unlink()
+        target.symlink_to(outside)
+    with pytest.raises(sp.SubmissionError):
+        sp.prepare_submission(**inputs)
+
+
+@pytest.mark.parametrize("mutate", ["artifact", "source", "manifest", "extra", "write-failure"])
+def test_mutation_during_copy_is_atomic(inputs, monkeypatch, mutate):
+    write = sp._write_bytes
+    changed = False
+
+    def racing_write(path, data):
+        nonlocal changed
+        write(path, data)
+        if not changed:
+            changed = True
+            if mutate == "write-failure":
+                raise OSError("simulated write failure")
+            target = {
+                "artifact": inputs["bundle_root"] / "gerbers.zip",
+                "source": inputs["source_root"] / "board.kicad_pcb",
+                "manifest": inputs["bundle_root"] / "manifest.json",
+                "extra": inputs["bundle_root"] / "extra",
+            }[mutate]
+            target.write_bytes(b"mutated")
+
+    monkeypatch.setattr(sp, "_write_bytes", racing_write)
+    with pytest.raises((sp.SubmissionError, OSError)):
+        sp.prepare_submission(**inputs)
+    assert not inputs["destination"].exists()
+    assert not list(inputs["destination"].parent.glob(".handoff.stage-*"))
+
+
+def test_identity_binds_raw_records_settings_and_sources(inputs, tmp_path):
+    first = sp.prepare_submission(**inputs)
+    rewrite_csv(
+        inputs, "bom", lambda rows: rows.__setitem__(slice(1, None), list(reversed(rows[1:])))
+    )
+    reordered = sp.prepare_submission(**(inputs | {"destination": tmp_path / "reordered"}))
+    assert first.sha256 != reordered.sha256  # Raw BOM hash changes despite same semantics.
+    assert (first.directory / "expected-matches.json").read_bytes() == (
+        reordered.directory / "expected-matches.json"
+    ).read_bytes()
+    changed = sp.prepare_submission(
+        **(
+            inputs
+            | {
+                "destination": tmp_path / "settings",
+                "settings": sp.FactorySettings("jlcpcb", 2, ("top",)),
+            }
+        )
+    )
+    assert changed.sha256 != reordered.sha256
+    path = inputs["source_root"] / "board.kicad_pcb"
+    path.write_bytes(b"new source")
+    inputs["source_evidence"]["pcb"] = sp.SourceEvidence(
+        path.name, digest(path.read_bytes()), path.stat().st_size
+    )
+    source = sp.prepare_submission(**(inputs | {"destination": tmp_path / "newsource"}))
+    assert source.sha256 != reordered.sha256
+
+
+def test_reverify_rejects_tampering_and_extra_files(inputs):
+    plan = sp.prepare_submission(**inputs)
+    plan.directory.chmod(0o700)
+    (plan.directory / "extra").write_text("extra")
+    with pytest.raises(sp.SubmissionError):
+        sp.verify_submission(plan.directory, plan.sha256)
+
+
+def test_live_refresh_is_explicitly_unsupported():
+    with pytest.raises(NotImplementedError, match="milestone B"):
+        sp.refresh_inventory(None)
+
+
+@pytest.mark.parametrize(
+    "settings",
+    [
+        sp.FactorySettings("unknown-factory", 4, ("top",)),
+        sp.FactorySettings("jlcpcb", True, ("top",)),
+        sp.FactorySettings("jlcpcb", 0, ("top",)),
+        sp.FactorySettings("jlcpcb", 4, ()),
+        sp.FactorySettings("jlcpcb", 4, ("top", "top")),
+        sp.FactorySettings("jlcpcb", 4, ("arbitrary-vendor-code",)),
+    ],
+)
+def test_invalid_settings(inputs, settings):
+    with pytest.raises(sp.SubmissionError):
+        sp.prepare_submission(**(inputs | {"settings": settings}))
+    assert not inputs["destination"].exists()
+
+
+def test_no_network_or_clients_for_preparation(inputs, monkeypatch):
+    import socket
+
+    def forbidden(*args, **kwargs):
+        pytest.fail("Offline preparation attempted network I/O")
+
+    monkeypatch.setattr(socket.socket, "connect", forbidden)
+    monkeypatch.setattr(socket, "create_connection", forbidden)
+    monkeypatch.setenv("JLCPCB_API_KEY", "must-not-appear-in-plan")
+    plan = sp.prepare_submission(**inputs)
+    assert b"must-not-appear-in-plan" not in plan.plan_bytes
+    with pytest.raises(sp.SubmissionError):
+        sp.prepare_submission(**(inputs | {"board_quantity": 0}))
+
+
+def test_nested_exact_paths_and_explicit_output_names(inputs):
+    bundle = inputs["bundle_root"]
+    (bundle / "gerbers").mkdir()
+    (bundle / "gerbers.zip").rename(bundle / "gerbers" / "actual.zip")
+    inputs["bundle_files"] = ("gerbers/actual.zip", "bom.csv", "cpl.csv")
+    inputs["artifacts"]["gerber"] = "gerbers/actual.zip"
+    refresh_manifest(inputs)
+    plan = sp.prepare_submission(
+        **(
+            inputs
+            | {
+                "output_names": {
+                    "gerber": "fabrication.zip",
+                    "bom": "assembly.csv",
+                    "cpl": "placement.csv",
+                }
+            }
+        )
+    )
+    assert (plan.directory / "fabrication.zip").read_bytes() == (
+        bundle / "gerbers" / "actual.zip"
+    ).read_bytes()
+
+
+def test_no_legacy_filename_fallback(inputs):
+    bundle = inputs["bundle_root"]
+    (bundle / "nested").mkdir()
+    (bundle / "gerbers.zip").rename(bundle / "nested" / "gerbers.zip")
+    with pytest.raises(sp.SubmissionError):
+        sp.prepare_submission(**inputs)
+
+
+def test_duplicate_manifest_keys_are_not_last_value_wins(inputs):
+    path = inputs["bundle_root"] / "manifest.json"
+    path.write_text(
+        '{"files":{},"files":' + json.dumps(json.loads(path.read_text())["files"]) + "}"
+    )
+    with pytest.raises(sp.SubmissionError):
+        sp.prepare_submission(**inputs)
+
+
+def test_destination_bytes_verified_before_publish(inputs, monkeypatch):
+    original = sp._write_bytes
+
+    def corrupt(path, data):
+        original(path, data + b"corruption")
+
+    monkeypatch.setattr(sp, "_write_bytes", corrupt)
+    with pytest.raises(sp.SubmissionError, match="Destination bytes"):
+        sp.prepare_submission(**inputs)
+    assert not inputs["destination"].exists()
+
+
+def test_standard_export_headers_without_quantity(inputs):
+    rewrite_csv(inputs, "bom", lambda rows: [row.pop() for row in rows])
+    plan = sp.prepare_submission(**inputs)
+    assert sum(item["per_board"] for item in json.loads(plan.plan_bytes)["demand"]) == 85
+
+
+@pytest.mark.parametrize(
+    "mutation", ["boolean-size", "invalid-hash", "missing-source-path", "same-source-path"]
+)
+def test_source_evidence_is_complete_and_unambiguous(inputs, mutation):
+    evidence = inputs["source_evidence"]["pcb"]
+    if mutation == "boolean-size":
+        evidence = sp.SourceEvidence(evidence.path, evidence.sha256, True)
+    elif mutation == "invalid-hash":
+        evidence = sp.SourceEvidence(evidence.path, "not-a-sha256", evidence.size)
+    elif mutation == "missing-source-path":
+        evidence = sp.SourceEvidence("missing.kicad_pcb", evidence.sha256, evidence.size)
+    else:
+        evidence = inputs["source_evidence"]["schematic"]
+    inputs["source_evidence"]["pcb"] = evidence
+    with pytest.raises(sp.SubmissionError):
+        sp.prepare_submission(**inputs)
+    assert not inputs["destination"].exists()
+
+
+def test_destination_inside_frozen_input_is_rejected(inputs):
+    with pytest.raises(sp.SubmissionError):
+        sp.prepare_submission(**(inputs | {"destination": inputs["bundle_root"] / "handoff"}))
+    assert not (inputs["bundle_root"] / "handoff").exists()
+
+
+def test_claimed_destination_is_not_touched(inputs):
+    lock = inputs["destination"].parent / ".handoff.prepare-lock"
+    lock.write_bytes(b"peer owns publication")
+    with pytest.raises(sp.SubmissionError, match="claimed"):
+        sp.prepare_submission(**inputs)
+    assert lock.read_bytes() == b"peer owns publication"
+    assert not inputs["destination"].exists()


### PR DESCRIPTION
## Summary

Prepare an existing frozen manufacturing bundle as a deterministic offline assembly handoff, preserving selected Gerber ZIP/BOM/CPL bytes exactly. This implements **milestone A only** of #5142; the issue remains open for milestone B (exact-ID inventory composition).

## Changes

- Add `export.submission_plan.prepare_submission`, frozen evidence/settings/result models, and `verify_submission` with an externally retained plan digest.
- Require a complete manifest/file allowlist, explicit PCB/schematic hash-and-size bindings, canonical paths, distinct selected files/output names, and positive integer quantity. Reject missing/changed/extra files, aliases, symlinks and malformed CSV coverage.
- Parse the existing JLCPCB BOM/CPL dialect separately from copied bytes. Aggregate repeated IDs by distinct references before multiplying board quantity once; preserve explicit exclusions only when already absent from both uploads.
- Verify staged output bytes and reread input snapshots before publishing a read-only directory atomically. Never overwrite an existing handoff or instantiate a network/credential client.
- Emit versioned canonical plan bytes and a deterministic expected reference matching list, explicitly marking inventory unknown and approval/matching/upload/order unestablished or not performed.
- Document Python API, supported input dialect, layout, identity, atomicity and platform limitations. Live refresh explicitly raises `NotImplementedError` pending milestone B.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Exact frozen input/source evidence and closed file set | A complete | Missing/changed/extra files, incomplete hash/size evidence, source aliases, strict paths and symlinks rejected |
| Byte-exact copies and atomic failure | A complete | UTF-8 BOM/CRLF/ZIP preservation; input mutation and destination corruption injected during copying; no published partial output |
| Frozen BOM/CPL coverage and explicit population | A complete | Duplicate/missing/extra/conflicting references, quantity disagreement, invalid fields and populated exclusions rejected |
| Aggregate ID demand before multiplying once | A complete | Clearly synthetic 24 BOM rows / 21 IDs / 85 placements: per-ID assertions at quantities 1 and 10 (85 / 850 total) |
| Deterministic identity and expected matching list | A complete | Replay byte equality; changed quantity/settings/source/raw BOM invalidates identity; reordered BOM retains semantic expected list |
| No supplier/transaction/credential effects | A complete | Offline socket fail-if-called tests, credential environment sentinel absent from output, explicit unknown/not-performed states |
| Exact-ID live observation/provenance/snapshot composition | B outstanding | #5115 and #5090 still open at implementation check; no unsafe legacy Part.stock interpretation or fallback used |

## Test Plan

TDD: yes — the initial submission contract tests were written before the new module and failed because the API was absent; implementation made them pass, then additional failure-path controls were added.

- `uv sync --frozen --extra dev` passed after integration with current main.
- `uv run --frozen pytest tests/test_submission_plan.py --no-cov -p no:cacheprovider -q --timeout=30`: **66 passed**.
- Cold baseline-gated mypy: no new type errors, unchanged ledger.
- Changed-file Ruff lint/format, version gate and diff checks passed.

**Live verification NOT performed.** All fixtures are synthetic offline data. Milestone B remains tracked in #5142 and depends on integrated #5033/#5034 contracts (PRs #5115/#5090). No current inventory, factory match, upload or purchase evidence is claimed.

Limitations: POSIX descriptor-relative filesystem operations (Linux/macOS); complete declared input bytes are held in memory during preparation. Read-only files are accidental-write protection, not WORM storage; retain the external digest and reverify before reuse. Caller controls input roots/destination parent; a process crash may leave a hidden staging directory/lock. Factory settings express explicit factory/layers/sides intent, not a complete vendor order payload. Source hashes bind caller-supplied provenance; they do not independently prove Gerber generation or board readiness.

Part of #5142