### PR TITLE
ci: select affected board jobs after lint and type checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,32 @@ concurrency:
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 jobs:
+  changes:
+    name: Select CI jobs
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      test: ${{ steps.plan.outputs['test'] }}
+      cpp-build-check: ${{ steps.plan.outputs['cpp-build-check'] }}
+      kicad-cli-smoke: ${{ steps.plan.outputs['kicad-cli-smoke'] }}
+      board-00-end-to-end: ${{ steps.plan.outputs['board-00-end-to-end'] }}
+      board-01-end-to-end: ${{ steps.plan.outputs['board-01-end-to-end'] }}
+      board-02-end-to-end: ${{ steps.plan.outputs['board-02-end-to-end'] }}
+      board-03-end-to-end: ${{ steps.plan.outputs['board-03-end-to-end'] }}
+      board-04-end-to-end: ${{ steps.plan.outputs['board-04-end-to-end'] }}
+      board-05-routing-regression: ${{ steps.plan.outputs['board-05-routing-regression'] }}
+      board-06-end-to-end: ${{ steps.plan.outputs['board-06-end-to-end'] }}
+      diffpair-routing-regression: ${{ steps.plan.outputs['diffpair-routing-regression'] }}
+      board-07-end-to-end: ${{ steps.plan.outputs['board-07-end-to-end'] }}
+      matchgroup-routing-regression: ${{ steps.plan.outputs['matchgroup-routing-regression'] }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+      - name: Select affected consumers from the complete event diff
+        id: plan
+        run: python3 scripts/ci/select_jobs.py
+
   lint:
     name: Lint & Format
     runs-on: ubuntu-latest
@@ -94,6 +120,8 @@ jobs:
         run: uv run python scripts/ci/check_mypy_baseline.py
 
   test:
+    needs: [changes, lint, typecheck]
+    if: ${{ needs.changes.outputs['test'] == 'true' }}
     name: Test
     # main pushes run this on the fleet's dedicated CI runner (2AMLogic/2am#29;
     # 2 slots for this repo); PR runs stay on GitHub-hosted. Push-only on
@@ -200,6 +228,8 @@ jobs:
           uv run pytest -n auto -o addopts= --benchmark-disable --timeout=60 -m "not slow" "${test_args[@]}"
 
   cpp-build-check:
+    needs: [changes, lint, typecheck]
+    if: ${{ needs.changes.outputs['cpp-build-check'] == 'true' }}
     # Issue #2501: catch source/.so drift by rebuilding the C++ extension
     # from a clean checkout and asserting the version-guard reports the
     # backend as available. If anyone changes cpp/ source without bumping
@@ -286,6 +316,8 @@ jobs:
           uv run pytest tests/test_router_cpp_backend.py::TestCppBuildVersionGuard -v --no-cov
 
   kicad-cli-smoke:
+    needs: [changes, lint, typecheck]
+    if: ${{ needs.changes.outputs['kicad-cli-smoke'] == 'true' }}
     name: kicad-cli Round-trip Smoke
     runs-on: ubuntu-latest
     timeout-minutes: 15
@@ -462,6 +494,8 @@ jobs:
           uv run python scripts/ci/check_routed_drc.py "${args[@]}"
 
   diffpair-routing-regression:
+    needs: [changes, lint, typecheck]
+    if: ${{ needs.changes.outputs['diffpair-routing-regression'] == 'true' }}
     # Issue #2660 / Epic #2556 Phase 4N: re-route board 06 (the diff-pair
     # testbench) from scratch on every PR and verify that
     #   (a) the resulting DRC error count is within the allowlist baseline
@@ -709,9 +743,10 @@ jobs:
             --seed 42
 
   matchgroup-routing-regression:
+    needs: [changes, lint, typecheck]
+    if: ${{ needs.changes.outputs['matchgroup-routing-regression'] == 'true' && vars.BOARD_07_CI_ENABLED == 'true' }}
     # Temporarily suspended at user request (#5097) to unblock unrelated PRs.
     # Set BOARD_07_CI_ENABLED=true after #5068/#5069 integration safeguards pass.
-    if: ${{ vars.BOARD_07_CI_ENABLED == 'true' }}
     # Issue #2726 / Epic #2661 Phase 3N: re-route board 07 (the
     # N-trace match-group testbench, #2724 Phase 3L) from scratch on
     # every PR and verify that
@@ -933,6 +968,8 @@ jobs:
             --seed 42
 
   board-00-end-to-end:
+    needs: [changes, lint, typecheck]
+    if: ${{ needs.changes.outputs['board-00-end-to-end'] == 'true' }}
     # Issue #3751: regenerate board 00 ("simple-led", the canonical
     # "Hello World" fixture) from its recipe (boards/00-simple-led/
     # generate_design.py) on every PR and assert that the resulting
@@ -1110,6 +1147,8 @@ jobs:
             /tmp/board00-staging/00-simple-led
 
   board-01-end-to-end:
+    needs: [changes, lint, typecheck]
+    if: ${{ needs.changes.outputs['board-01-end-to-end'] == 'true' }}
     # Issue #3762: same end-to-end gate as ``board-00-end-to-end``, applied
     # to board 01 ("voltage-divider").  Board 01 is verified clean on both
     # the copper-extracted and label-based LVS comparators, so its recipe
@@ -1202,6 +1241,8 @@ jobs:
             /tmp/board01-staging/01-voltage-divider
 
   board-02-end-to-end:
+    needs: [changes, lint, typecheck]
+    if: ${{ needs.changes.outputs['board-02-end-to-end'] == 'true' }}
     # Issue #3783: same full end-to-end gate as ``board-00-end-to-end`` /
     # ``board-01-end-to-end``, applied to board 02 ("charlieplex-led").
     # This job was deferred in #3779 because a fresh regen produced a
@@ -1302,6 +1343,8 @@ jobs:
             /tmp/board02-staging/02-charlieplex-led
 
   board-03-end-to-end:
+    needs: [changes, lint, typecheck]
+    if: ${{ needs.changes.outputs['board-03-end-to-end'] == 'true' }}
     # Issue #3795 (#3780 Part 2): LVS-ONLY end-to-end gate for board 03
     # ("usb-joystick"), graduated out of ``ADVISORY_LVS_BOARDS``.  Board 03's
     # recipe now runs ``write_lvs_report(..., require_clean=True,
@@ -1446,6 +1489,8 @@ jobs:
             /tmp/board03-staging/03-usb-joystick
 
   board-06-end-to-end:
+    needs: [changes, lint, typecheck]
+    if: ${{ needs.changes.outputs['board-06-end-to-end'] == 'true' }}
     # Issue #3779 (LVS re-enabled by #4012): end-to-end LVS gate for board
     # 06 ("diffpair-test").  The fixture schematic is now FULLY WIRED
     # (#4012: generate_schematic.py synthesizes PCB-native-pad symbols and
@@ -1598,9 +1643,10 @@ jobs:
             /tmp/board06-staging/06-diffpair-test
 
   board-07-end-to-end:
+    needs: [changes, lint, typecheck]
+    if: ${{ needs.changes.outputs['board-07-end-to-end'] == 'true' && vars.BOARD_07_CI_ENABLED == 'true' }}
     # Temporarily suspended at user request (#5097) to unblock unrelated PRs.
     # Set BOARD_07_CI_ENABLED=true after #5068/#5069 integration safeguards pass.
-    if: ${{ vars.BOARD_07_CI_ENABLED == 'true' }}
     # Issue #3779 (LVS honestly dirty per #4012): end-to-end gate for
     # board 07 ("matchgroup-test").  The fixture schematic is now FULLY
     # WIRED (#4012: 244/244 pads bound), so the copper comparator carries
@@ -1770,6 +1816,8 @@ jobs:
             /tmp/board07-staging/07-matchgroup-test
 
   board-05-routing-regression:
+    needs: [changes, lint, typecheck]
+    if: ${{ needs.changes.outputs['board-05-routing-regression'] == 'true' }}
     # Issue #3822: blocking-net baseline gate for board 05 ("bldc-motor-
     # controller").  Board 05 is the only demo board whose routing changes
     # CANNOT be validated on the local macOS host: an unmodified host regen of
@@ -1923,6 +1971,8 @@ jobs:
             /tmp/board05-ci/bldc_controller_routed.kicad_pcb
 
   board-04-end-to-end:
+    needs: [changes, lint, typecheck]
+    if: ${{ needs.changes.outputs['board-04-end-to-end'] == 'true' }}
     # Issue #3839: end-to-end gate for board 04 ("stm32-devboard").  Two
     # board-04 gaps shipped regressions undetected: (1) the recipe's main()
     # success gate omitted the already-computed drc_success / copper-LVS

--- a/docs/guides/ci-job-selection.md
+++ b/docs/guides/ci-job-selection.md
@@ -1,0 +1,74 @@
+# CI job selection
+
+CI starts on every pull request to main and every main push. The `Select CI
+jobs` job reads the event file and a complete Git diff; it does not filter out
+the workflow itself. `scripts/ci/select_jobs.py` emits one boolean per heavy
+job. Lint, type checking and the existing changed-routed-PCB check remain
+present for every run.
+
+All selected heavy jobs require the planner, lint and type checking to succeed.
+A failed or cancelled prerequisite prevents dependent work from starting. An
+unselected heavy job is intentionally skipped, not evidence that its tests
+passed. Reviewers must still reject failed prerequisite checks.
+
+| Changed inputs | Selected heavy jobs |
+| --- | --- |
+| `docs/**` | Python Test |
+| `boards/00-simple-led/**` through `boards/04-stm32-devboard/**` | Python Test and the corresponding board E2E |
+| `boards/05-bldc-motor-controller/**` | Python Test and Board05 routing regression |
+| `boards/06-diffpair-test/**` | Python Test, Board06 E2E and diff-pair routing regression |
+| `boards/07-matchgroup-test/**` | Python Test and both Board07 jobs, subject to the existing operator switch |
+| `boards/08-precision-acquisition/**`, `boards/09-usbc-pd-power/**` | Python Test (no dedicated native E2E job currently exists) |
+| Shared code, tests, scripts, CI, dependency/build inputs, unknown paths or new board directories | Full matrix |
+| Multiple known board/documentation paths | Union of their consumers |
+| Missing history, invalid event or discovery failure | Full matrix |
+
+Changes under a known board's `output/` also select the standalone KiCad
+round-trip smoke job, which reads committed schematic/PCB outputs.
+
+The full Python suite remains selected for docs and board inputs: tests read
+source citations, documentation contracts, recipes and saved PCB fixtures. This
+change does not pretend those tests are independent of their inputs. It avoids
+unrelated native build/smoke and board-routing jobs. Narrowing Python test
+collection further requires its own verified dependency map.
+
+PRs use the merge base of the event's base/head commits. Main pushes use the
+entire before/after range, including batched commits. Rename detection is off,
+so both old and new paths select their consumers. Paths are NUL-delimited to
+preserve whitespace and newlines. Event values are read as data and commit IDs
+must be full SHA values; no event text is interpolated into a shell command.
+An unavailable base must never be treated as an empty change set.
+
+The Board07 operator switch, job commands, seeds, allowances, native versions,
+container limits and timeouts remain unchanged. Main-only self-hosted routing
+and per-ref concurrency from #5239 remain in force. Main verification is not
+reused or omitted based on a previous PR result, and tests are not sharded.
+
+## Validation and measurement
+
+Run the selector and workflow contract tests with:
+
+```sh
+uv run pytest --no-cov tests/test_ci_job_selection.py tests/test_ci_routed_drc_workflow.py
+actionlint -shellcheck= .github/workflows/ci.yml
+```
+
+Behavioral tests use real Git repositories to cover divergent PR histories,
+multi-commit pushes, cross-board renames, deletions, unusual filenames and
+missing revisions. The workflow tests check every heavy job's output wiring and
+prerequisites. The selection change itself selects full CI coverage.
+
+Issue #5240 remains open until live evidence demonstrates the original outcome:
+lower daily job-minutes and PR queue waits below five minutes at comparable
+traffic rates. Record docs-only, single-board and shared-source examples; also
+verify that a failed cheap check prevents heavy execution. Do not merge an
+intentionally failing probe into main.
+
+For before/after windows, retain run IDs/attempts, event/head, created/start/end
+timestamps, job names, conclusions and runner identities from the Actions API.
+Separate hosted and self-hosted jobs, cancellations and superseded runs. Sum
+job execution durations, not run wall time, and do not call that billing data.
+Report sample size and PR arrival rate. With `needs` in place, job creation to
+start can include prerequisite time: report that separately from runner queue
+delay, using prerequisite completion to identify the earliest eligible start.
+Do not claim a queue improvement from classifier tests or predicted savings.

--- a/scripts/ci/select_jobs.py
+++ b/scripts/ci/select_jobs.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+"""Conservative job selection from a complete Git event diff (#5240).
+
+Only documented independent docs/board trees narrow the native job matrix.
+Unknown inputs or unavailable history select every job. Selection never changes
+an individual job's acceptance rules or the Board07 operator switch.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+BOARD_JOBS: dict[str, tuple[str, ...]] = {
+    "00-simple-led": ("board-00-end-to-end",),
+    "01-voltage-divider": ("board-01-end-to-end",),
+    "02-charlieplex-led": ("board-02-end-to-end",),
+    "03-usb-joystick": ("board-03-end-to-end",),
+    "04-stm32-devboard": ("board-04-end-to-end",),
+    "05-bldc-motor-controller": ("board-05-routing-regression",),
+    "06-diffpair-test": ("board-06-end-to-end", "diffpair-routing-regression"),
+    "07-matchgroup-test": ("board-07-end-to-end", "matchgroup-routing-regression"),
+    "08-precision-acquisition": (),
+    "09-usbc-pd-power": (),
+}
+JOBS = ("test", "cpp-build-check", "kicad-cli-smoke") + tuple(
+    job for jobs in BOARD_JOBS.values() for job in jobs
+)
+
+
+def select_jobs(paths: list[str] | None) -> dict[str, bool]:
+    """Return the union of affected consumers; None means discovery failed."""
+    selected: set[str] = set()
+    if paths is None:
+        return dict.fromkeys(JOBS, True)
+    for path in paths:
+        parts = path.split("/")
+        if not path or path.startswith("/") or any(p in {"", ".", ".."} for p in parts):
+            return dict.fromkeys(JOBS, True)
+        if parts[0] == "docs" and len(parts) > 1:
+            # Documentation/source-citation tests actually consume these files.
+            selected.add("test")
+        elif len(parts) > 2 and parts[0] == "boards" and parts[1] in BOARD_JOBS:
+            # General tests consume recipe code and saved board fixtures too.
+            selected.add("test")
+            selected.update(BOARD_JOBS[parts[1]])
+            if parts[2] == "output":
+                # Round-trip smoke reads committed board schematics and the
+                # Board00 routed PCB; keep their independent named gate.
+                selected.add("kicad-cli-smoke")
+        else:
+            # Includes src, scripts, tests, native/build/dependency inputs,
+            # workflow selection itself, shared board utilities and new boards.
+            return dict.fromkeys(JOBS, True)
+    return {job: job in selected for job in JOBS}
+
+
+def _sha(value: Any) -> str:
+    if not isinstance(value, str) or not re.fullmatch(r"[0-9a-fA-F]{40}", value):
+        raise ValueError("event lacks a full commit SHA")
+    if value == "0" * 40:
+        raise ValueError("event has no previous commit")
+    return value
+
+
+def changed_paths(event: dict[str, Any], event_name: str, repo: Path) -> list[str]:
+    """Use PR merge-base or complete push range, preserving both rename sides."""
+    if event_name == "pull_request":
+        pr = event["pull_request"]
+        base, head = _sha(pr["base"]["sha"]), _sha(pr["head"]["sha"])
+        base = (
+            subprocess.check_output(
+                ["git", "merge-base", base, head], cwd=repo, stderr=subprocess.PIPE
+            )
+            .decode("ascii")
+            .strip()
+        )
+        _sha(base)
+    elif event_name == "push":
+        base, head = _sha(event["before"]), _sha(event["after"])
+    else:
+        raise ValueError(f"unsupported event: {event_name}")
+    # No rename detection: a rename is a deletion plus addition, so both the
+    # old and new consumer remain selected, including cross-board moves.
+    raw = subprocess.check_output(
+        ["git", "diff", "--name-only", "--no-renames", "-z", base, head, "--"],
+        cwd=repo,
+        stderr=subprocess.PIPE,
+    )
+    if raw and not raw.endswith(b"\0"):
+        raise ValueError("incomplete NUL-delimited Git diff")
+    return [os.fsdecode(path) for path in raw.split(b"\0") if path]
+
+
+def plan(event_path: Path, event_name: str, repo: Path) -> dict[str, bool]:
+    try:
+        event = json.loads(event_path.read_text())
+        paths = changed_paths(event, event_name, repo)
+    except (OSError, ValueError, KeyError, TypeError, subprocess.SubprocessError) as exc:
+        print(
+            f"CI selection: full coverage; diff unavailable ({type(exc).__name__})", file=sys.stderr
+        )
+        paths = None
+    return select_jobs(paths)
+
+
+def main() -> None:
+    result = plan(
+        Path(os.environ["GITHUB_EVENT_PATH"]),
+        os.environ.get("GITHUB_EVENT_NAME", ""),
+        Path.cwd(),
+    )
+    with Path(os.environ["GITHUB_OUTPUT"]).open("a") as output:
+        for job, selected in result.items():
+            output.write(f"{job}={str(selected).lower()}\n")
+    print(json.dumps(result, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_ci_job_selection.py
+++ b/tests/test_ci_job_selection.py
@@ -1,0 +1,193 @@
+"""Behavioral coverage for CI selection, real Git diffs and job wiring."""
+
+import importlib.util
+import json
+import subprocess
+from pathlib import Path
+
+import pytest
+import yaml
+
+ROOT = Path(__file__).resolve().parents[1]
+SPEC = importlib.util.spec_from_file_location("ci_selection", ROOT / "scripts/ci/select_jobs.py")
+assert SPEC and SPEC.loader
+selector = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(selector)
+
+
+def chosen(paths):
+    return {job for job, selected in selector.select_jobs(paths).items() if selected}
+
+
+def test_docs_keep_actual_test_consumers_without_unrelated_routing():
+    assert chosen(["docs/guides/routing.md"]) == {"test"}
+
+
+@pytest.mark.parametrize("board,jobs", selector.BOARD_JOBS.items())
+def test_board_change_selects_all_and_only_its_consumers(board, jobs):
+    assert chosen([f"boards/{board}/generate_design.py"]) == {"test", *jobs}
+
+
+def test_multiple_boards_select_union():
+    assert chosen(
+        ["boards/00-simple-led/output/a.kicad_pcb", "boards/06-diffpair-test/design.py"]
+    ) == {
+        "test",
+        "kicad-cli-smoke",
+        "board-00-end-to-end",
+        "board-06-end-to-end",
+        "diffpair-routing-regression",
+    }
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "src/kicad_tools/router/core.py",
+        "scripts/ci/check_diffpair_coverage.py",
+        "scripts/ci/select_jobs.py",
+        ".github/workflows/ci.yml",
+        "pyproject.toml",
+        "uv.lock",
+        "cpp/src/router.cpp",
+        "tests/test_copper_lvs.py",
+        "boards/shared.py",
+        "boards/99-new-board/recipe.py",
+        "new-config",
+        "docs/../src/core.py",
+    ],
+)
+def test_shared_unknown_and_selection_changes_keep_full_coverage(path):
+    assert chosen([path]) == set(selector.JOBS)
+
+
+def test_absent_diff_is_not_an_empty_diff():
+    assert chosen(None) == set(selector.JOBS)
+    assert chosen([]) == set()
+
+
+@pytest.fixture
+def repo(tmp_path):
+    def git(*args):
+        return (
+            subprocess.check_output(["git", *args], cwd=tmp_path, stderr=subprocess.PIPE)
+            .decode()
+            .strip()
+        )
+
+    git("init", "-q")
+    git("config", "user.email", "test@example.invalid")
+    git("config", "user.name", "CI selection test")
+    (tmp_path / "initial").write_text("initial")
+    git("add", ".")
+    git("commit", "-qm", "initial")
+    return tmp_path, git
+
+
+def commit_file(repo, path, content="content"):
+    root, git = repo
+    target = root / path
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(content)
+    git("add", ".")
+    git("commit", "-qm", "fixture")
+    return git("rev-parse", "HEAD")
+
+
+def test_push_range_includes_all_commits_and_both_rename_sides(repo):
+    root, git = repo
+    old = "boards/00-simple-led/with space\nand newline.kicad_pcb"
+    base = commit_file(repo, old)
+    new = "boards/06-diffpair-test/moved.kicad_pcb"
+    (root / new).parent.mkdir(parents=True)
+    git("mv", old, new)
+    git("commit", "-qm", "rename")
+    head = commit_file(repo, "docs/new.md")
+    paths = selector.changed_paths({"before": base, "after": head}, "push", root)
+    assert set(paths) == {old, new, "docs/new.md"}
+    assert chosen(paths) == {
+        "test",
+        "board-00-end-to-end",
+        "board-06-end-to-end",
+        "diffpair-routing-regression",
+    }
+
+
+def test_pr_diff_uses_merge_base_excluding_unrelated_base_changes(repo):
+    root, git = repo
+    base = git("rev-parse", "HEAD")
+    git("checkout", "-qb", "topic")
+    head = commit_file(repo, "docs/topic.md")
+    git("checkout", "--detach", base)
+    base = commit_file(repo, "src/unrelated.py")
+    event = {"pull_request": {"base": {"sha": base}, "head": {"sha": head}}}
+    assert selector.changed_paths(event, "pull_request", root) == ["docs/topic.md"]
+
+
+@pytest.mark.parametrize(
+    "event,event_name",
+    [
+        ({"before": "0" * 40, "after": "a" * 40}, "push"),
+        ({"before": "a" * 40, "after": "b" * 40}, "push"),
+        ({"before": "$(touch sentinel)", "after": "b" * 40}, "push"),
+        ({}, "push"),
+        ({}, "workflow_dispatch"),
+        ([], "pull_request"),
+    ],
+)
+def test_failed_or_invalid_discovery_selects_full_coverage(repo, event, event_name):
+    root, _ = repo
+    path = root / "event.json"
+    path.write_text(json.dumps(event))
+    assert all(selector.plan(path, event_name, root).values())
+    assert not (root / "sentinel").exists()
+
+
+def test_invalid_event_file_selects_full_coverage(tmp_path):
+    path = tmp_path / "event.json"
+    path.write_text("{")
+    assert all(selector.plan(path, "push", tmp_path).values())
+    assert all(selector.plan(tmp_path / "missing", "push", tmp_path).values())
+
+
+def test_workflow_wires_every_heavy_consumer_and_retains_operator_gate():
+    workflow = yaml.safe_load((ROOT / ".github/workflows/ci.yml").read_text())
+    jobs = workflow["jobs"]
+    heavy = set(jobs) - {"changes", "lint", "typecheck", "routed-pcb-drc-check"}
+    assert heavy == set(selector.JOBS)
+    assert set(jobs["changes"]["outputs"]) == heavy
+    for job in heavy:
+        assert set(jobs[job]["needs"]) == {"changes", "lint", "typecheck"}
+        assert f"needs.changes.outputs['{job}'] == 'true'" in jobs[job]["if"]
+        assert "always()" not in jobs[job]["if"]  # Failed cheap gates must stop work.
+        assert jobs["changes"]["outputs"][job] == "${{ steps.plan.outputs['" + job + "'] }}"
+    for job in ("board-07-end-to-end", "matchgroup-routing-regression"):
+        assert "vars.BOARD_07_CI_ENABLED == 'true'" in jobs[job]["if"]
+    for job in ("test", "board-06-end-to-end"):
+        assert "github.event_name == 'push'" in jobs[job]["runs-on"]
+    triggers = workflow.get("on", workflow.get(True))  # YAML 1.1's on coercion.
+    assert set(triggers) == {"push", "pull_request"}
+    assert not any("paths" in config or "paths-ignore" in config for config in triggers.values())
+
+
+def test_cli_emits_workflow_outputs_from_event_file(repo, monkeypatch):
+    root, git = repo
+    base = git("rev-parse", "HEAD")
+    head = commit_file(repo, "docs/guide.md")
+    event_path = root / "event.json"
+    event_path.write_text(json.dumps({"before": base, "after": head}))
+    output = root / "output"
+    monkeypatch.setenv("GITHUB_EVENT_PATH", str(event_path))
+    monkeypatch.setenv("GITHUB_EVENT_NAME", "push")
+    monkeypatch.setenv("GITHUB_OUTPUT", str(output))
+    monkeypatch.chdir(root)
+    selector.main()
+    actual = dict(line.split("=", 1) for line in output.read_text().splitlines())
+    assert set(actual) == set(selector.JOBS)
+    assert actual.pop("test") == "true"
+    assert set(actual.values()) == {"false"}
+
+
+@pytest.mark.parametrize("board,jobs", selector.BOARD_JOBS.items())
+def test_saved_board_outputs_retain_standalone_native_smoke(board, jobs):
+    assert chosen([f"boards/{board}/output/board.kicad_sch"]) == {"test", "kicad-cli-smoke", *jobs}

--- a/tests/test_local_gate_manifest.py
+++ b/tests/test_local_gate_manifest.py
@@ -36,8 +36,10 @@ LOCAL_GATE = REPO_ROOT / "scripts" / "ci" / "local-gate.sh"
 
 # Jobs that exist in ci.yml but are intentionally NOT mirrored by
 # local-gate.sh.  Every entry needs a comment explaining why the job has no
-# local analogue.  Currently empty: all 16 ci.yml jobs are mirrored.
-CI_ONLY_JOBS: set[str] = set()
+# local analogue. The planner consumes GitHub event metadata and selects
+# remote jobs; the local gate deliberately runs its explicitly requested jobs
+# without event-based pruning. All actual validation jobs remain mirrored.
+CI_ONLY_JOBS: set[str] = {"changes"}
 
 
 def _ci_job_ids() -> set[str]:


### PR DESCRIPTION
CI previously started the full native board matrix for every change, and expensive jobs continued even when lint or type checking failed. Add a complete-Git-diff planner and make heavy jobs require successful planning, lint and type checks. Docs select the general Python suite; known board edits select that suite and their own board jobs, with standalone native smoke retained for committed board outputs. Shared/unknown paths and unavailable history select full coverage.

The Python suite remains selected because it consumes documentation contracts, board recipes and saved fixtures. Existing job commands, seeds, allowances, native/container settings, timeouts, triggers and concurrency are unchanged. Both Board07 jobs retain the operator switch, and PR jobs remain GitHub-hosted. The new planning-only job is explicitly excluded from the local validation-job manifest; every actual validation job remains mirrored.

Part of #5240.

Acceptance status:
- Path-to-consumer selection: implemented and behaviorally tested, including multi-board unions, both rename sides, deletions, unusual filenames, divergent PR histories and multi-commit pushes.
- Heavy jobs depend on lint and typecheck: implemented; every heavy output and prerequisite is covered by workflow contract tests.
- Reduced daily job-minutes and PR queue waits below five minutes: **not yet demonstrated**. Keep #5240 open for live docs/board/shared-source and cheap-failure examples plus comparable before/after traffic measurements. Main test-result reuse and test sharding are not implemented.

Validation:
- 105 selector, routed-DRC and local-gate tests pass, including 46 selector cases.
- 137 workflow/routing-fitness/diffpair/copper-LVS contract tests pass.
- Additional workflow consumers: 83 passed, 7 skipped on the first run, with two failures. The new planner's manifest failure was corrected and the complete local-gate suite now passes. The other failure was Board02 routing nondeterminism in unchanged runtime code (160 versus 252 normalized copper lines). A repeat passes both enabled determinism cases, with Board04 intentionally skipped; the build command found the native extension already installed, so no absent-backend cause or runtime fix is claimed.
- Actionlint syntax/expression checking (`-shellcheck=`), Ruff formatting/lint, scoped mypy, version gates and whitespace checks pass.
- Independently compared parsed YAML: all existing job payloads and workflow-level settings are unchanged except the intended needs/selection conditions.
- Independent review passed the 46 selector tests and six local-gate tests and found no remaining code blocker, including the committed-output smoke dependency.
- TDD: no; behavioral and real-Git integration tests were developed with the implementation. The local-gate drift failure was reproduced before its explicit orchestration-only exemption.

Fresh CI and final SHA-bound review are required. No live performance improvement or full native board qualification is claimed by these local checks.