### PR TITLE
fix(router): preserve pad shape in grid clearance checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Use shared project drill-clearance checks for Board07 relocation and fallback stubs; reject archived moves into foreign zone fill without saving partial repairs.
 
+### Fixed
+
+- Preserve authored pad shapes through router loading, workers, and native
+  conversion (#5229). Square pads no longer lose copper corners to a circular
+  approximation. Rotated search bounds enclose copper; unsupported custom or
+  layer-specific pad geometry stops routing explicitly.
+
 ### Added
 
 - **Flat signal-clearance table builder for clock-to-signal spacing**

--- a/docs/research/grid-pad-shape.md
+++ b/docs/research/grid-pad-shape.md
@@ -1,0 +1,33 @@
+# Router pad shape coverage
+
+Issue #5229 separates physical circles from square rectangles in Python grid
+clearance validation, via/segment deficit backstops, and native acceptance.
+Shape is retained through both PCB loading paths, component dictionaries,
+worker serialization, schema-backed builders, and physical pad copies.
+
+The router `Pad.shape` defaults to `rect` when a programmatic caller supplies
+no shape. Callers modeling an actual circle must pass `shape="circle"`.
+Equal dimensions alone no longer imply a circle. Authored circles use a disc;
+rectangles use the residual KiCad rotation convention established in #4910
+and #5182. Oval and roundrect pads currently use a conservative enclosing
+rectangle, including at their rounded corners. This can reject a route that
+exact rounded geometry would allow.
+
+Search obstacles use board-space enclosing bounds. Both pad insertion entry
+points register geometry and synchronize native state. Native interface 23
+adds explicit circle classification; rebuild with `kct build-native --force`.
+Version equality with another branch is not evidence of compatible native
+interfaces; compare the binding and source changes during integration.
+
+Custom pads, trapezoids, unknown shapes, and layer-specific padstacks are
+rejected before their source geometry can be reduced to nominal width/height.
+Those dimensions do not prove an enclosing bound for arbitrary copper. This
+is an explicit coverage limit, not a request to change a board's physical pads.
+A router with the relevant full-copper support is needed for those inputs.
+
+The change preserves authored clearance floors, layer spans, nonzero same-net
+exemptions, component policies, and finalization's existing 0.05 mm nudge reach.
+Tests include file-backed inputs, actual finalization, compiled native checks,
+positive circle controls, rotated rectangles, and exact-limit comparisons.
+These are geometry/routing controls, not native KiCad DRC or manufacturing
+qualification of a generated board.

--- a/src/kicad_tools/cli/placement_cmd.py
+++ b/src/kicad_tools/cli/placement_cmd.py
@@ -1089,6 +1089,8 @@ def _estimate_routability(pcb_path: Path, quiet: bool = False) -> tuple[float, i
                     ry = px * sin_r + py * cos_r
                     is_pth = pad.type == "thru_hole"
 
+                    from kicad_tools.router.io import _schema_pad_shape
+
                     pads.append(
                         {
                             "number": pad.number,
@@ -1107,6 +1109,7 @@ def _estimate_routability(pcb_path: Path, quiet: bool = False) -> tuple[float, i
                             # angle is the residual the router's obstacle
                             # models need for a correct rotated-pad AABB.
                             "rotation": pad.rotation,
+                            "shape": _schema_pad_shape(pad, ref),
                         }
                     )
 

--- a/src/kicad_tools/mcp/tools/routing.py
+++ b/src/kicad_tools/mcp/tools/routing.py
@@ -296,6 +296,8 @@ def route_net(
                 # Check if through-hole
                 is_through_hole = "*.Cu" in (pad.layers or [])
 
+                from kicad_tools.router.io import _schema_pad_shape
+
                 pad_info = {
                     "number": pad.number,
                     "x": fp_x + rx,
@@ -312,6 +314,7 @@ def route_net(
                     # here, so the full angle IS the residual the router's
                     # obstacle models need for a correct rotated-pad AABB.
                     "rotation": pad.rotation,
+                    "shape": _schema_pad_shape(pad, fp.reference),
                 }
                 component_pads[fp.reference].append(pad_info)
                 net_pads.append(pad_info)
@@ -1103,6 +1106,8 @@ def _build_pads_for_net(
 
             is_through_hole = "*.Cu" in pad_layers
 
+            from kicad_tools.router.io import _schema_pad_shape
+
             pads.append(
                 RouterPad(
                     x=abs_x,
@@ -1119,6 +1124,7 @@ def _build_pads_for_net(
                     # Absolute board-frame pad angle; see the identical note
                     # in ``_build_router_pads``-style dict above (#4910).
                     rotation=pad.rotation,
+                    shape=_schema_pad_shape(pad, fp.reference),
                 )
             )
 

--- a/src/kicad_tools/optim/place_route.py
+++ b/src/kicad_tools/optim/place_route.py
@@ -315,6 +315,8 @@ class PlaceRouteOptimizer:
                 # Determine if through-hole
                 is_pth = pad.type == "thru_hole"
 
+                from kicad_tools.router.io import _schema_pad_shape
+
                 pads.append(
                     {
                         "number": pad.number,
@@ -333,6 +335,7 @@ class PlaceRouteOptimizer:
                         # angle is what the obstacle models need to build a
                         # correct rotated-pad bounding box.
                         "rotation": pad.rotation,
+                        "shape": _schema_pad_shape(pad, ref),
                     }
                 )
 

--- a/src/kicad_tools/router/adaptive.py
+++ b/src/kicad_tools/router/adaptive.py
@@ -180,6 +180,7 @@ class AdaptiveAutorouter:
                     "x": cx + rx,
                     "y": cy + ry,
                     "width": pad.get("width", 0.5),
+                    "shape": pad.get("shape", "rect"),
                     "height": pad.get("height", 0.5),
                     "net": net_num,
                     "net_name": net_name,

--- a/src/kicad_tools/router/algorithms/evolutionary.py
+++ b/src/kicad_tools/router/algorithms/evolutionary.py
@@ -270,6 +270,7 @@ def _run_evolutionary_trial(config: dict) -> tuple[list, float, int]:
             # board rotation; dropping it here would silently rebuild every
             # rotated pad as axis-aligned in the worker process.
             rotation=pad_data.get("rotation", 0.0),
+            shape=pad_data.get("shape", "rect"),
         )
         router.pads[(ref, pin)] = pad
         router.grid.add_pad(pad)

--- a/src/kicad_tools/router/core.py
+++ b/src/kicad_tools/router/core.py
@@ -736,6 +736,7 @@ def _run_monte_carlo_trial(config: dict) -> tuple[list, float, int]:
             "through_hole": pad_data.get("through_hole", False),
             "drill": pad_data.get("drill", 0.0),
             "rotation": pad_data.get("rotation", 0.0),
+            "shape": pad_data.get("shape", "rect"),
         }
         # Add directly to avoid component grouping overhead
         from kicad_tools.router.primitives import Pad
@@ -754,6 +755,7 @@ def _run_monte_carlo_trial(config: dict) -> tuple[list, float, int]:
             through_hole=pad_info["through_hole"],
             drill=pad_info["drill"],
             rotation=pad_info["rotation"],
+            shape=pad_info["shape"],
         )
         key = (ref, pin)
         router.pads[key] = pad
@@ -2042,6 +2044,7 @@ class Autorouter:
                 through_hole=pad_info.get("through_hole", False),
                 drill=pad_info.get("drill", 0.0),
                 rotation=pad_info.get("rotation", 0.0),
+                shape=pad_info.get("shape", "rect"),
             )
             key = (ref, pin)
             # Issue #4271: ``self.pads`` is keyed (ref, pin), so a footprint
@@ -15005,6 +15008,7 @@ class Autorouter:
                     "through_hole": pad.through_hole,
                     "drill": pad.drill,
                     "rotation": pad.rotation,
+                    "shape": pad.shape,
                 }
             )
 
@@ -17483,6 +17487,7 @@ class Autorouter:
                         through_hole=pad.through_hole,
                         drill=pad.drill,
                         rotation=pad.rotation,
+                        shape=pad.shape,
                     )
                     self._escape_pad_overrides[pad_key] = virtual_pad
 
