### PR TITLE
feat(core): check KiCad lock markers before file writes

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -1561,3 +1561,6 @@ LCSC column (#4116); pass `--no-auto-lcsc` to export without enrichment.
 `kct mfr apply-rules` writes a sibling `.kicad_pro` (rules + Default netclass)
 so `kicad-cli pcb drc` uses the applied constraints instead of factory
 defaults (#4109).
+
+See [KiCad lock-marker advisories](kicad-lock-policy.md) for the covered write
+paths and `KCT_KICAD_LOCK_POLICY=warn|error|ignore` configuration.

--- a/docs/reference/kicad-lock-policy.md
+++ b/docs/reference/kicad-lock-policy.md
@@ -1,0 +1,43 @@
+# KiCad lock-marker advisories
+
+The core `save_pcb`, `save_schematic`, `save_project`, `save_footprint`, and
+`save_design_rules` functions check for KiCad's exact sibling marker before
+writing: `~<full filename>.lck`.
+For `my board.rev2.kicad_pcb`, this is `~my board.rev2.kicad_pcb.lck`.
+The CLI routing output and interrupted routing snapshot writers also check their actual destination,
+including the `_partial` filename when applicable. Other write paths are not
+covered by this policy. In particular, a caller that saves to a staging filename
+must check its eventual destination separately before replacing it.
+
+The default policy prints a warning to **stderr** and proceeds with the write.
+This preserves batch workflows when KiCad has left an abandoned marker. It also
+keeps JSON stdout clean. Set `KCT_KICAD_LOCK_POLICY` to select another policy:
+
+| Value | Behavior |
+| --- | --- |
+| `warn` | Default: warn on marker presence, then write normally. |
+| `error` | Raise `PermissionError` before creating temporary output or replacing the destination. Interrupted routing returns a failed-save result. |
+| `ignore` | Skip the advisory check and write normally. |
+
+Values are lowercase and exact; invalid values raise `ValueError`, even when
+no marker exists. Python callers of `core.kicad_lock.check_kicad_lock` may pass
+`policy=` explicitly, which takes precedence over the environment. Public save
+functions and routing writers use the shared environment setting.
+
+`probe_kicad_lock(path)` returns the marker path, presence, and optional
+`username` and `hostname` strings. These are unverified ownership metadata.
+Empty, malformed, oversized, unreadable, and nonregular markers are treated as
+present with unknown ownership. If marker existence cannot be inspected due to
+an operating-system error, the check conservatively treats it as present.
+Neither the probe nor the policy changes, deletes, or reclaims a marker.
+
+**Presence does not prove a live KiCad session.** KiCad's marker contains no PID;
+matching the current user or hostname does not exempt a marker. This check is
+advisory and has a race window: another process can open the destination after
+the check. It does not acquire an exclusive lock or add multi-file transaction
+protection. The existing atomic file writes remain unchanged.
+
+The filename and ownership-field conventions were checked against KiCad's
+[LOCKFILE source documentation](https://docs.kicad.org/doxygen/lockfile_8h_source.html)
+and [file-extension constants](https://docs.kicad.org/doxygen/wildcards__and__files__ext_8cpp_source.html).
+The implementation is independent; these sources establish the file convention.

--- a/src/kicad_tools/cli/route_cmd.py
+++ b/src/kicad_tools/cli/route_cmd.py
@@ -67,7 +67,9 @@ import textwrap
 import time
 from dataclasses import dataclass
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, cast
+
+from kicad_tools.core.kicad_lock import check_kicad_lock
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Iterator, Sequence
@@ -993,6 +995,7 @@ def _write_routed_pcb(
             the save would drop >90% of a non-trivial input's copper
             (issue #4413).  The output file is left untouched.
     """
+    check_kicad_lock(output_path)
     original_content = pcb_path.read_text()
 
     # Update layer stackup for terminal writes when we escalated above 2L.
@@ -1960,6 +1963,8 @@ def _save_partial_results() -> bool:
                 save_path = output_path
             else:
                 save_path = output_path.with_stem(output_path.stem + "_partial")
+
+            check_kicad_lock(cast(Path, save_path))
 
             # Insert routes before final closing parenthesis
             output_content = _insert_sexp_before_closing(original_content, route_sexp)

--- a/src/kicad_tools/core/kicad_lock.py
+++ b/src/kicad_tools/core/kicad_lock.py
@@ -1,0 +1,98 @@
+"""Advisory presence checks for KiCad's ``~<full filename>.lck`` markers.
+
+Ownership metadata never establishes process liveness. This check neither
+acquires a lock nor prevents another process from opening a file afterward.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import stat
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+LOCK_POLICY_ENV = "KCT_KICAD_LOCK_POLICY"
+
+
+@dataclass(frozen=True)
+class KiCadLockPresence:
+    """Observed marker presence, with optional unverified ownership metadata.
+
+    A marker whose existence cannot be inspected is conservatively treated as
+    present. Empty, unreadable, and malformed markers have unknown ownership.
+    """
+
+    path: Path
+    present: bool
+    username: str | None = None
+    hostname: str | None = None
+
+
+def probe_kicad_lock(path: str | Path) -> KiCadLockPresence:
+    """Inspect only the exact sibling marker; never modify it or infer liveness."""
+    destination = Path(path)
+    marker = destination.with_name(f"~{destination.name}.lck")
+    try:
+        info = marker.lstat()
+    except FileNotFoundError:
+        return KiCadLockPresence(marker, False)
+    except OSError:
+        return KiCadLockPresence(marker, True)
+    if not stat.S_ISREG(info.st_mode):
+        return KiCadLockPresence(marker, True)
+    try:
+        flags = os.O_RDONLY | getattr(os, "O_NONBLOCK", 0) | getattr(os, "O_NOFOLLOW", 0)
+        fd = os.open(marker, flags)
+        with os.fdopen(fd, "r", encoding="utf-8") as stream:
+            if not stat.S_ISREG(os.fstat(stream.fileno()).st_mode):
+                return KiCadLockPresence(marker, True)
+            text = stream.read(8193)
+        if len(text) > 8192:
+            return KiCadLockPresence(marker, True)
+        data = json.loads(text)
+        if not isinstance(data, dict):
+            return KiCadLockPresence(marker, True)
+        username = data.get("username")
+        hostname = data.get("hostname")
+        return KiCadLockPresence(
+            marker,
+            True,
+            username if isinstance(username, str) else None,
+            hostname if isinstance(hostname, str) else None,
+        )
+    except (OSError, ValueError, RecursionError):
+        return KiCadLockPresence(marker, True)
+
+
+def check_kicad_lock(path: str | Path, *, policy: str | None = None) -> KiCadLockPresence | None:
+    """Apply ``warn`` (default), ``error``, or ``ignore`` before a write.
+
+    Explicit policy overrides the environment. An invalid value always raises
+    ValueError. Ignore skips filesystem inspection. Error raises PermissionError
+    before a writer touches its output; warn prints only to stderr.
+    """
+    selected = policy if policy is not None else os.environ.get(LOCK_POLICY_ENV, "warn")
+    if selected not in ("warn", "error", "ignore"):
+        raise ValueError(
+            f"Invalid {LOCK_POLICY_ENV} value {selected!r}; expected warn, error or ignore"
+        )
+    if selected == "ignore":
+        return None
+    presence = probe_kicad_lock(path)
+    if presence.present:
+        owner = ", ".join(
+            f"{name}={value!r}"
+            for name, value in (("username", presence.username), ("hostname", presence.hostname))
+            if value is not None
+        )
+        message = (
+            f"{str(Path(path))!r} may be open in KiCad: lock marker {str(presence.path)!r} "
+            f"({owner or 'unknown ownership'}). Marker presence does not prove a live session. "
+            f"Set {LOCK_POLICY_ENV}=ignore to bypass this advisory check."
+        )
+        if selected == "error":
+            raise PermissionError(message)
+        print(f"Warning: {message}", file=sys.stderr)
+    return presence

--- a/src/kicad_tools/core/project_file.py
+++ b/src/kicad_tools/core/project_file.py
@@ -10,6 +10,7 @@ from pathlib import Path
 from typing import Any
 
 from kicad_tools.core.atomic_write import atomic_write_text
+from kicad_tools.core.kicad_lock import check_kicad_lock
 
 
 def load_project(path: str | Path) -> dict[str, Any]:
@@ -49,6 +50,7 @@ def save_project(data: dict[str, Any], path: str | Path) -> None:
     """
     path = Path(path)
     text = json.dumps(data, indent=2)
+    check_kicad_lock(path)
     atomic_write_text(path, text, encoding="utf-8")
 
 

--- a/src/kicad_tools/core/sexp_file.py
+++ b/src/kicad_tools/core/sexp_file.py
@@ -5,6 +5,7 @@ File I/O utilities for KiCad S-expression files.
 from pathlib import Path
 
 from kicad_tools.core.atomic_write import atomic_write_text
+from kicad_tools.core.kicad_lock import check_kicad_lock
 from kicad_tools.exceptions import FileFormatError
 from kicad_tools.exceptions import FileNotFoundError as KiCadFileNotFoundError
 from kicad_tools.sexp import SExp, parse_string, serialize_sexp
@@ -67,6 +68,7 @@ def save_schematic(sexp: SExp, path: str | Path) -> None:
 
     path = Path(path)
     text = serialize_sexp(sexp)
+    check_kicad_lock(path)
     atomic_write_text(path, text, encoding="utf-8")
 
 
@@ -180,6 +182,7 @@ def save_pcb(sexp: SExp, path: str | Path) -> None:
 
     path = Path(path)
     text = serialize_sexp(sexp)
+    check_kicad_lock(path)
     atomic_write_text(path, text, encoding="utf-8")
 
 
@@ -301,6 +304,7 @@ def save_footprint(sexp: SExp, path: str | Path) -> None:
 
     path = Path(path)
     text = serialize_sexp(sexp)
+    check_kicad_lock(path)
     atomic_write_text(path, text, encoding="utf-8")
 
 
@@ -385,4 +389,5 @@ def save_design_rules(sexp: SExp, path: str | Path) -> None:
     for child in sexp.values:
         lines.append(serialize_sexp(child))
     text = "\n".join(lines)
+    check_kicad_lock(path)
     atomic_write_text(path, text, encoding="utf-8")

--- a/tests/test_kicad_lock.py
+++ b/tests/test_kicad_lock.py
@@ -1,0 +1,258 @@
+"""Advisory lock marker policy and writer integration regressions."""
+
+import os
+
+import pytest
+
+from kicad_tools.core.project_file import save_project
+from kicad_tools.core.sexp_file import save_design_rules, save_footprint, save_pcb, save_schematic
+from kicad_tools.sexp import parse_string
+
+WRITERS = [
+    (save_pcb, "(kicad_pcb)", "kicad_pcb"),
+    (save_schematic, "(kicad_sch)", "kicad_sch"),
+    (save_footprint, '(footprint "x")', "kicad_mod"),
+    (save_design_rules, "(design_rules (version 1))", "kicad_dru"),
+    (save_project, None, "kicad_pro"),
+]
+
+
+@pytest.mark.parametrize("writer,sexp,extension", WRITERS)
+@pytest.mark.parametrize("policy", ["warn", "error", "ignore"])
+def test_all_core_writers(tmp_path, monkeypatch, capsys, writer, sexp, extension, policy):
+    path = tmp_path / f"my board.rev2.{extension}"
+    path.write_bytes(b"original")
+    marker = path.with_name("~" + path.name + ".lck")
+    marker.write_text('{"username":"alice","hostname":"workstation"}')
+    original_marker = marker.read_bytes()
+    monkeypatch.setenv("KCT_KICAD_LOCK_POLICY", policy)
+    data = parse_string(sexp) if sexp else {"new": True}
+    if policy == "error":
+        with pytest.raises(PermissionError, match="may be open in KiCad"):
+            writer(data, path)
+        assert path.read_bytes() == b"original"
+    else:
+        writer(data, path)
+        assert path.read_bytes() != b"original"
+    output = capsys.readouterr()
+    assert not output.out
+    assert ("may be open in KiCad" in output.err) == (policy == "warn")
+    assert marker.read_bytes() == original_marker
+    assert not path.with_suffix(path.suffix + ".tmp").exists()
+
+
+@pytest.mark.parametrize(
+    "content,owner",
+    [
+        ('{"username":"alice","hostname":"host"}', ("alice", "host")),
+        ("", (None, None)),
+        ("not-json PRIVATE", (None, None)),
+        ("[]", (None, None)),
+        ('{"username":12,"hostname":false}', (None, None)),
+        ('{"username":"","hostname":"host"}', ("", "host")),
+    ],
+)
+def test_probe_metadata(tmp_path, content, owner):
+    from kicad_tools.core.kicad_lock import probe_kicad_lock
+
+    path = tmp_path / "board.kicad_pcb"
+    marker = tmp_path / "~board.kicad_pcb.lck"
+    marker.write_text(content)
+    presence = probe_kicad_lock(path)
+    assert presence.present and presence.path == marker
+    assert (presence.username, presence.hostname) == owner
+    assert marker.read_text() == content
+
+
+def test_unreadable_marker_is_present(tmp_path, monkeypatch):
+    from kicad_tools.core.kicad_lock import probe_kicad_lock
+
+    path = tmp_path / "board.kicad_pcb"
+    marker = tmp_path / "~board.kicad_pcb.lck"
+    marker.touch()
+    real = os.open
+
+    def denied(self, *args, **kwargs):
+        if self == marker:
+            raise PermissionError("denied")
+        return real(self, *args, **kwargs)
+
+    monkeypatch.setattr(os, "open", denied)
+    presence = probe_kicad_lock(path)
+    assert presence.present and presence.username is None
+
+
+@pytest.mark.parametrize(
+    "name", ["board.kicad_pcb.lck", ".board.kicad_pcb.lck", "~other.kicad_pcb.lck"]
+)
+def test_unrelated_markers_do_not_warn(tmp_path, capsys, name):
+    from kicad_tools.core.kicad_lock import check_kicad_lock
+
+    (tmp_path / name).touch()
+    assert not check_kicad_lock(tmp_path / "board.kicad_pcb").present
+    assert capsys.readouterr() == ("", "")
+
+
+def test_policy_precedence_and_invalid_values(tmp_path, monkeypatch):
+    from kicad_tools.core.kicad_lock import check_kicad_lock
+
+    path = tmp_path / "board.kicad_pcb"
+    (tmp_path / "~board.kicad_pcb.lck").touch()
+    monkeypatch.setenv("KCT_KICAD_LOCK_POLICY", "error")
+    assert check_kicad_lock(path, policy="ignore") is None
+    monkeypatch.setenv("KCT_KICAD_LOCK_POLICY", "invalid")
+    with pytest.raises(ValueError, match="expected warn, error or ignore"):
+        check_kicad_lock(path)
+    assert check_kicad_lock(path, policy="ignore") is None
+    with pytest.raises(ValueError):
+        check_kicad_lock(path, policy="")
+
+
+def test_default_warning_and_json_stdout(tmp_path, monkeypatch, capsys):
+    import json
+
+    from kicad_tools.cli.sch_json import run_with_json_summary
+
+    monkeypatch.delenv("KCT_KICAD_LOCK_POLICY", raising=False)
+    path = tmp_path / "board.kicad_sch"
+    (tmp_path / "~board.kicad_sch.lck").write_text("MALFORMED PRIVATE")
+    result = run_with_json_summary(
+        "test-save",
+        path,
+        lambda: save_schematic(parse_string("(kicad_sch)"), path),
+        output_format="json",
+    )
+    output = capsys.readouterr()
+    assert result == 0 and json.loads(output.out)["success"] is True
+    assert "may be open in KiCad" in output.err
+    assert "MALFORMED PRIVATE" not in output.err
+
+
+@pytest.mark.parametrize("policy", ["warn", "error", "ignore"])
+@pytest.mark.parametrize("partial", [False, True])
+def test_routing_writers(tmp_path, monkeypatch, capsys, policy, partial):
+    from types import SimpleNamespace
+
+    from kicad_tools.cli import route_cmd
+
+    source = tmp_path / "source.kicad_pcb"
+    source.write_text("(kicad_pcb (version 20240108))")
+    output = tmp_path / "routed.kicad_pcb"
+    actual = output.with_stem("routed_partial") if partial else output
+    actual.write_bytes(b"original")
+    marker = actual.with_name("~" + actual.name + ".lck")
+    marker.touch()
+    monkeypatch.setenv("KCT_KICAD_LOCK_POLICY", policy)
+    if partial:
+        router = SimpleNamespace(routes=[1], to_sexp=lambda **kwargs: "(segment (width 0.2))")
+        monkeypatch.setattr(
+            route_cmd,
+            "_interrupt_state",
+            {"router": router, "output_path": output, "pcb_path": source, "quiet": True},
+        )
+        assert route_cmd._save_partial_results() == (policy != "error")
+    elif policy == "error":
+        with pytest.raises(PermissionError):
+            route_cmd._write_routed_pcb(source, output, "")
+    else:
+        assert route_cmd._write_routed_pcb(source, output, "") == output
+    assert (actual.read_bytes() == b"original") == (policy == "error")
+    assert not actual.with_suffix(actual.suffix + ".tmp").exists()
+    assert marker.read_bytes() == b""
+    captured = capsys.readouterr()
+    assert ("may be open in KiCad" in captured.err) == (policy == "warn")
+
+
+@pytest.mark.parametrize("completed", [False, True])
+def test_partial_uses_actual_destination_only(tmp_path, monkeypatch, completed):
+    from types import SimpleNamespace
+
+    from kicad_tools.cli import route_cmd
+
+    source = tmp_path / "source.kicad_pcb"
+    source.write_text("(kicad_pcb (version 20240108))")
+    output = tmp_path / "output.kicad_pcb"
+    actual = output if completed else output.with_stem("output_partial")
+    # Lock the input, and (unless canonical is the actual output) the intended output.
+    source.with_name("~" + source.name + ".lck").touch()
+    if not completed:
+        output.with_name("~" + output.name + ".lck").touch()
+    monkeypatch.setenv("KCT_KICAD_LOCK_POLICY", "error")
+    router = SimpleNamespace(routes=[1], to_sexp=lambda **kwargs: "(segment (width 0.2))")
+    monkeypatch.setattr(
+        route_cmd,
+        "_interrupt_state",
+        {
+            "router": router,
+            "output_path": output,
+            "pcb_path": source,
+            "quiet": True,
+            "best_completed_attempt": completed,
+        },
+    )
+    assert route_cmd._save_partial_results() is True
+    before = actual.read_bytes()
+    actual.with_name("~" + actual.name + ".lck").touch()
+    assert route_cmd._save_partial_results() is False
+    assert actual.read_bytes() == before
+
+
+@pytest.mark.parametrize("kind", ["fifo", "directory", "symlink"])
+def test_nonregular_markers_are_present_without_open(tmp_path, monkeypatch, kind):
+    from kicad_tools.core.kicad_lock import probe_kicad_lock
+
+    path = tmp_path / "board.kicad_pcb"
+    marker = tmp_path / "~board.kicad_pcb.lck"
+    if kind == "fifo":
+        os.mkfifo(marker)
+    elif kind == "directory":
+        marker.mkdir()
+    else:
+        marker.symlink_to(tmp_path / "absent")
+
+    def unexpected(*args, **kwargs):
+        pytest.fail("Nonregular marker must not be opened")
+
+    monkeypatch.setattr(os, "open", unexpected)
+    presence = probe_kicad_lock(path)
+    assert presence.present and presence.username is None
+
+
+@pytest.mark.parametrize("writer,sexp,extension", WRITERS)
+def test_absent_marker_success(tmp_path, capsys, writer, sexp, extension):
+    path = tmp_path / ("board." + extension)
+    writer(parse_string(sexp) if sexp else {"value": True}, path)
+    assert path.exists()
+    assert capsys.readouterr() == ("", "")
+
+
+def test_invalid_policy_preserves_destination_and_temp(tmp_path, monkeypatch):
+    path = tmp_path / "board.kicad_pcb"
+    path.write_bytes(b"original")
+    monkeypatch.setenv("KCT_KICAD_LOCK_POLICY", "WARN")
+    with pytest.raises(ValueError, match="Invalid KCT_KICAD_LOCK_POLICY"):
+        save_pcb(parse_string("(kicad_pcb)"), path)
+    assert path.read_bytes() == b"original"
+    assert not path.with_suffix(path.suffix + ".tmp").exists()
+
+
+def test_control_characters_in_metadata_and_paths_are_escaped(tmp_path, capsys):
+    import json
+
+    from kicad_tools.core.kicad_lock import check_kicad_lock
+
+    path = tmp_path / "board\n\x1b[31m.kicad_pcb"
+    marker = path.with_name("~" + path.name + ".lck")
+    marker.write_text(json.dumps({"username": "\x1b[31m", "hostname": "host\nsecond"}))
+    check_kicad_lock(path)
+    stderr = capsys.readouterr().err
+    assert "\x1b" not in stderr
+    assert stderr.count("\n") == 1
+
+
+def test_deeply_malformed_json_remains_present(tmp_path):
+    from kicad_tools.core.kicad_lock import probe_kicad_lock
+
+    path = tmp_path / "board.kicad_pcb"
+    path.with_name("~" + path.name + ".lck").write_text("[" * 1500)
+    assert probe_kicad_lock(path).present


### PR DESCRIPTION
Core file writers and routing saves previously ignored KiCad lock markers. Add a shared presence probe and `KCT_KICAD_LOCK_POLICY=warn|error|ignore`: the default warns on stderr and preserves batch writes; explicit error mode refuses before temporary output or destination replacement. Warnings keep machine-readable stdout clean.

The probe checks the exact `~<full filename>.lck` sibling, treats unreadable/malformed/nonregular markers as present with unknown ownership, bounds metadata reads, and escapes diagnostics. It never infers process liveness or edits a marker. The check is advisory, with a race window; it does not provide mutual exclusion.

Integrate the policy into `save_pcb`, `save_schematic`, `save_project`, `save_footprint`, `save_design_rules`, terminal routing output, and interrupted routing saves using their actual destinations. Preserve the parent's atomic-write behavior. Documentation covers configuration, Python precedence, conventions, and limits.

Parent #5106 merged as `9ca6179dff271564b6bad84321419ff52e36df8e`. This PR is now reconciled onto main at `664e7e8616c5bd6dc36fc6d808660b8c4f6c026d`; its lock-policy commit is patch-equivalent to the originally reviewed change. The diff contains only the lock policy and integrations. Keep the validation hold until final-main CI passes.

Validation:
- Independent review reproduced a FIFO-marker hang, verified its fix, and checked broken symlinks, escaped metadata/paths, clean stdout, all seven writer integrations, and actual partial-output destinations. Ten focused independent tests passed.
- `uv run pytest tests/test_kicad_lock.py tests/test_atomic_write.py tests/test_route_zones_preserved.py tests/test_route_cmd_zone_fill.py -q --no-cov`: 86 passed, including 46 new lock-policy cases.
- `uv run pytest tests/test_file_formats.py tests/test_project.py tests/test_partial_routing_features.py tests/test_format_json_sweep_drivers.py -q --no-cov`: 186 passed (one router-timeout warning). After a typing-only cast, all 46 lock cases passed again.
- Ruff check/format, whitespace, and version gate pass. Scoped mypy for the new guard is clean; existing project/route diagnostics reproduce on the parent baseline with no new diagnostics.
- After reconciliation: 272 lock/atomic writer/file/project/route-zone/partial-routing/JSON tests pass, along with Ruff check/format, whitespace, version gate, and scoped mypy. Final-main CI on `e7d87fcc411cc1c06c50402a59a711e56125b4c0` remains required; queued or absent checks are not success.

Closes #5105
Part of #4880
