### PR TITLE
ci: 12 GB / 8 GB for the runner-hosted Test and Board 06 job containers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,9 +126,13 @@ jobs:
       # can write $GITHUB_WORKSPACE (mirrors the smoke job).
       # On the runner this is a sibling container of the runner's own, created by
       # the host daemon, so the slot's cpuset/memory do not apply to it: pin it
-      # to the two kicad slots' cores (24-31) and 6 GB itself. GitHub-hosted
-      # runs get the plain --user 0:0 (4 vCPU / 16 GB VM, nothing to contain).
-      options: ${{ github.event_name == 'push' && '--user 0:0 --cpuset-cpus 24-31 --memory 6g' || '--user 0:0' }}
+      # to the two kicad slots' cores (24-31) and cap its memory. 12 GB, not
+      # the 6 GB first tried: at 6 GB four xdist workers each spawning
+      # kicad-cli DRC pushed the cgroup over its cap and the kernel SIGKILLed
+      # kicad-cli / crashed workers (31 failures, 2026-09-11 run 34645135306);
+      # a GitHub-hosted VM has 16 GB. GitHub-hosted runs get the plain
+      # --user 0:0 (nothing to contain).
+      options: ${{ github.event_name == 'push' && '--user 0:0 --cpuset-cpus 24-31 --memory 12g' || '--user 0:0' }}
     defaults:
       run:
         # The image's /bin/sh is dash; force bash (mirrors the smoke job).
@@ -1490,9 +1494,10 @@ jobs:
       image: kicad/kicad:10.0
       # On the runner this is a sibling container of the runner's own, created by
       # the host daemon, so the slot's cpuset/memory do not apply to it: pin it
-      # to the two kicad slots' cores (24-31) and 6 GB itself. GitHub-hosted
-      # runs get the plain --user 0:0 (4 vCPU / 16 GB VM, nothing to contain).
-      options: ${{ github.event_name == 'push' && '--user 0:0 --cpuset-cpus 24-31 --memory 6g' || '--user 0:0' }}
+      # to the two kicad slots' cores (24-31) and 8 GB (it passed at 6 GB on
+      # 2026-09-11; headroom, since the cap SIGKILLs rather than swaps).
+      # GitHub-hosted runs get the plain --user 0:0 (nothing to contain).
+      options: ${{ github.event_name == 'push' && '--user 0:0 --cpuset-cpus 24-31 --memory 8g' || '--user 0:0' }}
     defaults:
       run:
         shell: bash


### PR DESCRIPTION
Follow-up to #5239. First main run on the fleet CI runner (run 34645135306): **Board 06 green in 20 min**; **Test ran the whole suite in 14.6 min** (33 min on GitHub-hosted) but 31 of 28,673 tests failed — every one a `kicad-cli` DRC subprocess `died with <Signals.SIGKILL: 9>` or an xdist worker crash (`node down: Not properly terminated`). That is the 6 GB memory cap on the sibling job container: four workers each spawning `kicad-cli` exceed it and the kernel kills the largest process. A GitHub-hosted VM has 16 GB and the same job passed 13/13 there today.

Test → 12 GB, Board 06 → 8 GB. Verified by the main run this merge triggers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)