### PR TITLE
fix(current-paths): respect physical copper layers and graph edges

### DIFF
--- a/src/kicad_tools/router/current_paths.py
+++ b/src/kicad_tools/router/current_paths.py
@@ -40,7 +40,7 @@ Three things this module deliberately does NOT do, by design:
   hiding them.
 
 Endpoint attachment is by pad **extent**, not by an exact pad-center hit
-(:func:`_pad_covers` / :func:`_bind_pad`): a router may terminate a trace
+(:func:`_pad_covers`): a router may terminate a trace
 anywhere inside a pad's copper, and a wide power pad is routinely entered
 by several stubs at once, all shorted by the pad itself. Binding on an
 exact center match instead reported such boards ``unresolved`` -- a *false*
@@ -48,6 +48,20 @@ fail-closed, which is not conservative at all: it teaches users to delete
 declarations, and a deleted declaration is exactly the silent pass this
 module exists to prevent. Copper outside the pad extent still never
 attaches, so the fail-closed direction is preserved where it is real.
+
+The declared-path graph is layer-aware. Only real same-net via spans or
+plated multilayer pad copper establish layer changes. Via/track centerline
+contacts and same-layer endpoint/interior contacts split graph edges, while
+public evidence retains each original routed segment once (including its
+whole length and width). Pad-internal convex copper is normalized before
+whole-component cycle detection; physical via arrays remain ambiguous.
+
+Unsupported custom/trapezoid pads, repeated physical pad numbers, and copper
+on absent stackup layers make the declaration unresolved. Supported pad
+extents are circles, rectangles, capsules (oval), and rounded rectangles.
+Width-only copper overlaps, arcs, zones, and pad-interior contacts without a
+track/via node are outside this bounded centerline model; a resolved result is not a native connectivity or ampacity
+claim. These contacts require a separate physical geometry model.
 
 Consumers:
 
@@ -149,6 +163,9 @@ from collections import deque
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import TYPE_CHECKING
+
+from kicad_tools.core.geometry import point_to_segment_distance, segments_intersect
+from kicad_tools.core.layers import COPPER_LAYER_ORDER, via_spans_layer
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
@@ -472,100 +489,209 @@ def _net_segments(pcb: PCB, net_name: str) -> list[Segment]:
     ]
 
 
-def _build_graph(
-    segments: list[Segment],
-) -> dict[tuple[float, float], list[tuple[tuple[float, float], Segment]]]:
-    adjacency: dict[tuple[float, float], list[tuple[tuple[float, float], Segment]]] = {}
+# Copper node identity includes the layer. Pad normalization below may replace
+# a node with another copper node, but never merges layers by XY alone.
+_Node = tuple[float, float, str]
+
+
+@dataclass(eq=False)
+class _GraphEdge:
+    """One graph edge; several split edges may retain the same routed segment."""
+
+    segment: Segment | None = None  # None is real via barrel copper
+
+
+@dataclass
+class _CopperGraph:
+    adjacency: dict[_Node, list[tuple[_Node, _GraphEdge]]] = field(default_factory=dict)
+    pads: dict[tuple[str, str], _Node] = field(default_factory=dict)
+    internal: dict[_Node, list[Segment]] = field(default_factory=dict)
+
+
+def _copper_node(point: tuple[float, float], layer: str) -> _Node:
+    return (*_node_key(point), layer)
+
+
+def _build_graph(segments: list[Segment], pcb: PCB, net_name: str) -> _CopperGraph:
+    """Build exact centerline contacts and normalize convex pad-internal copper.
+
+    Supported contacts are same-layer track endpoints (including a T landing
+    in a segment interior), via centers on a track, and nodes inside supported
+    pad copper. Width-only overlaps, zone/arc connectivity and arbitrary pad
+    primitives are not modeled; no proximity tolerance invents a connection.
+    This is not a general PCB connectivity solver.
+    """
+    layers = {layer.name for layer in pcb.copper_layers}
+    net = pcb.get_net_by_name(net_name)
+    vias = [
+        via
+        for via in pcb.vias
+        if (via.net_name == net_name or (net is not None and via.net_number == net.number))
+        and len(via.layers) == 2
+        and len(set(via.layers)) == 2
+        and all(layer in layers for layer in via.layers)
+    ]
+    contacts: dict[str, set[tuple[float, float]]] = {layer: set() for layer in layers}
     for seg in segments:
