### PR TITLE
fix(ci): preserve content contracts on docs-only PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,10 +26,10 @@ jobs:
   # touched src/ or tests/ (measured 2026-09-11, 2AMLogic/2am#29), and every
   # board job legitimately depends on the router source, so this is NOT a
   # per-job path map -- it is a single "docs/site/agent-config only?" gate
-  # that spares the ~8% of PRs which change nothing under test the full
+  # that spares the ~8% of PRs which change only content the full
   # ~115 job-minutes. main pushes always run everything. If detection itself
   # fails, every job runs (fail-open), so a broken filter can only cost
-  # minutes, never a false green.
+  # minutes, never a false green. Content contracts still run in lint.
   changes:
     name: Detect Changes
     runs-on: ubuntu-latest
@@ -83,6 +83,9 @@ jobs:
 
       - name: Lint
         run: uv run ruff check .
+
+      - name: Check documentation and agent-content contracts
+        run: bash scripts/ci/check-content-contracts.sh
 
   typecheck:
     name: Type Check

--- a/docs/contributing/development.md
+++ b/docs/contributing/development.md
@@ -473,3 +473,34 @@ merged `main` SHA.
 
 - **Issues**: https://github.com/rjwalters/kicad-tools/issues
 - **Discussions**: https://github.com/rjwalters/kicad-tools/discussions
+
+
+### Content checks on docs-only pull requests
+
+The always-running **Lint & Format** job runs
+`bash scripts/ci/check-content-contracts.sh` after Ruff. The local equivalent,
+`bash scripts/ci/local-gate.sh lint`, invokes the same script and explicit pytest
+selection. Neither needs a native build. Changes to the runner, tests, or workflow
+also run this gate; it does not depend on changed-file detection.
+
+The selection covers source citations in guarded Markdown globs, diff-pair and
+match-group guide contracts, shipped command contracts and installation, board06
+and board07 README tolerance markers, and the board07 inventory in
+`boards/README.md`. An initial local run passed all 102 tests in 8.43 seconds,
+without skips (test execution only; dependency setup is additional).
+
+New documents matching the citation globs are checked automatically. Deleting or
+renaming required guides or commands fails their existing presence contracts;
+deleting an optional document need not fail. Citation checks intentionally omit
+research and investigation notes. Command-specific contracts enumerate known
+skills, so adding a command may also require extending those test lists.
+
+This is a maintained selection of Python content consumers, not a general
+validator for every excluded file. The audit found no Python test consumers of
+repository `site/**` or `.loom/**` inputs; their Node and shell checks remain
+separate. When adding a Python test that reads a path excluded by `changes.code`
+in `.github/workflows/ci.yml`, add it to the shared runner. If it requires native
+builds or routing and cannot run here, conservatively restore the full-Test
+trigger for that input instead of leaving the consumer untested. Ordinary
+content-only PRs still skip the unrelated native board jobs; main pushes and
+change-detection failures run the full gate.

--- a/scripts/ci/check-content-contracts.sh
+++ b/scripts/ci/check-content-contracts.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+# Shared by CI lint and local-gate.sh; no native build or board routing.
+# When adding a Python consumer of excluded content, extend this selection
+# or restore its full-Test trigger. See docs/contributing/development.md.
+set -euo pipefail
+cd "$(dirname "${BASH_SOURCE[0]}")/../.."
+exec uv run --extra dev --frozen pytest -q -o addopts= --no-cov --timeout=60 \
+  tests/test_content_contract_gate.py \
+  tests/test_docs_source_citations.py \
+  tests/test_diffpair_docs.py \
+  tests/test_match_group_docs.py \
+  tests/test_kct_skills_consumer_generic.py \
+  tests/install/test_install_kct.py \
+  tests/test_check_doc_drift.py \
+  tests/test_board_07_matchgroup_test.py::TestBoardsReadmeUpdated

