### PR TITLE
ci: Test, Board 06 and Diff-Pair run on the fleet CI runner for same-repo PRs too

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ permissions:
 # run per group, so the ~80 merges a day collapse to "one running, one
 # waiting" instead of the 13-deep queue of stale main runs that, together with
 # the superseded PR runs, held every job 70-100 min in queue against this
-# account's 20-job GitHub-hosted concurrency cap.
+# account's 40-job GitHub-hosted concurrency cap.
 concurrency:
   group: ci-${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
@@ -121,14 +121,13 @@ jobs:
     name: Test
     needs: changes
     if: ${{ !cancelled() && (github.event_name == 'push' || needs.changes.outputs.code == 'true' || needs.changes.result == 'failure') }}
-    # main pushes run this on the fleet's dedicated CI runner (2AMLogic/2am#29;
-    # 2 slots for this repo); PR runs stay on GitHub-hosted. Push-only on
-    # purpose: PR volume alone (~200 runs/day) exceeds the whole box, while
-    # main is serialised by the concurrency group above, so at most one run's
-    # heavy jobs are ever on the box and they never queue behind each other.
-    # What it buys: the two ~30-min jobs of every main run leave the account's
-    # 20-job GitHub-hosted pool to PR runs.
-    runs-on: ${{ github.event_name == 'push' && fromJSON('["self-hosted","heavy"]') || 'ubuntu-latest' }}
+    # Runs on the fleet's dedicated CI runner (2AMLogic/2am#29; ten slots for
+    # this repo since the 2026-09-11 resize) for main pushes AND same-repo PRs;
+    # fork PRs route back to GitHub-hosted instead of being skipped, so no
+    # outside fork ever executes on our host and required checks never go
+    # missing. Measured here vs ubuntu-latest: Test 17 vs 40 min, Board 06
+    # 19 vs 27, Diff-Pair ~15 vs 25.
+    runs-on: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && fromJSON('["self-hosted","heavy"]') || 'ubuntu-latest' }}
     env:
       # -n auto reads the container's 8-core cpuset on the runner; keep the
       # worker count at GitHub-hosted parity (4 vCPU) so memory stays bounded.
@@ -148,17 +147,15 @@ jobs:
     # step had continue-on-error.
     container:
       image: kicad/kicad:10.0
-      # Run as root so installs write system locations and actions/checkout
-      # can write $GITHUB_WORKSPACE (mirrors the smoke job).
       # On the runner this is a sibling container of the runner's own, created by
       # the host daemon, so the slot's cpuset/memory do not apply to it: pin it
-      # to the two kicad slots' cores (24-31) and cap its memory. 12 GB, not
-      # the 6 GB first tried: at 6 GB four xdist workers each spawning
-      # kicad-cli DRC pushed the cgroup over its cap and the kernel SIGKILLed
-      # kicad-cli / crashed workers (31 failures, 2026-09-11 run 34645135306);
-      # a GitHub-hosted VM has 16 GB. GitHub-hosted runs get the plain
-      # --user 0:0 (nothing to contain).
-      options: ${{ github.event_name == 'push' && '--user 0:0 --cpuset-cpus 24-31 --memory 12g' || '--user 0:0' }}
+      # to the kicad slots' cores (24-63) and cap its memory at 12g (6 GB
+      # SIGKILLed kicad-cli under four xdist workers, 2026-09-11; a
+      # GitHub-hosted VM has 16 GB).
+      # GitHub-hosted runs get the plain --user 0:0 (nothing to contain). Root
+      # either way, so installs write system locations and actions/checkout can
+      # write $GITHUB_WORKSPACE (mirrors the smoke job).
+      options: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && '--user 0:0 --cpuset-cpus 24-63 --memory 12g' || '--user 0:0' }}
     defaults:
       run:
         # The image's /bin/sh is dash; force bash (mirrors the smoke job).
@@ -545,7 +542,13 @@ jobs:
     name: Diff-Pair Routing Regression
     needs: changes
     if: ${{ !cancelled() && (github.event_name == 'push' || needs.changes.outputs.code == 'true' || needs.changes.result == 'failure') }}
-    runs-on: ubuntu-latest
+    # Runs on the fleet's dedicated CI runner (2AMLogic/2am#29; ten slots for
+    # this repo since the 2026-09-11 resize) for main pushes AND same-repo PRs;
+    # fork PRs route back to GitHub-hosted instead of being skipped, so no
+    # outside fork ever executes on our host and required checks never go
+    # missing. Measured here vs ubuntu-latest: Test 17 vs 40 min, Board 06
+    # 19 vs 27, Diff-Pair ~15 vs 25.
+    runs-on: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && fromJSON('["self-hosted","heavy"]') || 'ubuntu-latest' }}
     # Issue #3509: run inside the official KiCad 10 container (same image
     # as the test + kicad-cli-smoke jobs).  The board 06 recipe's pour
     # pipeline (zone fill -> stitch -> pour-connectivity repair -> re-fill
@@ -563,9 +566,14 @@ jobs:
     # fails the job instead of rotting in the log.
     container:
       image: kicad/kicad:10.0