-        a, b = _node_key(seg.start), _node_key(seg.end)
-        adjacency.setdefault(a, []).append((b, seg))
-        adjacency.setdefault(b, []).append((a, seg))
-    return adjacency
+        contacts.setdefault(seg.layer, set()).update((_node_key(seg.start), _node_key(seg.end)))
+    # Proper same-layer centerline crossings are also contacts. Ignoring
+    # them can hide a real parallel route even when neither trace ends there.
+    for i, first in enumerate(segments):
+        for second in segments[i + 1 :]:
+            if first.layer != second.layer or not segments_intersect(
+                *first.start, *first.end, *second.start, *second.end
+            ):
+                continue
+            dx, dy = first.end[0] - first.start[0], first.end[1] - first.start[1]
+            ex, ey = second.end[0] - second.start[0], second.end[1] - second.start[1]
+            ox, oy = second.start[0] - first.start[0], second.start[1] - first.start[1]
+            t = (ox * ey - oy * ex) / (dx * ey - dy * ex)
+            point = _node_key((first.start[0] + t * dx, first.start[1] + t * dy))
+            contacts[first.layer].add(point)
+    for via in vias:
+        for layer in layers:
+            if via_spans_layer(via.layers, layer):
+                contacts[layer].add(_node_key(via.position))
+
+    edges: list[tuple[_Node, _Node, _GraphEdge]] = []
+    for seg in segments:
+        points = [
+            point
+            for point in contacts[seg.layer]
+            if point_to_segment_distance(*point, *seg.start, *seg.end) <= _PAD_EPS
+        ]
+        points.sort(key=lambda point: math.dist(point, seg.start))
+        for point_a, point_b in zip(points, points[1:], strict=False):
+            edges.append(
+                (
+                    _copper_node(point_a, seg.layer),
+                    _copper_node(point_b, seg.layer),
+                    _GraphEdge(seg),
+                )
+            )
+    for via in vias:
+        nodes = [
+            _copper_node(via.position, layer)
+            for layer in COPPER_LAYER_ORDER
+            if layer in layers and via_spans_layer(via.layers, layer)
+        ]
+        for a, b in zip(nodes, nodes[1:], strict=False):
+            edges.append((a, b, _GraphEdge()))
+
+    # Contract only contacts inside one physical convex pad. Adding a pad hub
+    # plus the original internal track edges instead manufactures false cycles.
+    # External branches remain separate edges, so real parallel returns survive.
+    parents = {node: node for a, b, _ in edges for node in (a, b)}
+
+    def root(node: _Node) -> _Node:
+        while parents[node] != node:
+            parents[node] = parents[parents[node]]
+            node = parents[node]
+        return node
+
+    pad_contacts: dict[tuple[str, str], list[_Node]] = {}
+    internal_edges: set[_GraphEdge] = set()
+    wholly_internal_ids: set[int] = set()
+    for fp in pcb.footprints:
+        for pad in fp.pads:
+            if pad.net_name != net_name or pad.type == "np_thru_hole":
+                continue
+            nodes = [
+                node
+                for node in parents
+                if (node[2] in pad.layers or "*.Cu" in pad.layers)
+                and _pad_covers(pcb, fp.reference, pad.number, node[:2])
+            ]
+            # Only a plated through-hole pad establishes interlayer copper.
+            groups = (
+                [nodes]
+                if pad.type == "thru_hole"
+                else [[node for node in nodes if node[2] == layer] for layer in layers]
+            )
+            for group in groups:
+                if group:
+                    members = set(group)
+                    internal_edges.update(
+                        edge for a, b, edge in edges if a in members and b in members
+                    )
+                    wholly_internal_ids.update(
+                        id(seg)
+                        for seg in segments
+                        if _copper_node(seg.start, seg.layer) in members
+                        and _copper_node(seg.end, seg.layer) in members
+                    )
+                    hub = root(group[0])
+                    for node in group[1:]:
+                        parents[root(node)] = hub
+            pad_contacts[(fp.reference, pad.number)] = nodes
+
+    graph = _CopperGraph()
+    for key, nodes in pad_contacts.items():
+        hubs = {root(node) for node in nodes}
+        if len(hubs) == 1:
+            graph.pads[key] = hubs.pop()
+    for a, b, edge in edges:
+        ra, rb = root(a), root(b)
+        graph.adjacency.setdefault(ra, [])
+        graph.adjacency.setdefault(rb, [])
+        if edge in internal_edges and a != b:
+            # A split piece inside a pad cannot cover its original segment's
+            # external tail. That original needs a traversed external edge;
+            # otherwise a dangling sense spur becomes trunk/reinforcement.
+            if edge.segment is not None and id(edge.segment) in wholly_internal_ids:
+                graph.internal.setdefault(ra, []).append(edge.segment)
+            continue
+        graph.adjacency[ra].append((rb, edge))
+        graph.adjacency[rb].append((ra, edge))
+    return graph
 
 
-def _bfs_path(
-    adjacency: dict[tuple[float, float], list[tuple[tuple[float, float], Segment]]],
-    start: tuple[float, float],
-    goal: tuple[float, float],
-) -> list[Segment] | None:
-    """Shortest (fewest-hop) segment chain from ``start`` to ``goal``, or None."""
-    if start == goal:
-        return []
+def _bfs_path(graph: _CopperGraph, start: _Node, goal: _Node) -> list[Segment] | None:
+    """Find a route, reporting each original routed segment exactly once."""
     visited = {start}