@@ -17569,6 +17574,7 @@ class Autorouter:
                         through_hole=pad.through_hole,
                         drill=pad.drill,
                         rotation=pad.rotation,
+                        shape=pad.shape,
                     )
                     self._escape_pad_overrides[pad_key] = virtual_pad
 

--- a/src/kicad_tools/router/cpp/include/grid.hpp
+++ b/src/kicad_tools/router/cpp/include/grid.hpp
@@ -237,7 +237,8 @@ public:
     void add_pad(float x, float y, float width, float height,
                  int net, int layer_idx, uint32_t ref_hash,
                  float clearance_override,
-                 bool is_plane_net = false, float rotation = 0.0f);
+                 bool is_plane_net = false, float rotation = 0.0f,
+                 bool is_circular = false);
 
     void set_pad_via_policy(size_t index, float clearance, bool carveout_eligible);
 

--- a/src/kicad_tools/router/cpp/include/types.hpp
+++ b/src/kicad_tools/router/cpp/include/types.hpp
@@ -225,7 +225,8 @@ namespace router {
 // exists to end).  New module constant + four ``Pathfinder`` accessors =
 // binding-surface change; route output is unchanged (diagnostics only).
 // v22: residual pad rotation and candidate via-pad acceptance/policy refresh.
-constexpr int ROUTER_CPP_BUILD_VERSION = 22;
+// v23: explicit pad shape for segment/via clearance (Issue #5229).
+constexpr int ROUTER_CPP_BUILD_VERSION = 23;
 
 // Issue #4071: fixed-capacity owner-set size for per-cell corridor
 // reservations.  Observed owner sets in practice are tiny: 1 for the
@@ -592,6 +593,7 @@ struct PadInfo {
     float rotation = 0.0f;  // Residual KiCad board-space degrees (#5182)
     float via_clearance_override = 0.0f; // Component trace floor (Python backstop)
     bool via_carveout_eligible = false;
+    bool is_circular = false;  // Explicit circle shape; other pads use rectangles (#5229)
 };
 
 // Stored segment for validation (Issue #2439)

--- a/src/kicad_tools/router/cpp/src/bindings.cpp
+++ b/src/kicad_tools/router/cpp/src/bindings.cpp
@@ -269,7 +269,8 @@ NB_MODULE(router_cpp, m) {
         .def("add_pad", &Grid3D::add_pad,
              "x"_a, "y"_a, "width"_a, "height"_a,
              "net"_a, "layer_idx"_a, "ref_hash"_a, "clearance_override"_a,
-             "is_plane_net"_a = false, "rotation"_a = 0.0f)
+             "is_plane_net"_a = false, "rotation"_a = 0.0f,
+             "is_circular"_a = false)
         .def("set_pad_via_policy", &Grid3D::set_pad_via_policy,
              "index"_a, "clearance"_a, "carveout_eligible"_a)
         .def("add_stored_segment", &Grid3D::add_stored_segment,

--- a/src/kicad_tools/router/cpp/src/grid.cpp
+++ b/src/kicad_tools/router/cpp/src/grid.cpp
@@ -435,9 +435,10 @@ float Grid3D::memory_mb() const {
 
 void Grid3D::add_pad(float x, float y, float width, float height,
                      int net, int layer_idx, uint32_t ref_hash,
-                     float clearance_override, bool is_plane_net, float rotation) {
+                     float clearance_override, bool is_plane_net, float rotation,
+                     bool is_circular) {
     pads_.push_back({x, y, width, height, net, layer_idx, ref_hash,
-                     clearance_override, is_plane_net, rotation, clearance_override, false});
+                     clearance_override, is_plane_net, rotation, clearance_override, false, is_circular});
 }
 
 void Grid3D::set_pad_via_policy(size_t index, float clearance, bool carveout_eligible) {
@@ -794,18 +795,11 @@ ValidationResult Grid3D::validate_route(
             // Per-component clearance (Issue #1016)
             float required_clearance = pad.clearance_override;
 
-            // Issue #2908: Rect-aware geometry for rectangular SMD pads.
-            // The previous disc bound (``pad_radius = max(w, h) / 2``)
-            // over-rejected along the pad's SHORT axis -- a 1.475 x 0.3 mm
-            // LQFP-48 pad became a 0.7375 mm-radius disc, 0.587 mm of
-            // phantom inflation above / below the pad metal.  Vias and
-            // square pads (w == h within 1 micron) keep the disc model;
-            // it is exact for circular obstacles and cheaper to evaluate.
-            // Mirrors PR #2787 (validate/rules/clearance.py) and the
-            // Python validator at ``router/grid.py``.
+            // Issue #5229: Only explicitly circular pads use a disc. Equal
+            // dimensions do not imply a circle: square pad corners are copper.
+            // Oval and roundrect pads retain conservative rectangle bounds.
             float clearance;
-            const bool is_circular_pad = pad.rotation == 0.0f && std::abs(pad.width - pad.height) < 0.001f;
-            if (is_circular_pad) {
+            if (pad.is_circular) {
                 const float pad_radius = std::max(pad.width, pad.height) / 2.0f;
                 const float dist = point_to_segment_distance(
                     pad.x, pad.y, seg.x1, seg.y1, seg.x2, seg.y2);
@@ -995,7 +989,7 @@ ValidationResult Grid3D::validate_route(
             if (pad.layer_idx != -1 &&
                 (pad.layer_idx < layer_lo || pad.layer_idx > layer_hi)) continue;
             float clearance;
-            if (pad.rotation == 0.0f && std::abs(pad.width - pad.height) < 0.001f) {
+            if (pad.is_circular) {
                 clearance = std::hypot(via.x - pad.x, via.y - pad.y)
                     - std::max(pad.width, pad.height) / 2.0f - via_radius;
             } else {

--- a/src/kicad_tools/router/cpp_backend.py
+++ b/src/kicad_tools/router/cpp_backend.py
@@ -50,7 +50,7 @@ logger = logging.getLogger(__name__)
 # ``AttributeError`` deep in the routing code (e.g. ``router_cpp.PadBounds``
 # missing).  The guard below catches that at import time and falls back to the
 # pure-Python router with an actionable ``kct build-native`` hint.
-_REQUIRED_CPP_BUILD_VERSION = 22
+_REQUIRED_CPP_BUILD_VERSION = 23
 
 # Try to import C++ module with detailed error tracking
 _CPP_IMPORT_ERROR: str | None = None
@@ -1002,6 +1002,7 @@ class CppGrid:
                 clearance_override,
                 is_plane_net,
                 pad.rotation,
+                pad.shape == "circle",
             )
 
         from .grid import _sync_pad_via_policies

--- a/src/kicad_tools/router/diffpair_routing.py
+++ b/src/kicad_tools/router/diffpair_routing.py
@@ -4447,6 +4447,7 @@ class DiffPairRouter:
             # copy its rotation too or the shape is silently un-rotated
             # (issue #4910).
             rotation=template.rotation,
+            shape=template.shape,
         )
 
     def _segment_cells_clear(

--- a/src/kicad_tools/router/grid.py
+++ b/src/kicad_tools/router/grid.py
@@ -77,7 +77,7 @@ from .geometry import (
     segments_intersect as _geom_segments_intersect,
 )
 from .layers import Layer, LayerStack
-from .primitives import Obstacle, Pad, Route, Segment, Via
+from .primitives import Obstacle, Pad, Route, Segment, Via, pad_half_extents
 from .rules import DesignRules
 
 # Issue #2908: Plane-net name patterns for same-component validator carve-out.
@@ -264,6 +264,7 @@ def _sync_pad_to_cpp_grid(
             clearance_override,
             is_plane_net,
             pad.rotation,
+            pad.shape == "circle",
         )
     except (AttributeError, TypeError):
         # Older C++ binding without is_plane_net argument; ignore -- the
@@ -1774,8 +1775,8 @@ class RoutingGrid:
 
         if pad.through_hole:
             if pad.width > 0 and pad.height > 0:
-                effective_width = pad.width
-                effective_height = pad.height
+                half_w, half_h = pad_half_extents(pad)
+                effective_width, effective_height = 2 * half_w, 2 * half_h
             elif pad.drill > 0:
                 effective_width = pad.drill + 0.7
                 effective_height = effective_width
@@ -1783,8 +1784,8 @@ class RoutingGrid:
                 effective_width = 1.7
                 effective_height = 1.7
         else:
-            effective_width = pad.width
-            effective_height = pad.height
+            half_w, half_h = pad_half_extents(pad)
+            effective_width, effective_height = 2 * half_w, 2 * half_h
 
         x1 = pad.x - effective_width / 2 - clearance
         y1 = pad.y - effective_height / 2 - clearance
@@ -3147,7 +3148,7 @@ class RoutingGrid:
                 )
             )
 
-            is_circular_pad = pad.rotation == 0.0 and abs(pad.width - pad.height) < 0.001
+            is_circular_pad = pad.shape == "circle"
             if is_circular_pad:
                 pad_radius = max(pad.width, pad.height) / 2
                 dist = self._point_to_segment_distance(pad.x, pad.y, seg.x1, seg.y1, seg.x2, seg.y2)
@@ -3247,7 +3248,7 @@ class RoutingGrid:
                 )
             )
 
-            is_circular_pad = pad.rotation == 0.0 and abs(pad.width - pad.height) < 0.001
+            is_circular_pad = pad.shape == "circle"
             if is_circular_pad:
                 pad_radius = max(pad.width, pad.height) / 2
                 dist = math.hypot(via.x - pad.x, via.y - pad.y)
@@ -3539,11 +3540,11 @@ class RoutingGrid:
             # a 0.7375 mm-radius disc, 0.587 mm of phantom inflation above /
             # below the pad metal) and under-detected at long-axis corners
             # (the disc's rounded corner clips inside the rectangle's sharp
-            # corner). Vias and square pads (w == h within 1 micron) keep
-            # the disc model -- it is exact for circular obstacles and
-            # cheaper to evaluate. This mirrors PR #2787's fix at
+            # corner). Only explicitly circular pads use the disc model;
+            # square rectangles retain their copper corners (#5229).
+            # This mirrors PR #2787's distance calculation at
             # ``validate/rules/clearance.py::_segment_circle_clearance``.
-            is_circular_pad = pad.rotation == 0.0 and abs(pad.width - pad.height) < 0.001
+            is_circular_pad = pad.shape == "circle"
             if is_circular_pad:
                 pad_radius = max(pad.width, pad.height) / 2
                 dist = self._point_to_segment_distance(pad.x, pad.y, seg.x1, seg.y1, seg.x2, seg.y2)
@@ -6344,8 +6345,8 @@ class RoutingGrid:
     def add_pad_vectorized(self, pad: Pad) -> None:
         """Add a pad using vectorized NumPy operations for better performance.
 
-        This method uses pre-computed circular masks and array slicing
-        instead of per-cell loops, providing ~5x speedup for pad addition.
+        Compatibility entry point using the canonical shape-aware insertion
+        path, including native synchronization and geometric backstops.
 
         Thread-safe when thread_safe=True.
 
@@ -6356,99 +6357,12 @@ class RoutingGrid:
             self._add_pad_vectorized_unsafe(pad)
 
     def _add_pad_vectorized_unsafe(self, pad: Pad) -> None:
-        """Internal vectorized pad addition without locking."""
-        # Clearance model: trace clearance + trace half-width from pad edge.
-        # The pathfinder checks if the trace CENTER can be placed at a cell,
-        # so we must block cells where the trace edge would violate clearance.
-        clearance = self.rules.trace_clearance + self.rules.trace_width / 2
+        """Use the canonical insertion path, including geometry and native sync.
 
-        # Determine effective dimensions
-        if pad.through_hole:
-            if pad.width > 0 and pad.height > 0:
-                effective_width = pad.width
-                effective_height = pad.height
-            elif pad.drill > 0:
-                effective_width = pad.drill + 0.7
-                effective_height = effective_width
-            else:
-                effective_width = 1.7
-                effective_height = 1.7
-        else:
-            effective_width = pad.width
-            effective_height = pad.height
-
-        # Calculate affected region in grid coordinates
-        half_w = effective_width / 2 + clearance
-        half_h = effective_height / 2 + clearance
-
-        x1, y1 = pad.x - half_w, pad.y - half_h
-        x2, y2 = pad.x + half_w, pad.y + half_h
-
-        gx1, gy1 = self.world_to_grid(x1, y1)
-        gx2, gy2 = self.world_to_grid(x2, y2)
-
-        # Clamp to grid bounds
-        gx1 = max(0, gx1)
-        gy1 = max(0, gy1)
-        gx2 = min(self.cols - 1, gx2)
-        gy2 = min(self.rows - 1, gy2)
-
-        # Determine affected layers
-        if pad.through_hole:
-            layers = list(range(self.num_layers))
-        else:
-            layers = [self.layer_to_index(pad.layer.value)]
-
-        # Calculate pad metal area bounds (without clearance)
-        # Issue #996: Use ceil/floor to ensure we only mark cells whose CENTER
-        # is inside the metal area, not cells that are merely nearby.
-        # round() would include cells whose center is outside the metal area.
-        metal_half_w = effective_width / 2
-        metal_half_h = effective_height / 2
-        metal_x1, metal_y1 = pad.x - metal_half_w, pad.y - metal_half_h
-        metal_x2, metal_y2 = pad.x + metal_half_w, pad.y + metal_half_h
-        metal_gx1 = int(math.ceil((metal_x1 - self.origin_x) / self.resolution))
-        metal_gy1 = int(math.ceil((metal_y1 - self.origin_y) / self.resolution))
-        metal_gx2 = int(math.floor((metal_x2 - self.origin_x) / self.resolution))
-        metal_gy2 = int(math.floor((metal_y2 - self.origin_y) / self.resolution))
-
-        # Get center coordinates
-        center_gx, center_gy = self.world_to_grid(pad.x, pad.y)
-
-        # Vectorized update for each layer
-        for layer_idx in layers:
-            # Block the entire clearance zone
-            self._blocked[layer_idx, gy1 : gy2 + 1, gx1 : gx2 + 1] = True
-            self._original_net[layer_idx, gy1 : gy2 + 1, gx1 : gx2 + 1] = pad.net
-
-            # Issue #996: Only mark metal area as pad-blocked, not clearance zone.
-            # This allows the router to distinguish actual pad copper from clearance.
-            # Set net for metal area
-            metal_gy1_clamped = max(0, metal_gy1)
-            metal_gy2_clamped = min(self.rows - 1, metal_gy2)
-            metal_gx1_clamped = max(0, metal_gx1)
-            metal_gx2_clamped = min(self.cols - 1, metal_gx2)
-
-            # Only set net where it's currently 0 (avoid overwriting other pads)
-            metal_slice = (
-                layer_idx,
-                slice(metal_gy1_clamped, metal_gy2_clamped + 1),
-                slice(metal_gx1_clamped, metal_gx2_clamped + 1),
-            )
-            net_slice = self._net[metal_slice]
-            self._net[metal_slice] = np.where(net_slice == 0, pad.net, net_slice)
-
-            # Issue #996: Mark only metal area as pad-blocked (not clearance zone)
-            self._pad_blocked[metal_slice] = True
-
-            # Mark center cell with this pad's net
-            if 0 <= center_gx < self.cols and 0 <= center_gy < self.rows:
-                self._net[layer_idx, center_gy, center_gx] = pad.net
-                self._original_net[layer_idx, center_gy, center_gx] = pad.net
-
-            # Issue #4794: one bump per layer covers the three writes above
-            # (``_blocked`` halo, ``_net`` metal, ``_net`` centre cell).
-            self.bump_occupancy_generation()
+        A separate raster-only implementation omitted the acceptance backstop's
+        pad registry. Keep both public entry points subject to the same policy.
+        """
+        self._add_pad_unsafe(pad)
 
     def get_grid_statistics(self) -> dict:
         """Get statistics about grid usage and memory.

--- a/src/kicad_tools/router/io.py
+++ b/src/kicad_tools/router/io.py
@@ -2206,6 +2206,7 @@ def load_pads_for_analysis(pcb_path_or_text: str | Path) -> list[Pad]:
             # Extract pad number/pin
             pin_match = re.search(r'\(pad\s+"?([^"\s)]+)"?', pad_block)
             pin = pin_match.group(1) if pin_match else ""
+            pad_shape = _pad_shape_from_block(pad_block, ref, pin)
 
             # Extract pad type for through_hole detection
             is_thru = "thru_hole" in pad_block
@@ -2271,6 +2272,7 @@ def load_pads_for_analysis(pcb_path_or_text: str | Path) -> list[Pad]:
                     through_hole=is_thru,
                     footprint_name=footprint_name,
                     rotation=pad_rotation,
+                    shape=pad_shape,
                 )
             )
 
@@ -3229,6 +3231,7 @@ def route_pcb(
                     "x": cx + rx,
                     "y": cy + ry,
                     "width": pad.get("width", 0.5),
+                    "shape": pad.get("shape", "rect"),
                     "height": pad.get("height", 0.5),
                     "net": net_num,
                     "net_name": net_name,
@@ -3262,6 +3265,45 @@ def route_pcb(
     )
 
     return sexp, stats
+
+
+def _routing_pad_shape(shape: str, *, ref: str, pin: str, has_padstack: bool = False) -> str:
+    """Validate physical metadata before reducing a source pad to router geometry.
+
+    Oval and roundrect copper fits inside the rotated nominal rectangle.
+    Custom primitives and layer-specific padstacks can extend beyond that box;
+    routing must stop until their actual copper bounds are supported.
+    """
+    if has_padstack or shape not in {"circle", "rect", "oval", "roundrect"}:
+        geometry = "layer-specific padstack" if has_padstack else repr(shape)
+        raise ValueError(
+            f"Unsupported routing geometry {geometry} for pad {ref}.{pin}; "
+            "use circle, rect, oval, or roundrect pads without a padstack, "
+            "or route this board with a router supporting its full copper geometry."
+        )
+    return shape
+
+
+def _pad_shape_from_block(pad_block: str, ref: str, pin: str) -> str:
+    """Read the physical shape token, including empty or unquoted pad numbers."""
+    match = re.match(r'\(pad\s+(?:"[^\"]*"|[^\s()]+)\s+\w+\s+([^\s()]+)', pad_block)
+    return _routing_pad_shape(
+        match.group(1) if match else "",
+        ref=ref,
+        pin=pin,
+        has_padstack=re.search(r"\(padstack(?:\s|\))", pad_block) is not None,
+    )
+
+
+def _schema_pad_shape(pad, ref: str) -> str:
+    """Preserve schema shape while rejecting unsupported layer-specific copper."""
+    node = getattr(pad, "_sexp_node", None)
+    return _routing_pad_shape(
+        pad.shape,
+        ref=ref,
+        pin=pad.number,
+        has_padstack=node is not None and node.find("padstack") is not None,
+    )
 
 
 def _resolve_pad_dims_and_rotation(
@@ -3495,6 +3537,7 @@ def _install_fine_pitch_regions_from_components(
                         through_hole=bool(pad_info.get("through_hole", False)),
                         drill=float(pad_info.get("drill", 0.0)),
                         rotation=float(pad_info.get("rotation", 0.0)),
+                        shape=pad_info.get("shape", "rect"),
                     )
                 )
             except (TypeError, ValueError, KeyError):
@@ -3779,6 +3822,7 @@ def load_pcb_for_routing(
                 continue
             pad_num = pad_start.group(1) or pad_start.group(2)
             pad_type = pad_start.group(3)  # smd or thru_hole
+            pad_shape = _pad_shape_from_block(pad_block, ref, pad_num)
 
             # Extract at position (now searches entire multi-line block)
             at_match = re.search(r"\(at\s+([-\d.]+)\s+([-\d.]+)", pad_block)
@@ -3882,6 +3926,7 @@ def load_pcb_for_routing(
                     "drill": drill_size,
                     "layer": pad_layer,
                     "rotation": pad_rotation,
+                    "shape": pad_shape,
                 }
             )
 

--- a/src/kicad_tools/router/pad_geometry.py
+++ b/src/kicad_tools/router/pad_geometry.py
@@ -1,7 +1,8 @@
 """Geometry of router pads' rotated rectangular envelopes.
 
-Router Pad does not retain shape/corner radius. These predicates describe its
-rectangle, not roundrect/oval/custom copper. Bounds alone are for broad phase.
+Router Pad retains shape but not corner radius. These conservative predicates
+describe its rectangle, not exact circle/roundrect/oval copper. The grid acceptance
+paths separately distinguish circles. Bounds alone are for broad phase.
 """
 
 from __future__ import annotations

--- a/src/kicad_tools/router/primitives.py
+++ b/src/kicad_tools/router/primitives.py
@@ -499,6 +499,20 @@ class Pad:
     directly, so a non-cardinal rotation is never silently dropped again.
     """
 
+    shape: str = "rect"
+    """Authored shape; absent programmatic metadata uses a conservative rectangle.
+
+    Circles alone use a disc. Oval and roundrect use their enclosing rotated
+    rectangle until exact rounded geometry is supported. Custom/trapezoid
+    nominal dimensions do not bound their copper and are rejected explicitly.
+    """
+
+    def __post_init__(self) -> None:
+        if self.shape not in {"circle", "rect", "oval", "roundrect"}:
+            raise ValueError(
+                f"Unsupported routing pad shape {self.shape!r} for {self.ref}.{self.pin}"
+            )
+
 
 def pad_half_extents(pad: "Pad") -> tuple[float, float]:
     """Board-space ``(half_width, half_height)`` AABB extent of ``pad``.
@@ -524,6 +538,9 @@ def pad_half_extents(pad: "Pad") -> tuple[float, float]:
     byte-identical results.  Prefer this helper over reading ``pad.width`` /
     ``pad.height`` directly wherever a keep-out / clearance AABB is built.
     """
+    if pad.shape == "circle":
+        radius = max(pad.width, pad.height) / 2.0
+        return radius, radius
     if pad.rotation == 0.0:
         return pad.width / 2.0, pad.height / 2.0
     theta = math.radians(pad.rotation)

--- a/tests/router/test_grid_pad_shape_5229.py
+++ b/tests/router/test_grid_pad_shape_5229.py
@@ -1,0 +1,175 @@
+"""Physical square/circle witnesses for shape-aware grid acceptance."""
+
+import math
+
+import pytest
+
+from kicad_tools.router import DesignRules
+from kicad_tools.router.core import Autorouter
+from kicad_tools.router.cpp_backend import CppGrid, is_cpp_available
+from kicad_tools.router.grid import RoutingGrid
+from kicad_tools.router.layers import Layer
+from kicad_tools.router.primitives import Pad, Route, Segment, Via
+
+
+def rules():
+    return DesignRules(
+        trace_width=0.02,
+        trace_clearance=0.127,
+        grid_resolution=0.05,
+        via_diameter=0.2,
+        via_drill=0.1,
+        via_clearance=0.127,
+    )
+
+
+def witness(shape, angle=0):
+    pad = Pad(10, 10, 2, 2, 1, "FOREIGN", ref="J1", pin="1", shape=shape, rotation=angle)
+    c, s = math.cos(math.radians(angle)), math.sin(math.radians(angle))
+
+    def pos(x, y):
+        return 10 + x * c + y * s, 10 - x * s + y * c
+
+    seg = Segment(*pos(0.95, 0.95), *pos(1.5, 0.95), 0.02, Layer.F_CU, 2)
+    via = Via(*pos(0.95, 0.95), 0.1, 0.2, (Layer.F_CU, Layer.B_CU), 2)
+    return pad, seg, via
+
+
+@pytest.mark.parametrize(
+    "shape,valid", [("rect", False), ("circle", True), ("oval", False), ("roundrect", False)]
+)
+@pytest.mark.parametrize("angle", [0, -45, 30, 90, 180, 270])
+def test_python_shape_backstops(shape, valid, angle):
+    pad, seg, via = witness(shape, angle)
+    grid = RoutingGrid(20, 20, rules())
+    grid.add_pad(pad)
+    assert grid.validate_segment_clearance(seg, exclude_net=2)[0] is valid
+    assert (grid.worst_segment_pad_deficit(seg, 2)[0] == 0) is valid
+    assert (grid.worst_via_pad_deficit(via, 2)[0] == 0) is valid
+    if shape == "circle":
+        assert grid.validate_segment_clearance(seg, exclude_net=2)[1] == pytest.approx(
+            math.hypot(0.95, 0.95) - 1 - 0.01
+        )
+    if not valid:
+        assert grid.worst_segment_pad_deficit(seg, 2)[0] > 0.05
+        assert grid.worst_via_pad_deficit(via, 2)[0] > 0.05
+
+
+@pytest.mark.parametrize("shape,valid", [("rect", False), ("circle", True)])
+@pytest.mark.parametrize("angle", [0, -45, 30, 90])
+@pytest.mark.parametrize("late", [False, True])
+@pytest.mark.parametrize("kind", ["segment", "via"])
+def test_native_shape_backstops(shape, valid, angle, late, kind):
+    if not is_cpp_available():
+        pytest.skip("requires rebuilt native backend")
+    from kicad_tools.router import router_cpp
+
+    pad, seg, via = witness(shape, angle)
+    grid = RoutingGrid(20, 20, rules())
+    if not late:
+        grid.add_pad(pad)
+    cpp = CppGrid.from_routing_grid(grid)
+    if late:
+        grid.add_pad(pad)
+    segments, vias = [], []
+    if kind == "segment":
+        item = router_cpp.Segment()
+        item.x1, item.y1, item.x2, item.y2 = seg.x1, seg.y1, seg.x2, seg.y2
+        item.width, item.layer, item.net = seg.width, 0, 2
+        segments.append(item)
+    else:
+        item = router_cpp.Via()
+        item.x, item.y, item.diameter, item.drill = via.x, via.y, via.diameter, via.drill
+        item.layer_from, item.layer_to, item.net = 0, 1, 2
+        vias.append(item)
+    assert cpp._impl.validate_route(segments, vias, 2, [], 0.127, 0.127, 0.1).valid is valid
+
+
+@pytest.mark.parametrize("shape,demoted", [("rect", True), ("circle", False)])
+@pytest.mark.parametrize("force_python", [False, True])
+@pytest.mark.parametrize("kind", ["segment", "via"])
+def test_real_finalization(shape, demoted, force_python, kind):
+    if not force_python and not is_cpp_available():
+        pytest.skip("requires rebuilt native backend")
+    pad, seg, via = witness(shape)
+    router = Autorouter(20, 20, rules=rules(), force_python=force_python)
+    router.add_component(
+        "J1",
+        [
+            {
+                "number": "1",
+                "x": pad.x,
+                "y": pad.y,
+                "width": 2,
+                "height": 2,
+                "net": 1,
+                "net_name": "FOREIGN",
+                "shape": shape,
+            }
+        ],
+    )
+    route = Route(
+        2,
+        "SIGNAL",
+        segments=[seg] if kind == "segment" else [],
+        vias=[via] if kind == "via" else [],
+    )
+    router.routes.append(route)
+    router.grid.mark_route(route)
+    router.grid.mark_route_usage(route)
+    net_routes = {2: [route]}
+    assert router._demote_pad_clearance_violation_nets(net_routes) == ([2] if demoted else [])
+    assert (route in router.routes) is not demoted
+    assert router.rules.trace_clearance == 0.127
+
+
+@pytest.mark.parametrize("shape", ["custom", "trapezoid", "unknown"])
+def test_unsupported_shape_rejected(shape):
+    with pytest.raises(ValueError, match="shape"):
+        Pad(10, 10, 2, 2, 1, "FOREIGN", shape=shape)
+
+
+@pytest.mark.parametrize("method", ["add_pad", "add_pad_vectorized"])
+def test_rotated_search_encloses_copper_and_registers_backstop(method):
+    pad = Pad(10, 10, 4, 1, 1, "FOREIGN", rotation=45, shape="rect")
+    grid = RoutingGrid(20, 20, rules())
+    getattr(grid, method)(pad)
+    gx, gy = grid.world_to_grid(9, 11.2)  # strictly inside rotated physical copper
+    assert grid._pad_blocked[0, gy, gx]
+    assert pad in grid._pads
+    seg = Segment(8, 11.2, 12, 11.2, 0.02, Layer.F_CU, 2)
+    assert not grid.validate_segment_clearance(seg, exclude_net=2)[0]
+
+
+@pytest.mark.parametrize("shape", ["rect", "circle"])
+@pytest.mark.parametrize(
+    "net,layer,through,valid",
+    [
+        (1, Layer.F_CU, False, False),
+        (2, Layer.F_CU, False, True),
+        (0, Layer.F_CU, False, False),
+        (1, Layer.B_CU, False, True),
+        (1, Layer.B_CU, True, False),
+    ],
+)
+def test_shape_preserves_same_net_and_layer_policy(shape, net, layer, through, valid):
+    grid = RoutingGrid(20, 20, rules())
+    grid.add_pad(Pad(10, 10, 2, 2, net, "PAD", layer=layer, through_hole=through, shape=shape))
+    seg = Segment(10, 10, 10.5, 10, 0.02, Layer.F_CU, 2)
+    assert grid.validate_segment_clearance(seg, exclude_net=2)[0] is valid
+    assert (grid.worst_segment_pad_deficit(seg, 2)[0] == 0) is valid
+    via = Via(10, 10, 0.1, 0.2, (Layer.F_CU, Layer.F_CU), 2)
+    assert (grid.worst_via_pad_deficit(via, 2)[0] == 0) is valid
+
+
+@pytest.mark.parametrize("shape", ["rect", "circle"])
+@pytest.mark.parametrize("offset,valid", [(0, True), (-0.001, False), (0.001, True)])
+def test_exact_clearance_comparison_unchanged(shape, offset, valid):
+    # Axis witness has exactly the same physical edge for circle and square.
+    # Binary-exact dimensions avoid a floating equality assertion by accident.
+    design = DesignRules(trace_width=0.25, trace_clearance=0.125, grid_resolution=0.05)
+    grid = RoutingGrid(20, 20, design)
+    grid.add_pad(Pad(10, 10, 2, 2, 1, "FOREIGN", shape=shape))
+    seg = Segment(11.25 + offset, 10, 12 + offset, 10, 0.25, Layer.F_CU, 2)
+    assert grid.validate_segment_clearance(seg, exclude_net=2)[0] is valid
+    assert (grid.worst_segment_pad_deficit(seg, 2)[0] == 0) is valid

--- a/tests/router/test_pad_shape_transport_5229.py
+++ b/tests/router/test_pad_shape_transport_5229.py
@@ -1,0 +1,174 @@
+"""Source shape survives real loading, worker reconstruction, and endpoint copies."""
+
+import math
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import pytest
+
+from kicad_tools.router import Autorouter, DesignRules
+from kicad_tools.router.algorithms.evolutionary import _run_evolutionary_trial
+from kicad_tools.router.core import _run_monte_carlo_trial
+from kicad_tools.router.diffpair_routing import DiffPairRouter
+from kicad_tools.router.io import _schema_pad_shape, load_pads_for_analysis, load_pcb_for_routing
+from kicad_tools.router.layers import Layer
+from kicad_tools.router.primitives import Pad, Segment
+from kicad_tools.schema.pcb import PCB
+
+
+def board_text(shape="rect", angle=45, size="4 1", extra=""):
+    return f"""(kicad_pcb (version 20240108) (generator test)
+      (net 0 "") (net 1 "SIGNAL")
+      (gr_rect (start 0 0) (end 30 30) (layer "Edge.Cuts") (width 0.1))
+      (footprint "Test:Pad" (layer "F.Cu") (at 10 10 30)
+        (property "Reference" "J1" (at 0 0) (layer "F.SilkS"))
+        (pad "1" smd {shape} (at 2 1 {angle}) (size {size})
+          (layers "F.Cu") (net 1 "SIGNAL") {extra}))
+    )"""
+
+
+def load(path, loader):
+    if loader == "analysis":
+        return load_pads_for_analysis(path)[0]
+    router, _ = load_pcb_for_routing(
+        str(path),
+        validate_drc=False,
+        force_python=True,
+        rules=DesignRules(grid_resolution=0.1),
+        edge_clearance=0,
+    )
+    return router.pads[("J1", "1")]
+
+
+@pytest.mark.parametrize("loader", ["analysis", "routing"])
+@pytest.mark.parametrize(
+    "shape,angle,size",
+    [
+        ("rect", 0, "2 2"),
+        ("circle", 45, "2 2"),
+        ("rect", 45, "4 1"),
+        ("rect", -45, "4 1"),
+        ("rect", 90, "4 1"),
+        ("oval", 45, "4 1"),
+        ("roundrect", 45, "2 2"),
+    ],
+)
+def test_file_backed_shape_and_absolute_orientation(tmp_path, loader, shape, angle, size):
+    path = tmp_path / "shape.kicad_pcb"
+    path.write_text(board_text(shape, angle, size))
+    pad = load(path, loader)
+    assert pad.shape == shape
+    # Footprint rotation applies once to the local offset; the pad angle is
+    # already absolute and must not acquire another 30 degrees.
+    assert (pad.x, pad.y) == pytest.approx((10 + math.sqrt(3) + 0.5, 10 + math.sqrt(3) / 2 - 1))
+    assert pad.rotation == (0 if angle == 90 else angle % 360)
+    dims = tuple(map(float, size.split()))
+    assert (pad.width, pad.height) == (dims[::-1] if angle == 90 else dims)
+
+
+@pytest.mark.parametrize("loader", ["analysis", "routing"])
+@pytest.mark.parametrize(
+    "shape,extra",
+    [
+        (
+            "custom",
+            "(primitives (gr_poly (pts (xy -5 -5) (xy 5 -5) (xy 5 5)) (width 0) (fill yes)))",
+        ),
+        ("trapezoid", "(rect_delta 3 0)"),
+        ("rect", '(padstack (mode custom) (layer "B.Cu" (shape rect) (size 8 8)))'),
+    ],
+)
+def test_unsupported_copper_rejected_before_router_construction(
+    tmp_path, monkeypatch, loader, shape, extra
+):
+    path = tmp_path / "unsupported.kicad_pcb"
+    path.write_text(board_text(shape, size="1 1", extra=extra))
+    constructor = Mock(side_effect=AssertionError("unsupported copper reached router"))
+    monkeypatch.setattr("kicad_tools.router.io.Autorouter", constructor)
+    with pytest.raises(ValueError, match="Unsupported routing geometry.*J1.1"):
+        load(path, loader)
+    constructor.assert_not_called()
+
+
+@pytest.mark.parametrize("shape", ["rect", "circle", "oval", "roundrect"])
+def test_schema_metadata_and_padstack_guard(tmp_path, shape):
+    path = tmp_path / "schema.kicad_pcb"
+    path.write_text(board_text(shape, size="2 2"))
+    pcb = PCB.load(str(path))
+    assert _schema_pad_shape(pcb.footprints[0].pads[0], "J1") == shape
+    path.write_text(board_text(shape, extra="(padstack (mode custom))"))
+    pcb = PCB.load(str(path))
+    with pytest.raises(ValueError, match="layer-specific padstack"):
+        _schema_pad_shape(pcb.footprints[0].pads[0], "J1")
+
+
+@pytest.mark.parametrize("worker", [_run_monte_carlo_trial, _run_evolutionary_trial])
+def test_worker_roundtrip_preserves_geometric_discrimination(monkeypatch, worker):
+    router = Autorouter(20, 20, rules=DesignRules(grid_resolution=0.1), force_python=True)
+    for ref, x, shape in [("J1", 5, "rect"), ("J2", 12, "circle")]:
+        router.add_component(
+            ref,
+            [
+                {
+                    "number": "1",
+                    "x": x,
+                    "y": 10,
+                    "width": 2,
+                    "height": 2,
+                    "rotation": 45,
+                    "shape": shape,
+                    "net": 1,
+                    "net_name": "SIGNAL",
+                }
+            ],
+        )
+    config = router._serialize_for_parallel()
+    config.update(
+        trial_num=0, chrom_idx=0, seed=0, base_order=[], net_order=[], use_negotiated=False
+    )
+    restored = []
+
+    def inspect_worker(actual, order):
+        restored.append(actual)
+        for ref, valid in [("J1", False), ("J2", True)]:
+            pad = actual.pads[(ref, "1")]
+            assert pad.shape == router.pads[(ref, "1")].shape
+            assert pad.rotation == 45
+            # At a diamond tip, a rotated 2x2 square reaches beyond a disc.
+            segment = Segment(pad.x + 1.3, 9.99, pad.x + 1.3, 10.01, 0.02, Layer.F_CU, 2)
+            assert actual.grid.validate_segment_clearance(segment, exclude_net=2)[0] is valid
+        return []
+
+    monkeypatch.setattr(Autorouter, "route_all", inspect_worker)
+    monkeypatch.setattr(Autorouter, "_evaluate_solution", lambda self, routes: 0)
+    worker(config)
+    assert len(restored) == 1
+
+
+@pytest.mark.parametrize("shape", ["circle", "rect", "oval", "roundrect"])
+def test_diffpair_virtual_pad_copies_shape(shape):
+    router = Autorouter(20, 20, force_python=True)
+    owner = SimpleNamespace(autorouter=router)
+    original = Pad(5, 5, 2, 2, 1, "SIGNAL", ref="J1", pin="1", rotation=45, shape=shape)
+    copied = DiffPairRouter._virtual_pad_at(owner, original, 8, 9, 0)
+    assert (copied.x, copied.y) == (8, 9)
+    assert (copied.shape, copied.rotation, copied.width, copied.height) == (shape, 45, 2, 2)
+
+
+@pytest.mark.parametrize("method", ["generate_escape_routes", "_apply_in_pad_escape_rescues"])
+@pytest.mark.parametrize("shape", ["circle", "rect"])
+def test_escape_virtual_pad_copies_shape(monkeypatch, method, shape):
+    router = Autorouter(20, 20, force_python=True)
+    pad = Pad(5, 5, 2, 2, 1, "SIGNAL", ref="J1", pin="1", rotation=45, shape=shape)
+    router.pads[("J1", "1")] = pad
+    escape = SimpleNamespace(pad=pad, escape_point=(8, 9), escape_layer=Layer.B_CU)
+    package = SimpleNamespace(ref="J1", package_type=SimpleNamespace(name="TEST"))
+    monkeypatch.setattr(router._escape, "generate_escapes", lambda package: [escape])
+    monkeypatch.setattr(
+        router._escape, "generate_in_pad_rescues_only", lambda package, pin_filter: [escape]
+    )
+    monkeypatch.setattr(router._escape, "apply_escape_routes", lambda escapes: [])
+    getattr(router, method)([package])
+    copied = router._escape_pad_overrides[("J1", "1")]
+    assert (copied.x, copied.y, copied.layer) == (8, 9, Layer.B_CU)
+    assert (copied.shape, copied.rotation, copied.width, copied.height) == (shape, 45, 2, 2)

--- a/tests/test_static_halo_ripup_3545.py
+++ b/tests/test_static_halo_ripup_3545.py
@@ -70,6 +70,7 @@ def _tht_pad(x: float, y: float, net: int, net_name: str, ref: str, pin: str) ->
         pin=pin,
         through_hole=True,
         drill=1.0,
+        shape="circle",
     )
 
 


### PR DESCRIPTION
## Summary

A trace or via overlapping the corner of a square pad previously passed grid clearance validation because equal pad dimensions implied a circle. Preserve authored shape and distinguish actual circles from square copper through Python and native grid acceptance and finalization. The existing 0.127 mm clearance and 0.05 mm finalization nudge reach are unchanged.

## Changes

- Carry shape through both file loaders, schema-backed builders, component dictionaries, worker serialization/restoration and physical pad copies.
- Use explicit circle classification in Python and C++; rectangles retain the rotation geometry merged in #5234. Oval/roundrect pads use documented conservative enclosing rectangles. Programmatic pads without shape default to rect; intended circles must pass shape="circle".
- Enclose rotated copper in search bounds. Both pad insertion entry points now register geometry and synchronize native state through one implementation.
- Reject custom/trapezoid/unknown shapes and layer-specific padstacks instead of assuming nominal size encloses their copper. No physical board changes or clearance waivers are introduced.
- Native interface 23 adds an explicit circle flag. Rebuild required; coordinate later integration of other native PRs by actual source/binding changes, not version-number equality.

## Acceptance Criteria Verification

| Criterion | Verification |
|---|---|
| File-backed shape/orientation, footprint rotation and offset, absolute angle once | Both loaders and real schema controls in test_pad_shape_transport_5229.py |
| Square trace/via overlap rejection and actual finalization | Python and compiled native controls at unchanged authored floor/nudge reach |
| Actual circle remains clear at square-corner witness | Positive numerical clearance assertion plus native initial/late conversion |
| Valid gaps, same-net/net-zero, layers/PTH, signed/cardinal/noncardinal angles and exact-limit behavior | New shape matrix plus all prerequisite rotation controls |
| Worker/copy/backend preservation and actual native build | Both real worker restoration paths, physical virtual copies, native v23 force-build and signature/availability verification |
| Existing policy and routing regressions | Local suites below; full board CI remains required before merge |

## Test Plan

- Integrated onto main b5301388, including #5228 rotation consumers: 586 passed with no skips across new shape/transport controls, both rotation suites and router IO.
- New regression files alone: 119 passed with no skips, including compiled native cases. A fresh independent reviewer also passed all 119 and inspected the diff, finding no concrete blocker before reaching its usage limit during remaining regression review. This is provisional evidence, not final approval.
- Additional local regression runs: 322 passed across IO/grid/fine-pitch/clearance/occupancy; 147 passed across MCP/evolutionary/adaptive consumers; 84 existing placement optimizer/CLI tests passed. Native/policy review ran 401 passed, 3 existing skips across native parity/foreign-pad/carve-out/grid tests (suites overlap; counts are not additive).
- `uv run kct build-native --force --verbose` succeeded. Fresh interpreter verified actual worktree extension, v23 and appended is_circular argument. Native remains available after integration. Build-version guard: 4 passed.
- Repository Ruff lint/format, whitespace and version gates pass. Mypy: 1,437 diagnostics, all within unchanged 1,472 baseline, before the main integration.
- TDD: no — transport/native changes and tests were developed together. The new Python witness first failed on the missing shape constructor argument, then passed with implementation; no full test-first claim.
- No native KiCad board regeneration or manufacturing qualification is claimed. Require fresh CI and final SHA-bound Judge review before merge.

Closes #5229