-      # Run as root so installs write system locations and actions/checkout
-      # can write $GITHUB_WORKSPACE (mirrors the test + smoke jobs).
-      options: --user 0:0
+      # On the runner this is a sibling container of the runner's own, created by
+      # the host daemon, so the slot's cpuset/memory do not apply to it: pin it
+      # to the kicad slots' cores (24-63) and cap its memory at 8g (same shape as
+      # Board 06: one board, one router run, kicad-cli DRC).
+      # GitHub-hosted runs get the plain --user 0:0 (nothing to contain). Root
+      # either way, so installs write system locations and actions/checkout can
+      # write $GITHUB_WORKSPACE (mirrors the smoke job).
+      options: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && '--user 0:0 --cpuset-cpus 24-63 --memory 8g' || '--user 0:0' }}
     defaults:
       run:
         # The image's /bin/sh is dash; force bash (mirrors the test job).
@@ -1526,14 +1534,13 @@ jobs:
     name: Board 06 End-to-End (LVS)
     needs: changes
     if: ${{ !cancelled() && (github.event_name == 'push' || needs.changes.outputs.code == 'true' || needs.changes.result == 'failure') }}
-    # main pushes run this on the fleet's dedicated CI runner (2AMLogic/2am#29;
-    # 2 slots for this repo); PR runs stay on GitHub-hosted. Push-only on
-    # purpose: PR volume alone (~200 runs/day) exceeds the whole box, while
-    # main is serialised by the concurrency group above, so at most one run's
-    # heavy jobs are ever on the box and they never queue behind each other.
-    # What it buys: the two ~30-min jobs of every main run leave the account's
-    # 20-job GitHub-hosted pool to PR runs.
-    runs-on: ${{ github.event_name == 'push' && fromJSON('["self-hosted","heavy"]') || 'ubuntu-latest' }}
+    # Runs on the fleet's dedicated CI runner (2AMLogic/2am#29; ten slots for
+    # this repo since the 2026-09-11 resize) for main pushes AND same-repo PRs;
+    # fork PRs route back to GitHub-hosted instead of being skipped, so no
+    # outside fork ever executes on our host and required checks never go
+    # missing. Measured here vs ubuntu-latest: Test 17 vs 40 min, Board 06
+    # 19 vs 27, Diff-Pair ~15 vs 25.
+    runs-on: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && fromJSON('["self-hosted","heavy"]') || 'ubuntu-latest' }}
     # The measured recipe takes 28m; allow the independent synthetic/LVS,
     # plane-net and artifact gates to finish within the whole-job deadline.
     # Internal routing budgets and all validation gates remain unchanged.
@@ -1542,10 +1549,12 @@ jobs:
       image: kicad/kicad:10.0
       # On the runner this is a sibling container of the runner's own, created by
       # the host daemon, so the slot's cpuset/memory do not apply to it: pin it
-      # to the two kicad slots' cores (24-31) and 8 GB (it passed at 6 GB on
-      # 2026-09-11; headroom, since the cap SIGKILLs rather than swaps).
-      # GitHub-hosted runs get the plain --user 0:0 (nothing to contain).
-      options: ${{ github.event_name == 'push' && '--user 0:0 --cpuset-cpus 24-31 --memory 8g' || '--user 0:0' }}
+      # to the kicad slots' cores (24-63) and cap its memory at 8g (passed at 6 GB;
+      # headroom, since the cap SIGKILLs rather than swaps).
+      # GitHub-hosted runs get the plain --user 0:0 (nothing to contain). Root
+      # either way, so installs write system locations and actions/checkout can
+      # write $GITHUB_WORKSPACE (mirrors the smoke job).
+      options: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && '--user 0:0 --cpuset-cpus 24-63 --memory 8g' || '--user 0:0' }}
     defaults:
       run:
         shell: bash

--- a/tests/test_check_diffpair_coverage.py
+++ b/tests/test_check_diffpair_coverage.py
@@ -341,7 +341,11 @@ class TestWorkflowJob:
         job must run inside the official KiCad container (same image as
         the test + kicad-cli-smoke jobs) so the fills actually run."""
         job = workflow["jobs"][JOB_NAME]
-        assert job["runs-on"] == "ubuntu-latest"
+        # Since 2AMLogic/2am#29 the job runs on the fleet's dedicated runner
+        # for same-repo runs and falls back to ubuntu-latest for fork PRs;
+        # either way the container below is what provides kicad-cli.
+        runs_on = str(job["runs-on"])
+        assert "ubuntu-latest" in runs_on, runs_on
         container = job.get("container")
         assert isinstance(container, dict), (
             "diffpair-routing-regression must run inside the kicad/kicad "


### PR DESCRIPTION
Operator decision (2AMLogic/2am#29, evening of 2026-09-11): accept the account's 40-job GitHub-hosted cap (Pro; a personal account cannot go higher) and move this repo's three heavy jobs onto the dedicated runner **for PRs as well as main pushes**. The box is being resized to a c7i.16xlarge with **ten slots for this repo** to fit the load: ~230 runs/day survive cancel-in-progress × (17 + 19 + ~15 min on the runner) ≈ 11,700 slot-minutes/day.

- Same-repo-or-push expression (the one klayout-tools and loom use): fork PRs keep routing to `ubuntu-latest`, so no outside fork ever executes on our host. Fork-PR approval policy on this repo moves to `all_external_contributors` as it did for those two.
- Job containers pin to the kicad slots' cores (`--cpuset-cpus 24-63`) with 12 / 8 / 8 GB caps.
- Expected: GitHub-hosted pool ~57k → ~36k job-minutes/day (average 25 of 40 concurrent instead of pinned at 40); PR wall ~107 min + queue → ~20 min.

Held until the resized box reports ten kicad slots online; this PR's own run is the first PR to route (its `Test` must land on a `ci-runner-kicad-*`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)