-    queue: deque[tuple[float, float]] = deque([start])
-    parent: dict[tuple[float, float], tuple[tuple[float, float], Segment]] = {}
+    queue = deque([start])
+    parent: dict[_Node, tuple[_Node, _GraphEdge]] = {}
     while queue:
         cur = queue.popleft()
         if cur == goal:
             break
-        for nxt, seg in adjacency.get(cur, []):
-            if nxt in visited:
-                continue
-            visited.add(nxt)
-            parent[nxt] = (cur, seg)
-            queue.append(nxt)
+        for nxt, edge in graph.adjacency.get(cur, []):
+            if nxt not in visited:
+                visited.add(nxt)
+                parent[nxt] = (cur, edge)
+                queue.append(nxt)
     if goal not in visited:
         return None
-    path_segments: list[Segment] = []
+    evidence = list(graph.internal.get(goal, []))
     node = goal
     while node != start:
-        prev, seg = parent[node]
-        # Pad shorts are pseudo-edges standing for a pad's own copper, not
-        # routed segments: they must not appear in the covered-segment set
-        # (nothing can check their width, and they are not "uncovered copper"
-        # a designer could route differently).
-        if not isinstance(seg, _PadShort):
-            path_segments.append(seg)
+        prev, edge = parent[node]
+        if edge.segment is not None:
+            evidence.append(edge.segment)
+        evidence.extend(graph.internal.get(prev, []))
         node = prev
-    path_segments.reverse()
-    return path_segments
+    # A via may split an original segment into several traversed graph edges.
+    # Audit/ampacity/reinforcement still operate on whole original segments.
+    return list({id(seg): seg for seg in reversed(evidence)}.values())
 
 
-def _component_has_cycle(
-    adjacency: dict[tuple[float, float], list[tuple[tuple[float, float], Segment]]],
-    start: tuple[float, float],
-) -> bool:
-    """True if the connected component containing ``start`` has a cycle.
+def _component_has_cycle(graph: _CopperGraph, start: _Node) -> bool:
+    """Keep the conservative whole-component ambiguity policy.
 
