### PR TITLE
fix(ci): exempt changes detector from local validation manifest

### DIFF
--- a/tests/test_local_gate_manifest.py
+++ b/tests/test_local_gate_manifest.py
@@ -36,8 +36,10 @@ LOCAL_GATE = REPO_ROOT / "scripts" / "ci" / "local-gate.sh"
 
 # Jobs that exist in ci.yml but are intentionally NOT mirrored by
 # local-gate.sh.  Every entry needs a comment explaining why the job has no
-# local analogue.  Currently empty: all 16 ci.yml jobs are mirrored.
-CI_ONLY_JOBS: set[str] = set()
+# local analogue. The changes detector selects remote jobs from PR metadata;
+# it performs no validation. The local gate runs its explicitly requested
+# validation jobs without GitHub event filtering, so no detector is needed.
+CI_ONLY_JOBS: set[str] = {"changes"}
 
 
 def _ci_job_ids() -> set[str]:


### PR DESCRIPTION
PR #5246 added the `changes` detector without updating the local CI manifest contract, so every full Test run fails with `ci.yml jobs not in --list output: ['changes']`. Exempt that orchestration-only job with an explicit rationale. Every actual validation job remains covered by the existing set-equality check.

Validation: reproduced the failing manifest assertion on the exact #5246 head; all six local-gate tests pass after the change, including command-failure propagation. Ruff lint/format and whitespace checks pass. No native execution is needed for this test-contract correction.

Closes #5247. The separately reported docs/agent test-selection gap in #5246 and performance objective in #5240 remain open concerns.