--- a/scripts/ci/local-gate.sh
+++ b/scripts/ci/local-gate.sh
@@ -114,6 +114,7 @@ SKIP_RC=75
 job_lint() {
   uv run ruff format . --check
   uv run ruff check .
+  bash scripts/ci/check-content-contracts.sh
 }
 
 job_typecheck() {

--- a/tests/test_content_contract_gate.py
+++ b/tests/test_content_contract_gate.py
@@ -1,0 +1,55 @@
+"""Keep content validation mandatory when the expensive CI jobs are skipped."""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+import yaml
+
+ROOT = Path(__file__).resolve().parents[1]
+RUNNER = "scripts/ci/check-content-contracts.sh"
+
+
+def test_ci_content_gate_is_unconditional() -> None:
+    workflow = yaml.safe_load((ROOT / ".github/workflows/ci.yml").read_text())
+    lint = workflow["jobs"]["lint"]
+    assert "if" not in lint
+    assert "needs" not in lint
+    steps = [step for step in lint["steps"] if step.get("run") == f"bash {RUNNER}"]
+    assert len(steps) == 1
+    assert "if" not in steps[0]
+    assert not steps[0].get("continue-on-error", False)
+    assert not lint.get("continue-on-error", False)
+
+
+def test_local_lint_propagates_content_failure(tmp_path: Path) -> None:
+    """Execute the real local dispatcher and shared runner with a failing pytest."""
+    for relative in (RUNNER, "scripts/ci/local-gate.sh"):
+        target = tmp_path / relative
+        target.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copyfile(ROOT / relative, target)
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    uv = bin_dir / "uv"
+    uv.write_text(
+        "#!/usr/bin/env bash\n"
+        'case " $* " in\n'
+        '  *" pytest "*) echo "content-pytest-reached"; exit 1 ;;\n'
+        '  *" ruff "*) exit 0 ;;\n'
+        "  *) exit 2 ;;\n"
+        "esac\n"
+    )
+    uv.chmod(0o755)
+    result = subprocess.run(
+        ["bash", str(tmp_path / "scripts/ci/local-gate.sh"), "lint"],
+        env={**os.environ, "PATH": f"{bin_dir}{os.pathsep}{os.environ['PATH']}"},
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert "content-pytest-reached" in result.stdout
+    assert ">>> lint: FAIL" in result.stdout
+    assert result.returncode == 1

--- a/tests/test_local_gate_manifest.py
+++ b/tests/test_local_gate_manifest.py
@@ -36,8 +36,10 @@ LOCAL_GATE = REPO_ROOT / "scripts" / "ci" / "local-gate.sh"
 
 # Jobs that exist in ci.yml but are intentionally NOT mirrored by
 # local-gate.sh.  Every entry needs a comment explaining why the job has no
-# local analogue.  Currently empty: all 16 ci.yml jobs are mirrored.
-CI_ONLY_JOBS: set[str] = set()
+# local analogue. The changes detector selects remote jobs from PR metadata;
+# it performs no validation. The local gate runs its explicitly requested
+# validation jobs without GitHub event filtering, so no detector is needed.
+CI_ONLY_JOBS: set[str] = {"changes"}
 
 
 def _ci_job_ids() -> set[str]:


### PR DESCRIPTION
Docs-only PRs currently skip Python tests that consume documentation and shipped agent commands, allowing broken content contracts to pass CI. Run a shared lightweight selection from the existing always-running lint job and local lint gate. The selection covers citations, guide recipes, shipped command contracts/installers, and README contracts without native builds or routing.

Part of #5249. Includes merged #5248 (06cab944), resolving the local-gate manifest regression. Keep #5249 open until a post-merge docs-only CI example confirms this gate runs while unrelated board jobs skip.

Validation:
- Local lint gate: Ruff plus 104 tests passed in 7 seconds; independent review repeated 104 tests in 6.34 seconds, no skips.
- Mutation probes: valid added document passes; invalid citation and shipped-command instruction fail; deleting or renaming a required guide fails. All probe files restored.
- New regression tests enforce unconditional CI invocation and local failure propagation.
- Shell syntax, diff whitespace, and mypy baseline pass (1437 errors within 1472 allowed).
- After integrating merged #5248, all six local-gate tests pass, including manifest equality and failure propagation; all 104 content-contract tests also pass.

The contributor guide documents the audited coverage and requires new excluded-path consumers to join the selection or restore their full-test trigger. No new job, per-board path mapping, or heavy-job dependency was introduced.


Dependency integration at `7926091c132ebc90505f0abe043c1d3a24ed3430` changes only the manifest exemption from merged #5248. The content runner and its CI/local wiring are unchanged. Fresh exact-head CI and final review remain required. The post-merge docs-only CI demonstration remains a requirement of #5249.