-    A cycle anywhere in the component reachable from a declared endpoint
-    means the net's copper offers more than one electrical route between
-    some pair of points in that component -- i.e. current entering at
-    ``start`` could split across parallel branches. This is a deliberately
-    coarse, whole-component check (not limited to routes between the
-    declared source and sink): the issue requires that a parallel return
-    or alternate-mode path never be silently collapsed into a single
-    confident result, and erring toward "ambiguous" is the fail-closed
-    direction.
+    Distinct split edges count separately, even when they refer to the same
+    original routed segment. Real via edges count too; there is no via-array
+    or current-sharing exception.
     """
     visited = {start}
     stack = [start]
-    seen_segment_ids: set[int] = set()
-    edge_count = 0
+    seen_edges: set[_GraphEdge] = set()
     while stack:
-        cur = stack.pop()
-        for nxt, seg in adjacency.get(cur, []):
-            seg_id = id(seg)
-            if seg_id not in seen_segment_ids:
-                seen_segment_ids.add(seg_id)
-                edge_count += 1
+        for nxt, edge in graph.adjacency.get(stack.pop(), []):
+            seen_edges.add(edge)
             if nxt not in visited:
                 visited.add(nxt)
                 stack.append(nxt)
-    return edge_count > len(visited) - 1
-
-
-class _PadShort:
-    """A zero-length pseudo-edge standing for a pad's own copper.
-
-    Every trace endpoint landing inside one pad is the *same* electrical
-    node -- the pad shorts them. Modelling that as an explicit edge (rather
-    than by rewriting node keys) keeps :func:`_component_has_cycle`'s
-    edge-vs-node counting honest: each instance is distinct, so ``id()``
-    dedup counts pad shorts exactly once each, and a pad that fans out to
-    branches which never rejoin still counts as a tree.
-    """
-
-    __slots__ = ()
+    return len(seen_edges) > len(visited) - 1
 
 
 def _pad_covers(pcb: PCB, ref: str, pad_number: str, point: tuple[float, float]) -> bool:
@@ -606,39 +732,27 @@ def _pad_covers(pcb: PCB, ref: str, pad_number: str, point: tuple[float, float])
     local_x = dx * cos_a - dy * sin_a
     local_y = dx * sin_a + dy * cos_a
 
-    if pad.shape in ("circle", "oval"):
-        return (local_x / half_w) ** 2 + (local_y / half_h) ** 2 <= 1.0 + _PAD_EPS
-    # rect / roundrect / trapezoid / custom: the bounding rectangle. Ignoring a
-    # roundrect's clipped corners over-approximates by at most a corner radius,
-    # which is far below any clearance a trace could legally end in.
-    return abs(local_x) <= half_w + _PAD_EPS and abs(local_y) <= half_h + _PAD_EPS
-
-
-def _bind_pad(
-    adjacency: dict[tuple[float, float], list[tuple[tuple[float, float], Segment]]],
-    pcb: PCB,
-    ref: str,
-    pad_number: str,
-    position: tuple[float, float],
-) -> tuple[float, float] | None:
-    """Attach a pad to the copper graph, returning its node (or None).
-
-    All graph nodes lying on the pad are shorted together through a hub node
-    at the pad's center, because the pad's own copper connects them. Returns
-    ``None`` -- the fail-closed outcome -- only when no copper touches the pad
-    at all.
-    """
-    hub = _node_key(position)
-    on_pad = [n for n in adjacency if _pad_covers(pcb, ref, pad_number, n)]
-    if not on_pad:
-        return None
-    for node in on_pad:
-        if node == hub:
-            continue
-        short = _PadShort()
-        adjacency.setdefault(hub, []).append((node, short))  # type: ignore[arg-type]
-        adjacency.setdefault(node, []).append((hub, short))  # type: ignore[arg-type]
-    return hub
+    if pad.shape == "circle":
+        radius = min(half_w, half_h)
+        return math.hypot(local_x, local_y) <= radius + _PAD_EPS
+    if pad.shape == "oval":
+        # KiCad ovals are capsules, not ellipses.
+        radius = min(half_w, half_h)
+        dx = max(abs(local_x) - (half_w - radius), 0.0)
+        dy = max(abs(local_y) - (half_h - radius), 0.0)
+        return math.hypot(dx, dy) <= radius + _PAD_EPS
+    if pad.shape == "rect":
+        return abs(local_x) <= half_w + _PAD_EPS and abs(local_y) <= half_h + _PAD_EPS
+    if pad.shape == "roundrect":
+        ratio = pad.roundrect_rratio
+        if not 0 <= ratio <= 0.5:
+            return False
+        radius = 2 * min(half_w, half_h) * ratio
+        dx = max(abs(local_x) - (half_w - radius), 0.0)
+        dy = max(abs(local_y) - (half_h - radius), 0.0)
+        return math.hypot(dx, dy) <= radius + _PAD_EPS
+    # Custom/trapezoid copper cannot be inferred from its bounding rectangle.
+    return False
 
 
 def _resolve_endpoint(
@@ -647,7 +761,13 @@ def _resolve_endpoint(
     fp = pcb.get_footprint(endpoint.ref)
     if fp is None:
         return None, f"component {endpoint.ref!r} not found on board"
-    pad = next((p for p in fp.pads if p.number == endpoint.pad), None)
+    matches = [p for p in fp.pads if p.number == endpoint.pad]
+    if len(matches) > 1:
+        return (
+            None,
+            f"pad {endpoint.label()} has multiple physical occurrences; contact is unsupported",
+        )
+    pad = matches[0] if matches else None
     if pad is None:
         return None, f"pad {endpoint.label()} not found on component {endpoint.ref!r}"
     if pad.net_name != expected_net:
@@ -721,9 +841,33 @@ def resolve_current_path(pcb: PCB, spec: CurrentPathSpec) -> PathResolution:
             sink=sink,
         )
 
-    adjacency = _build_graph(net_segments)
+    # Unknown shapes or repeated physical pad numbers might hide alternate
+    # routes. Refuse the net rather than silently ignoring their copper.
+    unsupported = None
+    for fp in pcb.footprints:
+        seen_numbers: set[str] = set()
+        for pad in fp.pads:
+            if pad.net_name != spec.net_name or pad.type == "np_thru_hole":
+                continue
+            if pad.number in seen_numbers or pad.shape not in {
+                "rect",
+                "roundrect",
+                "circle",
+                "oval",
+            }:
+                unsupported = f"unsupported physical pad contact at {fp.reference}.{pad.number}"
+            seen_numbers.add(pad.number)
+    layers = {layer.name for layer in pcb.copper_layers}
+    if any(seg.layer not in layers for seg in net_segments):
+        unsupported = "routed copper uses a layer absent from the board stackup"
+    if unsupported:
+        return PathResolution(
+            spec=spec, status=STATUS_UNRESOLVED, reason=unsupported, source=source, sink=sink
+        )
 
-    if _node_key(source.position) == _node_key(sink.position):
+    adjacency = _build_graph(net_segments, pcb, spec.net_name)
+
+    if spec.source == spec.sink:
         # Degenerate self-path: a declaration whose source and sink are the
         # same pad covers no copper, so it resolves trivially without needing
         # anything attached to the graph at all (preserved from before the
@@ -739,8 +883,8 @@ def resolve_current_path(pcb: PCB, spec: CurrentPathSpec) -> PathResolution:
     # path as "unresolved" -- a FALSE fail-closed, which teaches users to
     # delete declarations and is every bit as unsafe as the silent pass this
     # rule exists to prevent.
-    start = _bind_pad(adjacency, pcb, source.ref, source.pad, source.position)
-    goal = _bind_pad(adjacency, pcb, sink.ref, sink.pad, sink.position)
+    start = adjacency.pads.get((source.ref, source.pad))
+    goal = adjacency.pads.get((sink.ref, sink.pad))
 
     if start is None:
         return PathResolution(

--- a/tests/test_cli_check_current_paths.py
+++ b/tests/test_cli_check_current_paths.py
@@ -303,3 +303,34 @@ class TestErrorPaths:
         captured = capsys.readouterr()
         assert "--no-current-paths" in captured.err
         assert "--current-paths" in captured.err
+
+
+@pytest.mark.parametrize("bridge", [False, True])
+def test_cli_cross_layer_path_requires_via(tmp_path, bridge):
+    board = tmp_path / "layers.kicad_pcb"
+    copper = _T_NETWORK_PCB_TEMPLATE.format(
+        trunk_width=ADEQUATE_TRUNK_WIDTH_MM, sense_width=SENSE_WIDTH_MM
+    )
+    copper = copper.replace(
+        f'(end 120 50) (width {ADEQUATE_TRUNK_WIDTH_MM}) (layer "F.Cu")',
+        f'(end 120 50) (width {ADEQUATE_TRUNK_WIDTH_MM}) (layer "B.Cu")',
+    )
+    assert f'(end 120 50) (width {ADEQUATE_TRUNK_WIDTH_MM}) (layer "B.Cu")' in copper
+    if bridge:
+        copper = (
+            copper.rstrip()[:-1]
+            + '(via (at 60 50) (size 0.8) (drill 0.4) (layers "F.Cu" "B.Cu") (net 1))\n)\n'
+        )
+    board.write_text(copper)
+    before = board.read_bytes()
+    sidecar = _write_sidecar(tmp_path / "cp.json", [_trunk_spec(), _sense_spec()])
+    report = tmp_path / "report.json"
+    status = _run_check(board, report, extra=["--current-paths", str(sidecar)])
+    violations = _path_ampacity_violations(report)
+    if bridge:
+        assert status == 0
+        assert violations == []
+    else:
+        assert status == 2
+        assert any("unresolved" in v["message"].lower() for v in violations)
+    assert board.read_bytes() == before

--- a/tests/test_current_paths.py
+++ b/tests/test_current_paths.py
@@ -75,8 +75,8 @@ def _t_network_pcb(*, trunk_width: float = 3.0, sense_width: float = 0.2):
 
     The junction sits at an explicit vertex (the trunk is routed as two
     segments meeting there), matching how a real T-tap is routed -- a
-    single continuous trunk segment with a spur touching its *interior*
-    would not form a graph node for the tap.
+    single continuous trunk segment also connects an exact same-layer
+    spur endpoint touching its interior.
     """
     from kicad_tools.schema.pcb import PCB
 
