### PR TITLE
fix(router): validate rotated pad clearance in Python and native grids

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1202,6 +1202,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Grid routing acceptance now retains non-cardinal pad rotation in Python
+  segment/via backstops and the native validator, including late pad additions
+  (#5182). Native candidate vias now check foreign pad copper using the same
+  component clearance and exclusions as finalization. Requires native build v22.
+
+
 - **Declared current paths reported `unresolved` on real boards whenever a
   trace did not land on the exact pad center** (#4980) — endpoint resolution
   (`router/current_paths.py`) attached a `RefDes.pad` endpoint to the copper

--- a/docs/research/grid-pad-rotation.md
+++ b/docs/research/grid-pad-rotation.md
@@ -1,0 +1,41 @@
+# Grid pad rotation acceptance (#5182)
+
+The grid's three Python pad checks and native segment/via acceptance use the
+pad's local rectangular axes. KiCad positive angles rotate copper by the
+negative mathematical angle in board XY coordinates; the inverse transform
+uses the positive residual angle. The #4910 parser's cardinal width/height swap
+is retained, and zero residual angles take the original arithmetic path.
+An enclosing AABB is useful for grid blockage but cannot determine physical
+clearance: it also covers empty space beside a rotated rectangle.
+
+Native build v22 carries rotation through initial population and late pad
+registration. Candidate vias now check foreign pads even when the candidate
+route contains no segments. Violation code 8 means via-pad; code 7 remains
+reserved for the search's pairwise-blocked reason. The violation location is
+the pad center. Old native builds are disabled by the existing version guard.
+
+Via-pad acceptance follows `worst_via_pad_deficit`: inclusive via layer spans,
+through-hole pads on every layer, same-net exclusion, and the component's trace
+clearance floor. Other native via quadrants retain their separate via floors.
+Only eligible relaxed/fine-pitch component references may waive a nonnegative
+via-pad gap; plane pads and copper overlap (including net 0) are never waived.
+Eligibility and clearance are refreshed lazily before native via acceptance
+when late pad additions, rules or corridor relaxation change. Repeated checks
+reuse the grid pitch cache and policy snapshot; segment-only routes skip this
+work.
+The preexisting native segment carve-out policy is unchanged.
+
+These are the grid's existing rectangular/disc approximations, not arbitrary
+KiCad pad-shape geometry. Zero-residual equal-width/height pads still use the
+legacy disc heuristic. Shape discrimination, including square pads, is tracked
+separately in [#5229](https://github.com/rjwalters/kicad-tools/issues/5229).
+Rounded rectangles and ovals continue to use the rectangle envelope where
+width differs from height; this change does not claim exact shape fidelity.
+
+Regression points are constructed independently from original 4-by-1 pad
+coordinates using the negative full KiCad angle. Tests exercise signed,
+cardinal and near-cardinal angles; true overlaps and sub-floor gaps; valid
+points within the enclosing AABB; initial and late native registration;
+policy exclusions; and actual Autorouter finalization with the unchanged
+0.127 mm floor and 0.05 mm nudge reach. Native tests run against a locally
+compiled extension and skip explicitly when that backend is unavailable.

--- a/src/kicad_tools/router/cpp/include/grid.hpp
+++ b/src/kicad_tools/router/cpp/include/grid.hpp
@@ -239,6 +239,8 @@ public:
                  float clearance_override,
                  bool is_plane_net = false, float rotation = 0.0f);
 
+    void set_pad_via_policy(size_t index, float clearance, bool carveout_eligible);
+
     // Register a completed route's segments for clearance validation.
     void add_stored_segment(float x1, float y1, float x2, float y2,
                             float width, int layer_idx, int net);

--- a/src/kicad_tools/router/cpp/include/grid.hpp
+++ b/src/kicad_tools/router/cpp/include/grid.hpp
@@ -237,7 +237,7 @@ public:
     void add_pad(float x, float y, float width, float height,
                  int net, int layer_idx, uint32_t ref_hash,
                  float clearance_override,
-                 bool is_plane_net = false);
+                 bool is_plane_net = false, float rotation = 0.0f);
 
     // Register a completed route's segments for clearance validation.
     void add_stored_segment(float x1, float y1, float x2, float y2,

--- a/src/kicad_tools/router/cpp/include/types.hpp
+++ b/src/kicad_tools/router/cpp/include/types.hpp
@@ -587,6 +587,7 @@ struct PadInfo {
     // by classifying ``pad.net_name`` (the C++ side has no string
     // table, so the boolean is computed in Python and passed in).
     bool is_plane_net = false;
+    float rotation = 0.0f;  // Residual KiCad board-space degrees (#5182)
 };
 
 // Stored segment for validation (Issue #2439)

--- a/src/kicad_tools/router/cpp/include/types.hpp
+++ b/src/kicad_tools/router/cpp/include/types.hpp
@@ -224,7 +224,8 @@ namespace router {
 // negotiated strategy fell through to blanket retry (the thrash Phase 2
 // exists to end).  New module constant + four ``Pathfinder`` accessors =
 // binding-surface change; route output is unchanged (diagnostics only).
-constexpr int ROUTER_CPP_BUILD_VERSION = 21;
+// v22: residual pad rotation and candidate via-pad acceptance/policy refresh.
+constexpr int ROUTER_CPP_BUILD_VERSION = 22;
 
 // Issue #4071: fixed-capacity owner-set size for per-cell corridor
 // reservations.  Observed owner sets in practice are tiny: 1 for the
@@ -354,7 +355,8 @@ struct Via {
 // When ``success == false`` the search was unable to produce a route.  The
 // numbering mirrors ``ValidationResult::violation_type`` so Python callers
 // can dispatch on the same vocabulary across both search-time failures and
-// post-route validator violations.
+// post-route validator violations. Validation-only code 8 is via-pad;
+// code 7 remains reserved for the search PAIRWISE_BLOCKED reason.
 //
 // FAILURE_VIA_VIA_BLOCKED is set when every via candidate considered during
 // the A* expansion was refused by the geometric via-vs-via clearance check
@@ -588,6 +590,8 @@ struct PadInfo {
     // table, so the boolean is computed in Python and passed in).
     bool is_plane_net = false;
     float rotation = 0.0f;  // Residual KiCad board-space degrees (#5182)
+    float via_clearance_override = 0.0f; // Component trace floor (Python backstop)
+    bool via_carveout_eligible = false;
 };
 
 // Stored segment for validation (Issue #2439)
@@ -646,7 +650,7 @@ struct ValidationResult {
     float min_clearance = std::numeric_limits<float>::infinity();
     float violation_x = 0.0f;
     float violation_y = 0.0f;
-    int violation_type = 0;  // 0=none, 1=seg-pad, 2=seg-seg, 3=seg-via, 4=via-seg, 5=via-via, 6=drill
+    int violation_type = 0;  // 0=none, 1=seg-pad, 2=seg-seg, 3=seg-via, 4=via-seg, 5=via-via, 6=drill, 7=reserved, 8=via-pad
 };
 
 }  // namespace router

--- a/src/kicad_tools/router/cpp/src/bindings.cpp
+++ b/src/kicad_tools/router/cpp/src/bindings.cpp
@@ -269,7 +269,7 @@ NB_MODULE(router_cpp, m) {
         .def("add_pad", &Grid3D::add_pad,
              "x"_a, "y"_a, "width"_a, "height"_a,
              "net"_a, "layer_idx"_a, "ref_hash"_a, "clearance_override"_a,
-             "is_plane_net"_a = false)
+             "is_plane_net"_a = false, "rotation"_a = 0.0f)
         .def("add_stored_segment", &Grid3D::add_stored_segment,
              "x1"_a, "y1"_a, "x2"_a, "y2"_a,
              "width"_a, "layer_idx"_a, "net"_a)

--- a/src/kicad_tools/router/cpp/src/bindings.cpp
+++ b/src/kicad_tools/router/cpp/src/bindings.cpp
@@ -270,6 +270,8 @@ NB_MODULE(router_cpp, m) {
              "x"_a, "y"_a, "width"_a, "height"_a,
              "net"_a, "layer_idx"_a, "ref_hash"_a, "clearance_override"_a,
              "is_plane_net"_a = false, "rotation"_a = 0.0f)
+        .def("set_pad_via_policy", &Grid3D::set_pad_via_policy,
+             "index"_a, "clearance"_a, "carveout_eligible"_a)
         .def("add_stored_segment", &Grid3D::add_stored_segment,
              "x1"_a, "y1"_a, "x2"_a, "y2"_a,
              "width"_a, "layer_idx"_a, "net"_a)

--- a/src/kicad_tools/router/cpp/src/grid.cpp
+++ b/src/kicad_tools/router/cpp/src/grid.cpp
@@ -437,7 +437,30 @@ void Grid3D::add_pad(float x, float y, float width, float height,
                      int net, int layer_idx, uint32_t ref_hash,
                      float clearance_override, bool is_plane_net, float rotation) {
     pads_.push_back({x, y, width, height, net, layer_idx, ref_hash,
-                     clearance_override, is_plane_net, rotation});
+                     clearance_override, is_plane_net, rotation, clearance_override, false});
+}
+
+void Grid3D::set_pad_via_policy(size_t index, float clearance, bool carveout_eligible) {
+    auto& pad = pads_.at(index);
+    pad.via_clearance_override = clearance;
+    pad.via_carveout_eligible = carveout_eligible;
+}
+
+// Transform into local copper axes, not the enclosing board-space box.
+static float pad_rect_distance(const PadInfo& pad, float x1, float y1,
+                               float x2, float y2) {
+    if (pad.rotation == 0.0f) {
+        return rect_segment_centerline_distance(
+            pad.x, pad.y, pad.width, pad.height, x1, y1, x2, y2);
+    }
+    const float angle = pad.rotation * 3.14159265358979323846f / 180.0f;
+    const float c = std::cos(angle), s = std::sin(angle);
+    const float dx1 = x1 - pad.x, dy1 = y1 - pad.y;
+    const float dx2 = x2 - pad.x, dy2 = y2 - pad.y;
+    return rect_segment_centerline_distance(
+        0.0f, 0.0f, pad.width, pad.height,
+        c * dx1 - s * dy1, s * dx1 + c * dy1,
+        c * dx2 - s * dy2, s * dx2 + c * dy2);
 }
 
 void Grid3D::add_stored_segment(float x1, float y1, float x2, float y2,
@@ -791,23 +814,8 @@ ValidationResult Grid3D::validate_route(
                 // Rect-aware: signed centerline-to-rect distance.  Negative
                 // means the segment centerline lies inside the pad rectangle
                 // (a real DRC defect).
-                float center_dist;
-                if (pad.rotation == 0.0f) {
-                    center_dist = rect_segment_centerline_distance(
-                        pad.x, pad.y, pad.width, pad.height,
-                        seg.x1, seg.y1, seg.x2, seg.y2);
-                } else {
-                    // KiCad copper rotates by -angle in board coordinates;
-                    // inverse-transform endpoints with +angle into local axes.
-                    const float angle = pad.rotation * 3.14159265358979323846f / 180.0f;
-                    const float c = std::cos(angle), s = std::sin(angle);
-                    const float dx1 = seg.x1 - pad.x, dy1 = seg.y1 - pad.y;
-                    const float dx2 = seg.x2 - pad.x, dy2 = seg.y2 - pad.y;
-                    center_dist = rect_segment_centerline_distance(
-                        0.0f, 0.0f, pad.width, pad.height,
-                        c * dx1 - s * dy1, s * dx1 + c * dy1,
-                        c * dx2 - s * dy2, s * dx2 + c * dy2);
-                }
+                const float center_dist = pad_rect_distance(
+                    pad, seg.x1, seg.y1, seg.x2, seg.y2);
                 clearance = center_dist - seg_half_width;
             }
 
@@ -978,6 +986,33 @@ ValidationResult Grid3D::validate_route(
         // Via spans from layer_from to layer_to
         int layer_lo = std::min(via.layer_from, via.layer_to);
         int layer_hi = std::max(via.layer_from, via.layer_to);
+
+        // Candidate via vs foreign pads (#5182): match worst_via_pad_deficit.
+        // Its floor is the component TRACE clearance; other via quadrants below
+        // retain their existing via clearance and pairwise widening policies.
+        for (const auto& pad : pads_) {
+            if (pad.net == exclude_net) continue;
+            if (pad.layer_idx != -1 &&
+                (pad.layer_idx < layer_lo || pad.layer_idx > layer_hi)) continue;
+            float clearance;
+            if (pad.rotation == 0.0f && std::abs(pad.width - pad.height) < 0.001f) {
+                clearance = std::hypot(via.x - pad.x, via.y - pad.y)
+                    - std::max(pad.width, pad.height) / 2.0f - via_radius;
+            } else {
+                clearance = pad_rect_distance(pad, via.x, via.y, via.x, via.y) - via_radius;
+            }
+            // No net-0 metal-overlap exception for vias.
+            if (!pad.is_plane_net && pad.via_carveout_eligible &&
+                is_excluded_ref(pad.ref_hash) && clearance >= 0.0f) continue;
+            result.min_clearance = std::min(result.min_clearance, clearance);
+            if (clearance < pad.via_clearance_override - CLEARANCE_EPSILON_MM) {
+                result.valid = false;
+                result.violation_x = pad.x;
+                result.violation_y = pad.y;
+                result.violation_type = 8;  // via-pad (7 reserved for search pairwise)
+                return result;
+            }
+        }
 
         for (const auto& seg : stored_segments_) {
             if (seg.net == exclude_net) continue;

--- a/src/kicad_tools/router/cpp/src/grid.cpp
+++ b/src/kicad_tools/router/cpp/src/grid.cpp
@@ -435,9 +435,9 @@ float Grid3D::memory_mb() const {
 
 void Grid3D::add_pad(float x, float y, float width, float height,
                      int net, int layer_idx, uint32_t ref_hash,
-                     float clearance_override, bool is_plane_net) {
+                     float clearance_override, bool is_plane_net, float rotation) {
     pads_.push_back({x, y, width, height, net, layer_idx, ref_hash,
-                     clearance_override, is_plane_net});
+                     clearance_override, is_plane_net, rotation});
 }
 
 void Grid3D::add_stored_segment(float x1, float y1, float x2, float y2,
@@ -781,7 +781,7 @@ ValidationResult Grid3D::validate_route(
             // Mirrors PR #2787 (validate/rules/clearance.py) and the
             // Python validator at ``router/grid.py``.
             float clearance;
-            const bool is_circular_pad = std::abs(pad.width - pad.height) < 0.001f;
+            const bool is_circular_pad = pad.rotation == 0.0f && std::abs(pad.width - pad.height) < 0.001f;
             if (is_circular_pad) {
                 const float pad_radius = std::max(pad.width, pad.height) / 2.0f;
                 const float dist = point_to_segment_distance(
@@ -791,9 +791,23 @@ ValidationResult Grid3D::validate_route(
                 // Rect-aware: signed centerline-to-rect distance.  Negative
                 // means the segment centerline lies inside the pad rectangle
                 // (a real DRC defect).
-                const float center_dist = rect_segment_centerline_distance(
-                    pad.x, pad.y, pad.width, pad.height,
-                    seg.x1, seg.y1, seg.x2, seg.y2);
+                float center_dist;
+                if (pad.rotation == 0.0f) {
+                    center_dist = rect_segment_centerline_distance(
+                        pad.x, pad.y, pad.width, pad.height,
+                        seg.x1, seg.y1, seg.x2, seg.y2);
+                } else {
+                    // KiCad copper rotates by -angle in board coordinates;
+                    // inverse-transform endpoints with +angle into local axes.
+                    const float angle = pad.rotation * 3.14159265358979323846f / 180.0f;
+                    const float c = std::cos(angle), s = std::sin(angle);
+                    const float dx1 = seg.x1 - pad.x, dy1 = seg.y1 - pad.y;
+                    const float dx2 = seg.x2 - pad.x, dy2 = seg.y2 - pad.y;
+                    center_dist = rect_segment_centerline_distance(
+                        0.0f, 0.0f, pad.width, pad.height,
+                        c * dx1 - s * dy1, s * dx1 + c * dy1,
+                        c * dx2 - s * dy2, s * dx2 + c * dy2);
+                }
                 clearance = center_dist - seg_half_width;
             }
 

--- a/src/kicad_tools/router/cpp_backend.py
+++ b/src/kicad_tools/router/cpp_backend.py
@@ -50,7 +50,7 @@ logger = logging.getLogger(__name__)
 # ``AttributeError`` deep in the routing code (e.g. ``router_cpp.PadBounds``
 # missing).  The guard below catches that at import time and falls back to the
 # pure-Python router with an actionable ``kct build-native`` hint.
-_REQUIRED_CPP_BUILD_VERSION = 21
+_REQUIRED_CPP_BUILD_VERSION = 22
 
 # Try to import C++ module with detailed error tracking
 _CPP_IMPORT_ERROR: str | None = None
@@ -934,6 +934,7 @@ class CppGrid:
         from .grid import _is_plane_net_pad
 
         component_pitches = grid.compute_component_pitches()
+        grid._component_pitch_cache = component_pitches
 
         # Issue #3371 / P_FP2: Fine-pitch escape regions installed on the
         # grid (empty list when the detector has not run, which is the
@@ -1003,6 +1004,9 @@ class CppGrid:
                 pad.rotation,
             )
 
+        from .grid import _sync_pad_via_policies
+
+        _sync_pad_via_policies(grid, cpp_grid)
         return cpp_grid
 
     def index_to_layer(self, index: int) -> int:
@@ -2671,8 +2675,8 @@ class CppPathfinder:
     ) -> tuple[float, float] | None:
         """Validate post-route geometric clearance using C++ validation.
 
-        Issue #2439: Uses the C++ validate_route() call which runs all 4
-        validation checks (segment-pad, segment-segment, via-segment,
+        Issue #2439: Uses the C++ validate_route() call which runs
+        validation checks (segment-pad, segment-segment, via-pad, via-segment,
         via-via, same-net drill spacing) in a single C++ call, eliminating
         Python callback overhead.
 
@@ -2762,6 +2766,11 @@ class CppPathfinder:
         # trace-vs-trace copper, not pads and vias).  No-op without a voltage
         # map.
         self._sync_pairwise_domains_to_cpp()
+
+        if route.vias and py_grid is not None:
+            from .grid import _sync_pad_via_policies
+
+            _sync_pad_via_policies(py_grid, self._grid)
 
         vresult = self._grid._impl.validate_route(
             cpp_segs,

--- a/src/kicad_tools/router/cpp_backend.py
+++ b/src/kicad_tools/router/cpp_backend.py
@@ -1000,6 +1000,7 @@ class CppGrid:
                 ref_hash,
                 clearance_override,
                 is_plane_net,
+                pad.rotation,
             )
 
         return cpp_grid

--- a/src/kicad_tools/router/grid.py
+++ b/src/kicad_tools/router/grid.py
@@ -135,6 +135,34 @@ _PLANE_NET_EXACT: frozenset[str] = frozenset(
 )
 
 
+def _pad_rect_segment_centerline_distance(
+    pad: Pad, x1: float, y1: float, x2: float, y2: float
+) -> float:
+    """Distance in pad-local axes, preserving the cardinal legacy fast path.
+
+    KiCad board coordinates rotate copper by minus the declared angle, so
+    the inverse transform below uses plus rotation. Dimensions stay local.
+    This rectangular model does not infer arbitrary native pad shapes.
+    """
+    if pad.rotation == 0.0:
+        return _rect_segment_centerline_distance(
+            pad.x, pad.y, pad.width, pad.height, x1, y1, x2, y2
+        )
+    angle = math.radians(pad.rotation)
+    c, s = math.cos(angle), math.sin(angle)
+    dx1, dy1, dx2, dy2 = x1 - pad.x, y1 - pad.y, x2 - pad.x, y2 - pad.y
+    return _rect_segment_centerline_distance(
+        0.0,
+        0.0,
+        pad.width,
+        pad.height,
+        c * dx1 - s * dy1,
+        s * dx1 + c * dy1,
+        c * dx2 - s * dy2,
+        s * dx2 + c * dy2,
+    )
+
+
 def _sync_pad_to_cpp_grid(
     py_grid: RoutingGrid,
     cpp_grid: Any,
@@ -3085,17 +3113,14 @@ class RoutingGrid:
                 )
             )
 
-            is_circular_pad = abs(pad.width - pad.height) < 0.001
+            is_circular_pad = pad.rotation == 0.0 and abs(pad.width - pad.height) < 0.001
             if is_circular_pad:
                 pad_radius = max(pad.width, pad.height) / 2
                 dist = self._point_to_segment_distance(pad.x, pad.y, seg.x1, seg.y1, seg.x2, seg.y2)
                 clearance = dist - seg_half_width - pad_radius
             else:
-                center_dist = _rect_segment_centerline_distance(
-                    pad.x,
-                    pad.y,
-                    pad.width,
-                    pad.height,
+                center_dist = _pad_rect_segment_centerline_distance(
+                    pad,
                     seg.x1,
                     seg.y1,
                     seg.x2,
@@ -3188,7 +3213,7 @@ class RoutingGrid:
                 )
             )
 
-            is_circular_pad = abs(pad.width - pad.height) < 0.001
+            is_circular_pad = pad.rotation == 0.0 and abs(pad.width - pad.height) < 0.001
             if is_circular_pad:
                 pad_radius = max(pad.width, pad.height) / 2
                 dist = math.hypot(via.x - pad.x, via.y - pad.y)
@@ -3196,11 +3221,8 @@ class RoutingGrid:
             else:
                 # Degenerate (point) segment: distance from the pad rect
                 # boundary to the via center.
-                center_dist = _rect_segment_centerline_distance(
-                    pad.x,
-                    pad.y,
-                    pad.width,
-                    pad.height,
+                center_dist = _pad_rect_segment_centerline_distance(
+                    pad,
                     via.x,
                     via.y,
                     via.x,
@@ -3487,7 +3509,7 @@ class RoutingGrid:
             # the disc model -- it is exact for circular obstacles and
             # cheaper to evaluate. This mirrors PR #2787's fix at
             # ``validate/rules/clearance.py::_segment_circle_clearance``.
-            is_circular_pad = abs(pad.width - pad.height) < 0.001
+            is_circular_pad = pad.rotation == 0.0 and abs(pad.width - pad.height) < 0.001
             if is_circular_pad:
                 pad_radius = max(pad.width, pad.height) / 2
                 dist = self._point_to_segment_distance(pad.x, pad.y, seg.x1, seg.y1, seg.x2, seg.y2)
@@ -3497,11 +3519,8 @@ class RoutingGrid:
                 # means the segment centerline lies inside the pad rectangle
                 # (a real DRC defect; the magnitude is the deepest signed
                 # depth).
-                center_dist = _rect_segment_centerline_distance(
-                    pad.x,
-                    pad.y,
-                    pad.width,
-                    pad.height,
+                center_dist = _pad_rect_segment_centerline_distance(
+                    pad,
                     seg.x1,
                     seg.y1,
                     seg.x2,

--- a/src/kicad_tools/router/grid.py
+++ b/src/kicad_tools/router/grid.py
@@ -163,6 +163,39 @@ def _pad_rect_segment_centerline_distance(
     )
 
 
+def _sync_pad_via_policies(py_grid: RoutingGrid, cpp_grid: Any) -> None:
+    """Refresh lazily before via acceptance when pad policy inputs change.
+
+    Via-pad acceptance follows the finalization backstop's component trace
+    clearance, not the separate via-to-track/via floor or escape-region rule.
+    """
+    pitches = py_grid._component_pitch_cache
+    if pitches is None:
+        pitches = py_grid.compute_component_pitches()
+        py_grid._component_pitch_cache = pitches
+    rules = py_grid.rules
+    policy_key = (
+        id(pitches),
+        len(py_grid._pads),
+        frozenset(py_grid._relaxed_clearance_refs),
+        rules.trace_clearance,
+        rules.trace_width,
+        rules.strict_pad_clearance,
+        rules.fine_pitch_clearance,
+        rules.fine_pitch_threshold,
+        tuple(sorted(rules.component_clearances.items())),
+    )
+    if getattr(cpp_grid, "_pad_via_policy_key", None) == policy_key:
+        return
+    for index, pad in enumerate(py_grid._pads):
+        clearance = py_grid.rules.get_clearance_for_component(pad.ref, pitches.get(pad.ref))
+        eligible = py_grid._same_component_carveout_active(
+            pad.ref, clearance, py_grid.rules.trace_clearance, pitches
+        )
+        cpp_grid._impl.set_pad_via_policy(index, clearance, eligible)
+    cpp_grid._pad_via_policy_key = policy_key
+
+
 def _sync_pad_to_cpp_grid(
     py_grid: RoutingGrid,
     cpp_grid: Any,
@@ -230,6 +263,7 @@ def _sync_pad_to_cpp_grid(
             ref_hash,
             clearance_override,
             is_plane_net,
+            pad.rotation,
         )
     except (AttributeError, TypeError):
         # Older C++ binding without is_plane_net argument; ignore -- the

--- a/tests/router/test_grid_pad_rotation_5182.py
+++ b/tests/router/test_grid_pad_rotation_5182.py
@@ -1,0 +1,247 @@
+"""Physical negative-KiCad-angle controls for grid acceptance, not AABB oracles."""
+
+import math
+
+import pytest
+
+from kicad_tools.router import DesignRules
+from kicad_tools.router.cpp_backend import is_cpp_available
+from kicad_tools.router.grid import RoutingGrid
+from kicad_tools.router.io import _resolve_pad_dims_and_rotation
+from kicad_tools.router.layers import Layer
+from kicad_tools.router.primitives import Pad, Segment, Via
+
+native = pytest.mark.skipif(
+    not is_cpp_available(), reason="native backend unavailable; run kct build-native"
+)
+
+ANGLES = [-45, -30, 0, 30, 45, 89.5, 90, 90.5, 180, 269.5, 270]
+
+
+def physical(angle, u, v):
+    c, s = math.cos(math.radians(angle)), math.sin(math.radians(angle))
+    return 10 + u * c + v * s, 10 - u * s + v * c
+
+
+def setup(angle):
+    w, h, rotation = _resolve_pad_dims_and_rotation(angle, 4, 1)
+    pad = Pad(10, 10, w, h, 2, "FOREIGN", ref="U2", rotation=rotation)
+    rules = DesignRules(trace_width=0.1, trace_clearance=0.127, grid_resolution=0.2)
+    grid = RoutingGrid(20, 20, rules)
+    grid.add_pad(pad)
+    return grid, pad
+
+
+@pytest.mark.parametrize("angle", ANGLES)
+@pytest.mark.parametrize("v,valid", [(0, False), (0.6, False), (0.8, True)])
+def test_python_backstops(angle, v, valid):
+    grid, pad = setup(angle)
+    a, b = physical(angle, 1.2, v), physical(angle, 1.6, v)
+    seg = Segment(*a, *b, 0.1, Layer.F_CU, 1)
+    via = Via(*physical(angle, 1.5, v), 0.1, 0.2, (Layer.F_CU, Layer.B_CU), 1)
+    assert (grid.worst_segment_pad_deficit(seg, 1)[0] == 0) is valid
+    assert (grid.worst_via_pad_deficit(via, 1)[0] == 0) is valid
+    assert grid.validate_segment_clearance(seg, exclude_net=1)[0] is valid
+    if not valid:
+        assert grid.worst_via_pad_deficit(via, 1)[1] == (pad.x, pad.y)
+
+
+@pytest.mark.parametrize("angle", ANGLES)
+@pytest.mark.parametrize("v,valid", [(0, False), (0.6, False), (0.8, True)])
+@pytest.mark.parametrize("kind", ["segment", "via"])
+@pytest.mark.parametrize("late", [False, True])
+@native
+def test_compiled_acceptance(angle, v, valid, kind, late):
+    from kicad_tools.router import router_cpp
+    from kicad_tools.router.cpp_backend import CppGrid, is_cpp_available
+
+    assert is_cpp_available(), "Build native backend to run these regression controls"
+    grid, pad = setup(angle)
+    if late:
+        grid = RoutingGrid(20, 20, grid.rules)
+    cpp = CppGrid.from_routing_grid(grid)
+    if late:
+        grid.add_pad(pad)
+    segments, vias = [], []
+    if kind == "segment":
+        item = router_cpp.Segment()
+        item.x1, item.y1 = physical(angle, 1.2, v)
+        item.x2, item.y2 = physical(angle, 1.6, v)
+        item.width, item.layer, item.net = 0.1, 0, 1
+        segments.append(item)
+    else:
+        item = router_cpp.Via()
+        item.x, item.y = physical(angle, 1.5, v)
+        item.diameter, item.drill = 0.2, 0.1
+        item.layer_from, item.layer_to, item.net = 0, 1, 1
+        vias.append(item)
+    result = cpp._impl.validate_route(segments, vias, 1, [], 0.127, 0.127, 0.1)
+    assert result.valid is valid
+
+
+@pytest.mark.parametrize("kind", ["segment", "via"])
+@pytest.mark.parametrize("force_python", [True, False])
+@pytest.mark.parametrize("v,demoted", [(0, True), (0.8, False)])
+def test_actual_finalization(kind, force_python, v, demoted):
+    from kicad_tools.router.core import Autorouter
+    from kicad_tools.router.primitives import Route
+
+    rules = DesignRules(trace_width=0.1, trace_clearance=0.127, grid_resolution=0.05)
+    if not force_python and not is_cpp_available():
+        pytest.skip("native backend unavailable")
+    router = Autorouter(20, 20, rules=rules, force_python=force_python)
+    _, pad = setup(45)
+    router.add_component(
+        "U2",
+        [
+            {
+                "number": "1",
+                "x": pad.x,
+                "y": pad.y,
+                "width": pad.width,
+                "height": pad.height,
+                "rotation": pad.rotation,
+                "net": 2,
+                "net_name": "FOREIGN",
+            }
+        ],
+    )
+    route = Route(1, "SIGNAL")
+    if kind == "segment":
+        route.segments.append(
+            Segment(*physical(45, 1.2, v), *physical(45, 1.6, v), 0.1, Layer.F_CU, 1)
+        )
+    else:
+        route.vias.append(Via(*physical(45, 1.5, v), 0.1, 0.2, (Layer.F_CU, Layer.B_CU), 1))
+    router.routes.append(route)
+    router.grid.mark_route(route)
+    router.grid.mark_route_usage(route)
+    net_routes = {1: [route]}
+    assert router._demote_pad_clearance_violation_nets(net_routes) == ([1] if demoted else [])
+    assert (route in router.routes) is not demoted
+    assert bool(net_routes[1]) is not demoted
+    assert rules.trace_clearance == 0.127
+    assert router.grid.resolution == 0.05
+
+
+@pytest.mark.parametrize("net", [0, 1, 2])
+@pytest.mark.parametrize(
+    "through,layer,span,valid",
+    [
+        (False, Layer.F_CU, (1, 0), False),
+        (False, Layer.B_CU, (0, 0), True),
+        (True, Layer.B_CU, (0, 0), False),
+    ],
+)
+@native
+def test_layer_span_and_same_net(net, through, layer, span, valid):
+    from kicad_tools.router import router_cpp
+    from kicad_tools.router.cpp_backend import CppGrid
+
+    grid, pad = setup(30)
+    pad.net, pad.through_hole, pad.layer = net, through, layer
+    cpp = CppGrid.from_routing_grid(grid)
+    x, y = physical(30, 1.5, 0)
+    via = router_cpp.Via()
+    via.x, via.y, via.diameter, via.drill = x, y, 0.2, 0.1
+    via.layer_from, via.layer_to, via.net = *span, 1
+    result = cpp._impl.validate_route([], [via], 1, [], 0.127, 0.4, 0.1)
+    expected = valid or net == 1
+    assert result.valid is expected
+    py_via = Via(x, y, 0.1, 0.2, tuple([Layer.F_CU, Layer.B_CU][i] for i in span), 1)
+    assert (grid.worst_via_pad_deficit(py_via, 1)[0] == 0) is expected
+    if not expected:
+        assert result.violation_type == 8
+        assert (result.violation_x, result.violation_y) == (10, 10)
+
+
+@pytest.mark.parametrize("mode", ["standard", "relaxed", "override", "strict", "plane"])
+@pytest.mark.parametrize("net", [0, 2])
+@pytest.mark.parametrize("v", [0, 0.65, 0.8])
+@native
+def test_via_carveout_and_component_floor(mode, net, v):
+    from kicad_tools.router import router_cpp
+    from kicad_tools.router.cpp_backend import CppGrid
+    from kicad_tools.router.grid import _sync_pad_via_policies
+
+    grid, pad = setup(30)
+    pad.net = net
+    if mode == "override":
+        grid.rules.component_clearances[pad.ref] = 0.04
+    if mode in ("relaxed", "strict", "plane"):
+        grid._relaxed_clearance_refs.add(pad.ref)
+    if mode == "strict":
+        grid.rules.strict_pad_clearance = True
+    if mode == "plane":
+        pad.net_name = "GND"
+    cpp = CppGrid.from_routing_grid(grid)
+    _sync_pad_via_policies(grid, cpp)
+    x, y = physical(30, 1.5, v)
+    via = router_cpp.Via()
+    via.x, via.y, via.diameter, via.drill = x, y, 0.2, 0.1
+    via.layer_from, via.layer_to, via.net = 0, 1, 1
+    result = cpp._impl.validate_route(
+        [], [via], 1, [router_cpp.fnv1a_hash(pad.ref)], 0.127, 0.4, 0.1
+    )
+    py_via = Via(x, y, 0.1, 0.2, (Layer.F_CU, Layer.B_CU), 1)
+    deficit, _ = grid.worst_via_pad_deficit(py_via, 1, exclude_refs={pad.ref})
+    assert result.valid is (deficit == 0)
+    expected = v == 0.8 or (v == 0.65 and mode in ("relaxed", "override"))
+    assert result.valid is expected
+
+
+@native
+def test_late_pad_policy_refresh_reuses_pitch_cache(monkeypatch):
+    from kicad_tools.router.cpp_backend import CppGrid, CppPathfinder
+    from kicad_tools.router.primitives import Route
+
+    grid, pad = setup(30)
+    cpp = CppGrid.from_routing_grid(grid)
+    calls = []
+    original = grid.compute_component_pitches
+
+    def counted():
+        calls.append(True)
+        return original()
+
+    monkeypatch.setattr(grid, "compute_component_pitches", counted)
+    # Completing a fine-pitch component changes the ORIGINAL pad's policy.
+    # Late construction must not recompute all-pairs pitches for each pad.
+    for offset in (0.5, 1):
+        grid.add_pad(Pad(10, 10 + offset, 0.1, 0.1, 1, "SIGNAL", ref=pad.ref))
+    assert calls == []
+    pf = CppPathfinder(cpp, grid.rules)
+    route = Route(1, "SIGNAL")
+    route.vias.append(Via(*physical(30, 1.5, 0.65), 0.1, 0.2, (Layer.F_CU, Layer.B_CU), 1))
+    own = Pad(5, 5, 0.1, 0.1, 1, "SIGNAL", ref=pad.ref)
+    assert pf._validate_route_clearance(route, own, own, 1) is None
+    # The public wrapper has other consumers of pitch; count only the shared
+    # grid cache computation and require no additional call on repeated checks.
+    count = len(calls)
+    assert count >= 1
+    assert pf._validate_route_clearance(route, own, own, 1) is None
+    assert len(calls) == count
+    # Policy-only changes are detected without rebuilding geometry/pitches.
+    grid.rules.strict_pad_clearance = True
+    assert pf._validate_route_clearance(route, own, own, 1) == (10, 10)
+    assert len(calls) == count
+
+
+@native
+def test_segment_only_acceptance_does_not_refresh_via_policy(monkeypatch):
+    import kicad_tools.router.grid as grid_module
+    from kicad_tools.router.cpp_backend import CppGrid, CppPathfinder
+    from kicad_tools.router.primitives import Route
+
+    grid, _ = setup(30)
+    cpp = CppGrid.from_routing_grid(grid)
+    pf = CppPathfinder(cpp, grid.rules)
+
+    def forbidden(*args):
+        pytest.fail("segment-only acceptance recomputed via policies")
+
+    monkeypatch.setattr(grid_module, "_sync_pad_via_policies", forbidden)
+    route = Route(1, "SIGNAL")
+    route.segments.append(Segment(2, 2, 3, 2, 0.1, Layer.F_CU, 1))
+    own = Pad(2, 2, 0.1, 0.1, 1, "SIGNAL")
+    assert pf._validate_route_clearance(route, own, own, 1) is None


### PR DESCRIPTION
Rotated pads now participate in Python and C++ grid clearance checks using their local rectangular axes. A trace or via crossing the physical copper of a 45-degree elongated pad is rejected; nearby valid copper within the enclosing bounding box remains allowed. Rotation is preserved both during initial native conversion and when pads are added later.

Native route validation now includes candidate-via/pad checks, including via-only routes. These follow the Python backstop's component trace-clearance floor, layer spans, same-net exclusion, and eligible same-component rules. Plane pads and copper overlaps, including net-zero overlaps, cannot use the via carve-out. Other native via floors and the existing segment policy remain unchanged. Cached policy refresh avoids repeated pitch computation and skips routes without vias.

Closes #5182

Parent #5181 / #4910 merged as `664e7e86`. This PR is reconciled onto main at `627fb9e561abf00bd555457bf6b44f5f4ae95d85`; its reviewed patch is byte-for-byte unchanged. All recorded regression suites and the independent geometry oracle were rerun after reconciliation. Fresh CI and final approval remain required before merge. Native interface version 22 requires rebuilding the extension. Coordinate any later backend changes from #5219; a matching version number alone does not establish ABI compatibility.

Validation:

- 214 new regressions passed, including actual compiled native cases, initial/late conversion, signed/cardinal/near-cardinal geometry, layer and clearance policies, cache invalidation, and real Autorouter finalization at the unchanged .127 mm floor/.05 mm nudge reach.
- Related geometry/policy suites: 361 passed, three existing skips tracked by #3133. Parent rotation/backend suites: 91 passed, six existing availability/mock skips. Build-staleness suite separately: 32 passed.
- Local native force-build and availability/version checks passed. An independent 2,600-case polygon comparison passed, with maximum outside-distance error 1.78e-15 mm. Independent Judge review passed policy/cache checks and found no remaining code issues.
- Ruff, formatting, whitespace, and version gate passed. Mypy matches the parent's 33 existing diagnostics exactly.

A combined backend/staleness test ordering exposes two existing monkeypatch-reference failures, reproduced on untouched parent source; the suites pass separately. No tests were weakened to hide those failures. Native KiCad board regeneration was not performed.

The existing rectangular/disc approximation remains: #5229 owns distinguishing square rectangles from true circles and broader shape preservation. This PR does not claim arbitrary KiCad pad-shape fidelity or change manufacturing thresholds.
