### PR TITLE
fix(mcp): use shared copper geometry for clearance measurements

### DIFF
--- a/docs/research/mcp-clearance-grid-audit.md
+++ b/docs/research/mcp-clearance-grid-audit.md
@@ -1,0 +1,46 @@
+# MCP clearance and router grid audit (#5128)
+
+`measure_clearance` now adapts parsed PCB elements to the shared validator's
+`CopperElement` and pair dispatcher. Footprint-local positions, absolute pad
+angles, shapes, roundrect ratios, and available polygons follow that shared
+path. MCP keeps its public `track` name and `Track-` references, layer selection,
+item matching, nonzero same-net exemption, net-zero comparisons, minimum
+selection, and result structure. The unrounded minimum still determines whether
+the unchanged required clearance is met. Pair locations come from the shared
+geometry: polygon pairs may report a closest-edge location rather than the old
+center midpoint.
+
+All pair types delegate: track/track, track/pad, track/via, pad/pad, pad/via, and
+via/via, including reversed operands. Missing pad polygons cause an explicit
+error instead of a silent disc fallback. `get_drc_violations` already uses
+`DRCChecker` and was not changed.
+
+This implementation depends on #5155's rounded-pad segment correction and
+#5227's polygon rotation-sign correction for physical noncardinal results.
+It does not implement another polygon engine. Shared-model limitations remain:
+plain rectangular segment/pad checks retain their analytic AABB behavior;
+unknown pad shapes fall back to rectangles; polygon overlap depth is a modeled
+penetration estimate. This is not universal exact KiCad geometry or custom-pad
+support, and does not certify manufacture.
+
+## Router grid disposition
+
+`router/grid.py::_rect_segment_centerline_distance` and its consumers are
+unchanged. The audit found calls in `worst_segment_pad_deficit`,
+`worst_via_pad_deficit`, and `validate_segment_clearance`: these affect routing
+and finalization acceptance/backstops, not just search performance.
+
+For an axis-aligned, non-square oval or roundrect, its enclosing rectangle is a
+conservative restriction around rounded corners. Keeping that restriction here
+avoids changing routing cost and backstop behavior while fixing MCP diagnostics.
+However, this does **not** establish that every grid pad model is conservative:
+the consumers infer circular pads from nearly equal width and height, which
+under-covers square rectangular corners. Discarded noncardinal orientation also
+under-covers real copper. Those distinct correctness risks are tracked in
+[#5229](https://github.com/rjwalters/kicad-tools/issues/5229), covering shape/rotation
+propagation, Python/C++ agreement, and finalization regressions. #5194's other router consumers do not cover these grid sites.
+
+No grid geometry, manufacturing thresholds, clearance floors, routing guards,
+or finalization exclusions were changed by this MCP adapter. The tests establish
+MCP/shared-model parity and independent physical controls for supported cases;
+they do not claim new router-runtime validation.

--- a/src/kicad_tools/mcp/tools/analysis.py
+++ b/src/kicad_tools/mcp/tools/analysis.py
@@ -8,7 +8,6 @@ for design rule checking, and measure_clearance for clearance analysis.
 from __future__ import annotations
 
 import logging
-import math
 import re
 import uuid
 from collections import Counter, defaultdict
@@ -16,12 +15,6 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal
 
 from kicad_tools.analysis.net_status import NetStatusAnalyzer
-from kicad_tools.core.geometry import (
-    point_to_segment_distance as _point_to_segment_distance,
-)
-from kicad_tools.core.geometry import (
-    segment_to_segment_distance as _segment_to_segment_distance,
-)
 from kicad_tools.exceptions import FileNotFoundError as KiCadFileNotFoundError
 from kicad_tools.exceptions import ParseError
 from kicad_tools.mcp.types import (
@@ -41,6 +34,8 @@ from kicad_tools.mcp.types import (
     ZoneInfo,
 )
 from kicad_tools.schema.pcb import PCB
+from kicad_tools.validate.rules.clearance import CopperElement as _ValidatorCopperElement
+from kicad_tools.validate.rules.clearance import _calculate_clearance as _validator_clearance
 
 if TYPE_CHECKING:
     from kicad_tools.schema.pcb import Footprint, Pad, Segment, Via
@@ -946,7 +941,17 @@ class _CopperElement:
         geometry: tuple[float, ...],
         reference: str,
         net_name: str = "",
+        *,
+        copper: _ValidatorCopperElement | None = None,
     ):
+        self.copper = copper or _ValidatorCopperElement(
+            element_type="segment" if element_type == "track" else element_type,
+            layer=layer,
+            net_number=net_number,
+            geometry=geometry,
+            reference=reference,
+            net_name=net_name,
+        )
         self.element_type = element_type
         self.layer = layer
         self.net_number = net_number
@@ -956,39 +961,49 @@ class _CopperElement:
 
     @classmethod
     def from_segment(cls, seg: Segment) -> _CopperElement:
-        """Create from a PCB segment."""
+        """Adapt shared validator geometry without changing MCP track naming."""
+        copper = _ValidatorCopperElement.from_segment(seg)
         return cls(
             element_type="track",
             layer=seg.layer,
             net_number=seg.net_number,
-            geometry=(seg.start[0], seg.start[1], seg.end[0], seg.end[1], seg.width),
+            geometry=copper.geometry,
             reference=f"Track-{seg.uuid[:8]}" if seg.uuid else "Track",
             net_name=seg.net_name if hasattr(seg, "net_name") else "",
+            copper=copper,
         )
 
     @classmethod
     def from_pad(cls, pad: Pad, footprint: Footprint) -> _CopperElement:
         """Create from a PCB pad with footprint context."""
-        abs_x, abs_y = _transform_pad_position(pad, footprint)
+        copper = _ValidatorCopperElement.from_pad(pad, footprint)
+        if copper.polygon is None:
+            raise ValueError(
+                f"Copper polygon unavailable for {footprint.reference}-{pad.number}; "
+                "cannot measure pad clearance safely"
+            )
         return cls(
             element_type="pad",
             layer="*",
             net_number=pad.net_number,
-            geometry=(abs_x, abs_y, pad.size[0], pad.size[1]),
+            geometry=copper.geometry,
             reference=f"{footprint.reference}-{pad.number}",
             net_name=pad.net_name,
+            copper=copper,
         )
 
     @classmethod
     def from_via(cls, via: Via) -> _CopperElement:
-        """Create from a PCB via."""
+        """Create from a PCB via using shared validator geometry."""
+        copper = _ValidatorCopperElement.from_via(via)
         return cls(
             element_type="via",
             layer="*",
             net_number=via.net_number,
-            geometry=(via.position[0], via.position[1], via.size, via.size),
+            geometry=copper.geometry,
             reference=f"Via-{via.uuid[:8]}" if via.uuid else "Via",
             net_name=via.net_name if hasattr(via, "net_name") else "",
+            copper=copper,
         )
 
     def on_layer(self, layer: str) -> bool:
@@ -1015,93 +1030,16 @@ class _CopperElement:
         return False
 
 
-def _transform_pad_position(pad: Pad, footprint: Footprint) -> tuple[float, float]:
-    """Transform pad position from footprint-local to board coordinates.
-
-    Uses KiCad's negated-angle pad rotation convention (see
-    :func:`kicad_tools.core.geometry.rotate_pad_offset`).
-    """
-    from kicad_tools.core.geometry import rotate_pad_offset
-
-    local_x, local_y = pad.position
-    rotated_x, rotated_y = rotate_pad_offset(local_x, local_y, footprint.rotation)
-
-    abs_x = footprint.position[0] + rotated_x
-    abs_y = footprint.position[1] + rotated_y
-
-    return abs_x, abs_y
-
-
-# _point_to_segment_distance and _segment_to_segment_distance are imported
-# from kicad_tools.core.geometry (consolidated in #2349).
-
-
 def _clearance_calculate(
     elem1: _CopperElement, elem2: _CopperElement
 ) -> tuple[float, float, float]:
-    """Calculate the clearance between two copper elements.
+    """Delegate every pair to the shared validator's supported copper model.
 
-    Returns:
-        Tuple of (clearance_mm, location_x, location_y)
+    Reporting names, filtering and minimum selection remain MCP concerns.
+    Unsupported shapes retain the validator's documented approximations;
+    geometry dependency errors propagate rather than silently using discs.
     """
-    t1, t2 = elem1.element_type, elem2.element_type
-
-    if t1 == "track" and t2 == "track":
-        return _segment_segment_clearance(elem1, elem2)
-    elif t1 == "track" and t2 in ("pad", "via"):
-        return _segment_circle_clearance(elem1, elem2)
-    elif t1 in ("pad", "via") and t2 == "track":
-        clearance, x, y = _segment_circle_clearance(elem2, elem1)
-        return clearance, x, y
-    else:
-        return _circle_circle_clearance(elem1, elem2)
-
-
-def _segment_segment_clearance(
-    seg1: _CopperElement, seg2: _CopperElement
-) -> tuple[float, float, float]:
-    """Calculate clearance between two trace segments."""
-    x1, y1, x2, y2, w1 = seg1.geometry
-    x3, y3, x4, y4, w2 = seg2.geometry
-
-    center_dist = _segment_to_segment_distance(x1, y1, x2, y2, x3, y3, x4, y4)
-    clearance = center_dist - (w1 / 2) - (w2 / 2)
-
-    loc_x = (x1 + x2 + x3 + x4) / 4
-    loc_y = (y1 + y2 + y3 + y4) / 4
-
-    return clearance, loc_x, loc_y
-
-
-def _segment_circle_clearance(
-    seg: _CopperElement, circle: _CopperElement
-) -> tuple[float, float, float]:
-    """Calculate clearance between a segment and a circle (pad/via)."""
-    x1, y1, x2, y2, seg_width = seg.geometry
-    cx, cy, w, h = circle.geometry
-
-    radius = max(w, h) / 2
-    center_dist = _point_to_segment_distance(cx, cy, x1, y1, x2, y2)
-    clearance = center_dist - (seg_width / 2) - radius
-
-    return clearance, cx, cy
-
-
-def _circle_circle_clearance(c1: _CopperElement, c2: _CopperElement) -> tuple[float, float, float]:
-    """Calculate clearance between two circles (pad/via)."""
-    x1, y1, w1, h1 = c1.geometry
-    x2, y2, w2, h2 = c2.geometry
-
-    r1 = max(w1, h1) / 2
-    r2 = max(w2, h2) / 2
-
-    center_dist = math.sqrt((x2 - x1) ** 2 + (y2 - y1) ** 2)
-    clearance = center_dist - r1 - r2
-
-    loc_x = (x1 + x2) / 2
-    loc_y = (y1 + y2) / 2
-
-    return clearance, loc_x, loc_y
+    return _validator_clearance(elem1.copper, elem2.copper)
 
 
 def _collect_elements(pcb: PCB, layer: str | None = None) -> list[_CopperElement]:

--- a/tests/test_mcp_clearance_geometry.py
+++ b/tests/test_mcp_clearance_geometry.py
@@ -1,0 +1,225 @@
+"""File-backed physical and shared-model checks for MCP clearance measurement."""
+
+import pytest
+
+from kicad_tools.mcp.tools.analysis import measure_clearance
+
+
+def board(tmp_path, elements):
+    path = tmp_path / "clearance.kicad_pcb"
+    path.write_text(f"""(kicad_pcb (version 20240108) (generator test)
+        (layers (0 "F.Cu" signal) (31 "B.Cu" signal))
+        (net 0 "") (net 1 "A") (net 2 "B") (net 3 "C")
+        {elements})""")
+    return path
+
+
+def pad(
+    ref="U1",
+    x=0,
+    y=0,
+    shape="rect",
+    width=4,
+    height=1,
+    angle=0,
+    fp_angle=0,
+    local=(0, 0),
+    net=1,
+    layer="F.Cu",
+    ratio=0.25,
+):
+    return f'''(footprint "P" (layer "{layer}") (at {x} {y} {fp_angle})
+        (property "Reference" "{ref}")
+        (pad "1" smd {shape} (at {local[0]} {local[1]} {angle}) (size {width} {height})
+          (layers "{layer}") (roundrect_rratio {ratio}) (net {net} "{chr(64 + net) if net else ""}")))'''
+
+
+def segment(a, b, width=0.2, net=2, layer="F.Cu", uuid="trace1"):
+    return f'''(segment (start {a[0]} {a[1]}) (end {b[0]} {b[1]})
+        (width {width}) (layer "{layer}") (net {net}) (uuid "{uuid}"))'''
+
+
+@pytest.mark.parametrize("reverse", [False, True])
+@pytest.mark.parametrize(
+    "a,b,width,expected", [((-3, 1), (3, 1), 0.2, 0.4), ((1.99, 0.49), (2.5, 0.49), 0.02, -0.01)]
+)
+def test_rectangle_physical_numbers(tmp_path, reverse, a, b, width, expected):
+    path = board(tmp_path, pad() + segment(a, b, width))
+    items = ("B", "U1") if reverse else ("U1", "B")
+    result = measure_clearance(str(path), *items, layer="F.Cu")
+    assert result.min_clearance_mm == pytest.approx(expected)
+    assert result.location == (0, 0)
+    assert len(result.clearances) == 1
+    measurement = result.clearances[0]
+    assert {measurement.from_type, measurement.to_type} == {"pad", "track"}
+    assert {measurement.from_item, measurement.to_item} == {"U1-1", "Track-trace1"}
+
+
+def via(x=0, y=2, size=0.5, net=2, uuid="via1"):
+    return f'''(via (at {x} {y}) (size {size}) (drill .2) (layers "F.Cu" "B.Cu")
+        (net {net}) (uuid "{uuid}"))'''
+
+
+@pytest.mark.parametrize("reverse", [False, True])
+@pytest.mark.parametrize(
+    "kind,expected",
+    [
+        ("pad_pad", 1.25),
+        ("pad_via", 1.25),
+        ("track_track", 0.8),
+        ("track_via", 0.65),
+        ("circle_via", 1.25),
+        ("via_via", 1.5),
+    ],
+)
+def test_pair_dispatches_numeric_and_shared_parity(tmp_path, kind, expected, reverse):
+    from kicad_tools.schema.pcb import PCB
+    from kicad_tools.validate.rules.clearance import CopperElement, _calculate_clearance
+
+    first = pad()
+    second = via()
+    if kind == "pad_pad":
+        second = pad("U2", 0, 2, "circle", 0.5, 0.5, net=2)
+    elif kind == "track_track":
+        first = segment((-2, 0), (2, 0), net=1, uuid="trackA")
+        second = segment((-2, 1), (2, 1), net=2, uuid="trackB")
+    elif kind == "track_via":
+        first = segment((-2, 0), (2, 0), net=1)
+        second = via(y=1)
+    elif kind == "circle_via":
+        first = pad(shape="circle", width=1, height=1)
+    elif kind == "via_via":
+        first = via(y=0, net=1, uuid="viaA")
+    path = board(tmp_path, first + second)
+    result = measure_clearance(str(path), *(("B", "A") if reverse else ("A", "B")), layer="F.Cu")
+    assert result.min_clearance_mm == pytest.approx(expected, abs=1e-4)
+    pcb = PCB.load(path)
+    elements = [CopperElement.from_pad(p, f) for f in pcb.footprints for p in f.pads]
+    elements += [CopperElement.from_segment(s) for s in pcb.segments]
+    elements += [CopperElement.from_via(v) for v in pcb.vias]
+    a, b = sorted(elements, key=lambda e: e.net_number)
+    direct = _calculate_clearance(b, a) if reverse else _calculate_clearance(a, b)
+    assert result.min_clearance_mm == round(direct[0], 4)
+    assert result.location == tuple(round(x, 3) for x in direct[1:])
+    assert len(result.clearances) == 1
+
+
+@pytest.mark.parametrize("reverse", [False, True])
+@pytest.mark.parametrize("trace_y,expected,passes", [(98.6, 0.1846, True), (98.45, 0.0904, False)])
+def test_c19_rotated_roundrect_actual_control(
+    tmp_path, monkeypatch, reverse, trace_y, expected, passes
+):
+    from kicad_tools.mcp.tools import analysis
+
+    path = board(
+        tmp_path,
+        pad(
+            "C19",
+            147.086449,
+            97.046534,
+            "roundrect",
+            1,
+            1.45,
+            angle=270,
+            fp_angle=-90,
+            local=(0.95, 0),
+        )
+        + segment((147.9, trace_y), (154.4, trace_y), width=0.11),
+    )
+    monkeypatch.setattr(analysis, "_get_design_rules_clearance", lambda pcb: 0.1016)
+    result = measure_clearance(
+        str(path), *(("B", "C19") if reverse else ("C19", "B")), layer="F.Cu"
+    )
+    assert result.min_clearance_mm == pytest.approx(expected, abs=0.005)
+    assert result.required_clearance_mm == 0.1016
+    assert result.passes_rules is passes
+    assert result.location == (147.086, 97.997)
+
+
+@pytest.mark.parametrize("reverse", [False, True])
+def test_oval_true_corner_clearance(tmp_path, reverse):
+    path = board(tmp_path, pad(shape="oval") + segment((1.95, 0.8), (3, 0.8)))
+    result = measure_clearance(str(path), *(("B", "A") if reverse else ("A", "B")), layer="F.Cu")
+    assert result.min_clearance_mm == pytest.approx(
+        (0.45**2 + 0.8**2) ** 0.5 - 0.5 - 0.1, abs=0.001
+    )
+
+
+def test_missing_polygon_fails_closed(tmp_path, monkeypatch):
+    from kicad_tools.validate.rules import clearance
+
+    path = board(tmp_path, pad() + segment((-3, 1), (3, 1)))
+    monkeypatch.setattr(clearance, "_pad_polygon", lambda *args: None)
+    with pytest.raises(ValueError, match="Copper polygon unavailable for U1-1"):
+        measure_clearance(str(path), "A", "B")
+
+
+def test_same_net_exempt_but_net_zero_included(tmp_path):
+    path = board(tmp_path, pad() + pad("U2", 0, 2, net=1))
+    with pytest.raises(ValueError, match="No clearance measurements possible"):
+        measure_clearance(str(path), "U1", "U2")
+    path = board(tmp_path, pad(net=0) + pad("U2", 0, 2, net=0))
+    assert measure_clearance(str(path), "U1", "U2").min_clearance_mm == 1
+
+
+def test_layers_and_neighbor_minimum(tmp_path):
+    path = board(
+        tmp_path,
+        pad()
+        + pad("U2", 0, 3, net=2)
+        + pad("U3", 0, 2, net=3)
+        + pad("U4", 0, 0, net=2, layer="B.Cu"),
+    )
+    result = measure_clearance(str(path), "U1")
+    assert result.item2 == "U3"
+    assert result.min_clearance_mm == 1
+    assert result.layer == "F.Cu"
+    assert result.location == (2, 1)
+    assert len(result.clearances) == 2
+    assert measure_clearance(str(path), "U1", layer="F.Cu") == result
+    with pytest.raises(ValueError, match="No copper elements found"):
+        measure_clearance(str(path), "U1", layer="B.Cu")
+
+
+def test_unrounded_minimum_compared_to_rule_floor(tmp_path, monkeypatch):
+    from kicad_tools.mcp.tools import analysis
+
+    path = board(tmp_path, pad() + segment((-3, 0.70159), (3, 0.70159)))
+    monkeypatch.setattr(analysis, "_get_design_rules_clearance", lambda pcb: 0.1016)
+    result = measure_clearance(str(path), "A", "B")
+    assert result.min_clearance_mm == 0.1016
+    assert result.passes_rules is False
+    assert result.required_clearance_mm == 0.1016
+
+
+@pytest.mark.parametrize("angle", [30, -30, 45])
+@pytest.mark.parametrize("other", ["track", "pad", "via"])
+@pytest.mark.parametrize("reverse", [False, True])
+def test_noncardinal_physical_overlap_and_mirrored_clearance(tmp_path, angle, other, reverse):
+    import math
+
+    def world(angle, x, y, center):
+        a = math.radians(-angle)
+        return center[0] + x * math.cos(a) - y * math.sin(a), center[1] + x * math.sin(
+            a
+        ) + y * math.cos(a)
+
+    fp = (10, 10)
+    center = world(37, 2, 1, fp)
+    first = pad(x=10, y=10, shape="roundrect", angle=angle, fp_angle=37, local=(2, 1), ratio=0.1)
+    for physical in (True, False):
+        target_angle = angle if physical else -angle
+        pos = world(target_angle, 1.8, 0.2, center)
+        if other == "track":
+            second = segment(world(target_angle, 1.6, 0.2, center), pos, width=0.1)
+        elif other == "pad":
+            second = pad("U2", *pos, shape="circle", width=0.1, height=0.1, net=2)
+        else:
+            second = via(*pos, size=0.1)
+        path = board(tmp_path, first + second)
+        result = measure_clearance(
+            str(path), *(("B", "A") if reverse else ("A", "B")), layer="F.Cu"
+        )
+        assert (result.min_clearance_mm < 0) is physical
+        if not physical:
+            assert result.min_clearance_mm > 0.2


### PR DESCRIPTION
MCP clearance measurements now use the shared validator copper model for every pair type. Pads retain their shape, rotation, rounded-corner ratio, and polygon, correcting false clearances and violations from the previous disc approximation. Public track names, references, layer selection, net-zero comparisons, result structure, and clearance thresholds remain intact. Missing pad polygons produce an explicit error.

The grid audit documents its conservative restriction around axis-aligned rounded corners and identifies unsafe square-pad and discarded-rotation cases in routing backstops. Those reproducible defects are tracked separately in #5229; this PR includes the audit disposition and does not change grid behavior.

Closes #5128

Prerequisites #5155 and #5230 have merged. This PR now targets main at reconciled head `7ca426de40ca68b410c099f965762b68978a1ae4`; its 15 CI checks pass and two conditional checks are skipped.

Validation: 197 tests passed across MCP clearance/analysis and shared clearance/polygon suites, including all 44 new MCP tests and 18 physical noncardinal controls that failed before the prerequisite correction. Six native tests skipped because kicad-cli is unavailable locally. Ruff, formatting, whitespace, and version gate passed; mypy retains two verified pre-existing errors. Independent Judge review found no code issues and reran all 44 new tests successfully. Final-head CI has passed on the reconciled head.