@@ -532,3 +532,234 @@ class TestReinforcementEligibleSegmentIds:
     def test_empty_specs_yields_empty_set(self) -> None:
         pcb = _t_network_pcb()
         assert reinforcement_eligible_segment_ids(pcb, []) == set()
+
+
+class TestPhysicalLayerGraph:
+    @pytest.mark.parametrize("bridge", ["missing", "wrong-net", "blind", "malformed", "valid"])
+    def test_cross_layer_t_requires_real_bridge(self, bridge):
+        pcb = _t_network_pcb()
+        pcb.segments[1].layer = "B.Cu"
+        if bridge != "missing":
+            via = pcb.add_via(60, 50, net="OTHER" if bridge == "wrong-net" else "NET1")
+            if bridge == "blind":
+                via.layers = ["F.Cu", "In1.Cu"]
+            if bridge == "malformed":
+                via.layers = ["F.Cu", "garbage", "B.Cu"]
+        resolution = resolve_current_path(pcb, _trunk_spec())
+        assert resolution.status == ("resolved" if bridge == "valid" else "unresolved")
+        if bridge == "valid":
+            assert {id(s) for s in resolution.segments} == {id(s) for s in pcb.segments[:2]}
+            assert resolution.length_mm == pytest.approx(100)
+        else:
+            assert not reinforcement_eligible_segment_ids(pcb, [_trunk_spec()])
+
+    @staticmethod
+    def _interior_pcb(*, split=False, reverse=False, receiving_layer="B.Cu"):
+        from kicad_tools.schema.pcb import PCB
+
+        pcb = PCB.create(layers=4)
+        _add_pad_footprint(pcb, ref="J1", x=20, y=50, net="NET1")
+        _add_pad_footprint(pcb, ref="J2", x=120, y=50, net="NET1")
+        pcb.add_trace((20, 50), (60, 50), width=3, layer="F.Cu", net="NET1")
+        pieces = [((40, 50), (60, 50)), ((60, 50), (120, 50))] if split else [((40, 50), (120, 50))]
+        for start, end in pieces:
+            pcb.add_trace(start, end, width=3, layer=receiving_layer, net="NET1")
+        pcb.add_via(60, 50, net="NET1")
+        if reverse:
+            pcb._segments.reverse()
+            for seg in pcb.segments:
+                seg.start, seg.end = seg.end, seg.start
+        return pcb
+
+    @pytest.mark.parametrize("split", [False, True])
+    @pytest.mark.parametrize("reverse", [False, True])
+    def test_interior_via_original_evidence(self, split, reverse):
+        pcb = self._interior_pcb(split=split, reverse=reverse)
+        original_ids = {id(seg) for seg in pcb.segments}
+        result = resolve_current_path(pcb, _trunk_spec())
+        assert result.ok
+        expected = [
+            s
+            for s in pcb.segments
+            if not (split and max(s.start[0], s.end[0]) == 60 and s.layer == "B.Cu")
+        ]
+        assert {id(s) for s in result.segments} == {id(s) for s in expected}
+        assert result.length_mm == pytest.approx(sum(_seg_len(s) for s in expected))
+        assert reinforcement_eligible_segment_ids(pcb, [_trunk_spec()]) == {id(s) for s in expected}
+        audit = audit_current_paths(pcb, [_trunk_spec()])
+        assert {id(s) for s in audit.uncovered.get("NET1", [])} == original_ids - {
+            id(s) for s in expected
+        }
+
+    @pytest.mark.parametrize(
+        "receiving_layer,span,expected",
+        [
+            ("In1.Cu", ["F.Cu", "B.Cu"], "resolved"),
+            ("In1.Cu", ["F.Cu", "In1.Cu"], "resolved"),
+            ("B.Cu", ["F.Cu", "In1.Cu"], "unresolved"),
+            ("In1.Cu", ["In2.Cu", "B.Cu"], "unresolved"),
+        ],
+    )
+    def test_interior_via_span(self, receiving_layer, span, expected):
+        pcb = self._interior_pcb(receiving_layer=receiving_layer)
+        pcb.vias[0].layers = span
+        assert resolve_current_path(pcb, _trunk_spec()).status == expected
+
+    def test_split_edges_count_as_distinct_cycle_edges(self):
+        pcb = self._interior_pcb()
+        # Three via contacts split the SAME B.Cu segment. Counting original
+        # segment IDs undercounts graph edges and misses this physical cycle.
+        pcb.add_trace((60, 50), (100, 50), width=3, layer="F.Cu", net="NET1")
+        pcb.add_via(80, 50, net="NET1")
+        pcb.add_via(100, 50, net="NET1")
+        assert resolve_current_path(pcb, _trunk_spec()).status == "ambiguous"
+        pcb._segments.reverse()
+        assert resolve_current_path(pcb, _trunk_spec()).status == "ambiguous"
+
+    def test_unused_vias_split_evidence_without_duplicate_accounting(self):
+        pcb = _t_network_pcb()
+        for x in (30, 40, 50):
+            pcb.add_via(x, 50, net="NET1")
+        result = resolve_current_path(pcb, _trunk_spec())
+        assert result.ok
+        assert len(result.segments) == 2
+        assert result.length_mm == pytest.approx(100)
+        assert audit_current_paths(pcb, [_trunk_spec(), _sense_spec()]).fully_covered
+
+    def test_interior_via_nearby_is_not_contact(self):
+        pcb = self._interior_pcb()
+        pcb.vias[0].position = (60, 50.01)
+        assert not resolve_current_path(pcb, _trunk_spec()).ok
+
+    @pytest.mark.parametrize(
+        "pad_type,layers,expected",
+        [
+            ("thru_hole", ["*.Cu"], "resolved"),
+            ("smd", ["F.Cu"], "unresolved"),
+            ("np_thru_hole", ["*.Cu"], "unresolved"),
+        ],
+    )
+    def test_actual_intermediate_pad_copper_bridges_layers(self, pad_type, layers, expected):
+        pcb = _t_network_pcb()
+        pcb.segments[1].layer = "B.Cu"
+        _add_pad_footprint(pcb, ref="TP1", x=60, y=50, net="NET1")
+        pad = pcb.get_footprint("TP1").pads[0]
+        pad.type, pad.layers = pad_type, layers
+        assert resolve_current_path(pcb, _trunk_spec()).status == expected
+
+    def test_distinct_pads_at_same_xy_do_not_make_self_path(self):
+        pcb = _t_network_pcb()
+        _add_pad_footprint(pcb, ref="BACK", x=20, y=50, net="NET1")
+        for ref, layer in (("J1", "F.Cu"), ("BACK", "B.Cu")):
+            pad = pcb.get_footprint(ref).pads[0]
+            pad.type, pad.layers = "smd", [layer]
+        pcb.add_trace((20, 50), (20, 40), width=1, layer="B.Cu", net="NET1")
+        spec = CurrentPathSpec(
+            name="opposite",
+            net_name="NET1",
+            source=PathEndpoint("J1", "1"),
+            sink=PathEndpoint("BACK", "1"),
+            continuous_a=1,
+        )
+        assert resolve_current_path(pcb, spec).status == "unresolved"
+
+    def test_pad_internal_star_does_not_manufacture_cycle(self):
+        pcb = _t_network_pcb()
+        # Both endpoints are within J1's copper. The pad already shorts
+        # these points, so this internal stub is not a physical return path.
+        pcb.add_trace((20, 50), (20.2, 50), width=1, layer="F.Cu", net="NET1")
+        pcb.add_trace((20.2, 50), (20.2, 40), width=1, layer="F.Cu", net="NET1")
+        result = resolve_current_path(pcb, _trunk_spec())
+        assert result.ok
+        assert len({id(s) for s in result.segments}) == len(result.segments)
+        # Rejoining outside the pad is a real parallel route and stays ambiguous.
+        pcb.add_trace((20.2, 40), (60, 50), width=1, layer="F.Cu", net="NET1")
+        assert resolve_current_path(pcb, _trunk_spec()).status == "ambiguous"
+
+    @pytest.mark.parametrize("shape", ["custom", "trapezoid"])
+    def test_unsupported_pad_shapes_fail_closed(self, shape):
+        pcb = _t_network_pcb()
+        pcb.get_footprint("J1").pads[0].shape = shape
+        assert resolve_current_path(pcb, _trunk_spec()).status == "unresolved"
+
+    def test_roundrect_clipped_corner_not_copper(self):
+        pcb = _t_network_pcb()
+        pad = pcb.get_footprint("J1").pads[0]
+        pad.shape, pad.size, pad.roundrect_rratio = "roundrect", (2, 2), 0.5
+        pcb.segments[0].start = (20.95, 50.95)
+        assert not resolve_current_path(pcb, _trunk_spec()).ok
+
+    def test_duplicate_physical_pad_number_is_not_guessed(self):
+        from copy import deepcopy
+
+        pcb = _t_network_pcb()
+        fp = pcb.get_footprint("J1")
+        fp.pads.append(deepcopy(fp.pads[0]))
+        assert resolve_current_path(pcb, _trunk_spec()).status == "unresolved"
+
+    def test_board09_via_array_stays_ambiguous_and_read_only(self):
+        from pathlib import Path
+
+        from kicad_tools.schema.pcb import PCB
+
+        board = (
+            Path(__file__).resolve().parents[1]
+            / "boards/09-usbc-pd-power/output/usbc_pd_power.kicad_pcb"
+        )
+        before = board.read_bytes()
+        pcb = PCB.load(board)
+        spec = CurrentPathSpec(
+            name="output",
+            net_name="+5V_OUT",
+            source=PathEndpoint("RSH1", "4"),
+            sink=PathEndpoint("J2", "1"),
+            continuous_a=3,
+        )
+        assert resolve_current_path(pcb, spec).status == "ambiguous"
+        assert board.read_bytes() == before
+
+    def test_transitive_pad_union_does_not_erase_external_return(self):
+        pcb = _t_network_pcb()
+        pcb.get_footprint("J1").pads[0].size = (1.6, 1.6)
+        for ref, x, y in (("TP1", 21, 51), ("TP2", 22, 50)):
+            _add_pad_footprint(pcb, ref=ref, x=x, y=y, net="NET1")
+            pcb.get_footprint(ref).pads[0].size = (1.6, 1.6)
+        for start, end in [
+            ((20, 50), (20.5, 50.5)),
+            ((20.5, 50.5), (21.5, 50.5)),
+            ((21.5, 50.5), (22, 50)),
+        ]:
+            pcb.add_trace(start, end, width=0.1, layer="F.Cu", net="NET1")
+        # The existing trunk crosses outside the joined pad copper at (21,50).
+        # Its endpoints collapse transitively but it must remain a self-loop.
+        assert resolve_current_path(pcb, _trunk_spec()).status == "ambiguous"
+
+    def test_disabled_copper_layer_is_not_bridged_by_wildcard_pad(self):
+        pcb = _t_network_pcb()
+        pcb.segments[0].layer = "In1.Cu"  # absent on this two-layer board
+        pcb.segments[1].layer = "In1.Cu"
+        assert resolve_current_path(pcb, _trunk_spec()).status == "unresolved"
+
+    @pytest.mark.parametrize("layer,expected", [("F.Cu", "ambiguous"), ("B.Cu", "resolved")])
+    def test_interior_crossing_cannot_hide_parallel_route(self, layer, expected):
+        pcb = _t_network_pcb()
+        # This return crosses the trunk interior at (40,50). The source
+        # through-hole pad connects either layer, but only F.Cu rejoins it.
+        pcb.add_trace((20, 50), (40, 40), width=1, layer=layer, net="NET1")
+        pcb.add_trace((40, 40), (40, 60), width=1, layer=layer, net="NET1")
+        assert resolve_current_path(pcb, _trunk_spec()).status == expected
+
+    @pytest.mark.parametrize("split_inside_pad", [False, True])
+    def test_pad_internal_piece_does_not_cover_external_spur(self, split_inside_pad):
+        pcb = _t_network_pcb()
+        pcb.add_trace((20, 50), (20, 40), width=0.1, layer="F.Cu", net="NET1")
+        spur = pcb.segments[-1]
+        if split_inside_pad:
+            pcb.add_via(20, 49.8, net="NET1")
+        result = resolve_current_path(pcb, _trunk_spec())
+        assert result.ok
+        assert result.length_mm == pytest.approx(100)
+        assert {id(s) for s in result.segments} == {id(s) for s in pcb.segments[:2]}
+        audit = audit_current_paths(pcb, [_trunk_spec(), _sense_spec()])
+        assert [id(s) for s in audit.uncovered["NET1"]] == [id(spur)]
+        assert id(spur) not in reinforcement_eligible_segment_ids(pcb, [_trunk_spec()])

