### PR TITLE
test: include footprints in spatial candidate PCB fixtures

### DIFF
--- a/tests/test_copper_candidates.py
+++ b/tests/test_copper_candidates.py
@@ -61,7 +61,7 @@ def test_chain_exhaustive_parity(monkeypatch, bridge):
             ((5, 0), (5, 0), "F.Cu"),  # zero length
         ]
     ]
-    pcb = SimpleNamespace(vias=[])
+    pcb = SimpleNamespace(vias=[], footprints=[])
     validator = connectivity.ConnectivityValidator(pcb)
     bridges = [((2, 0), frozenset({"F.Cu", "B.Cu"}))] if bridge else []
     monkeypatch.setattr(validator, "_collect_layer_bridges", lambda *args: bridges)
@@ -86,7 +86,7 @@ def test_production_exact_predicate_counts(monkeypatch, count):
         SimpleNamespace(start=(i * 10, 0), end=(i * 10 + 1, 0), layer="F.Cu", width=0.2)
         for i in range(count)
     ]
-    validator = connectivity.ConnectivityValidator(SimpleNamespace(vias=[]))
+    validator = connectivity.ConnectivityValidator(SimpleNamespace(vias=[], footprints=[]))
     chain_calls = 0
 
     def chain_predicate(*args):
@@ -155,7 +155,7 @@ def test_width_only_contact_exhaustive_parity(monkeypatch, layer, widths, extra_
         SimpleNamespace(start=(0, 0), end=(10, 0), layer="F.Cu", width=widths[0]),
         SimpleNamespace(start=(2, separation), end=(8, separation), layer=layer, width=widths[1]),
     ]
-    validator = connectivity.ConnectivityValidator(SimpleNamespace(vias=[]))
+    validator = connectivity.ConnectivityValidator(SimpleNamespace(vias=[], footprints=[]))
 
     def run():
         return validator._build_segment_chains(
@@ -174,7 +174,7 @@ def test_negative_width_shared_endpoint_exhaustive_parity(monkeypatch):
         SimpleNamespace(start=(0, 0), end=(10, 0), layer="F.Cu", width=-2),
         SimpleNamespace(start=(0, 0), end=(-2, 0), layer="F.Cu", width=0.2),
     ]
-    validator = connectivity.ConnectivityValidator(SimpleNamespace(vias=[]))
+    validator = connectivity.ConnectivityValidator(SimpleNamespace(vias=[], footprints=[]))
 
     def run():
         return validator._build_segment_chains(


### PR DESCRIPTION
After the spatial-candidate and physical-pad-identity changes landed together, 17 spatial tests failed during validator construction because their segment-only PCB fixtures omitted `footprints`.

Add an empty footprint list to the four fixture initializers. All candidate/exhaustive parity, boundary, negative-width, and operation-count assertions remain unchanged; production code is unchanged.

Validation: reproduced the 17 constructor failures on the integrated main code before the fix. Afterward, spatial candidates, duplicate-pad connectivity, copper LVS, and hierarchical LVS pass together: **150 passed**. Ruff lint/format and diff whitespace checks pass. Full CI is pending.

TDD: yes — existing integration regressions failed before the fixture correction and pass afterward.

Closes #5237.