--- a/tests/test_path_ampacity_check.py
+++ b/tests/test_path_ampacity_check.py
@@ -219,3 +219,17 @@ class TestPathAmpacityRule:
         results = rule.check(pcb, _design_rules_2oz())
         assert results.errors == []
         assert results.warnings == []
+
+
+@pytest.mark.parametrize("bridge", [False, True])
+def test_layer_transition_is_audited_before_ampacity(bridge):
+    pcb = _t_network_pcb(trunk_width=6.3)
+    pcb.segments[1].layer = "B.Cu"
+    if bridge:
+        pcb.add_via(60, 50, net="NET1")
+    result = PathAmpacityRule(specs=[_trunk_spec(), _sense_spec()]).check(pcb, _design_rules_2oz())
+    if bridge:
+        assert result.errors == []
+    else:
+        assert result.errors
+        assert any("unresolved" in error.message.lower() for error in result.errors)


### PR DESCRIPTION
Closes #5220. Prerequisite for #5221; part of #5197.

Current-path resolution could join F.Cu and B.Cu at the same XY coordinate without a physical via. Build a graph whose nodes include the copper layer, with interlayer connections only through supported same-net via spans or plated pad copper. Resolve explicit endpoint, interior-via, and same-layer crossing contacts while preserving distinct split graph edges for cycle detection.

Normalize copper contained within one supported physical pad without erasing external parallel returns. Path, ampacity, audit, and reinforcement consumers retain each traversed original segment once. A partly pad-internal dangling spur stays uncovered and ineligible for reinforcement. Unsupported pad shapes, duplicated physical pad identities, and disabled copper layers fail closed. Distinct pads sharing XY no longer become a trivial self-path.

The conservative whole-component cycle policy remains: Board09's via array is still ambiguous. This does not introduce current sharing, summed widths, via-capacity certification, or the motif exception planned for #5221. The centerline contact model and unsupported width-only, arc, zone, and pad-interior contacts are documented.

## Acceptance verification

- No-via cross-layer T is unresolved; valid same-net vias resolve it. Missing, wrong-net and nonbridging spans stay unresolved.
- Interior via landings respect spans. Segment ordering, splits, and extra via nodes preserve original evidence without duplicate length accounting.
- Split-edge and crossing cycles remain ambiguous. Pad-internal stars normalize without hiding external return paths.
- Trunk/sense currents, stale endpoints, uncovered copper, reinforcement eligibility, and CLI outcomes retain regression coverage.
- Board09 remains ambiguous and its source PCB bytes remain unchanged.

## Test Plan

TDD: no — reproduced the no-via cross-layer false resolution with a baseline script before implementation; regression tests followed. The independent review's dangling-spur reproduction was added and verified during the fix.

172 passed, 1 skipped across `test_current_paths.py`, `test_path_ampacity_check.py`, `test_cli_check_current_paths.py`, `test_pcb_reinforce.py`, and `test_cli_route_current_paths.py`. The existing native reinforcement DRC test skipped because `kicad-cli` was unavailable to that test run. Changed-file Ruff lint/format, scoped mypy, and whitespace checks pass. Independent code review reproduced and verified the dangling-spur correction; no remaining code findings. GitHub CI has not run on the new PR yet; no native current/ampacity qualification is claimed.
