### PR TITLE
perf(placement): reduce allocations in CPU force sampling

### DIFF
--- a/src/kicad_tools/optim/placement.py
+++ b/src/kicad_tools/optim/placement.py
@@ -1135,33 +1135,32 @@ class PlacementOptimizer:
         Returns:
             Force vector on the point
         """
-        edge = edge_end - edge_start
-        edge_len = edge.magnitude()
+        # Keep intermediate coordinates scalar: this hot path runs once per
+        # edge sample, so temporary Vector2D objects dominate the CPU fallback.
+        edge_x = edge_end.x - edge_start.x
+        edge_y = edge_end.y - edge_start.y
+        edge_len = math.sqrt(edge_x * edge_x + edge_y * edge_y)
         if edge_len < 1e-10:
             return Vector2D(0.0, 0.0)
 
-        # Vector from edge start to point
-        to_point = point - edge_start
-
-        # Project point onto edge line
-        t = to_point.dot(edge) / (edge_len * edge_len)
-        t = max(0.0, min(1.0, t))  # Clamp to edge
-
-        # Closest point on edge
-        closest = edge_start + edge * t
-
-        # Vector from closest point to test point
-        displacement = point - closest
-        distance = displacement.magnitude()
-
-        # Clamp minimum distance to prevent singularity
-        distance = max(distance, self.config.min_distance)
-
-        # Force magnitude: lambda * L / r^2 (1/r^2 falloff prevents divergence)
+        point_x = point.x - edge_start.x
+        point_y = point.y - edge_start.y
+        t = (point_x * edge_x + point_y * edge_y) / (edge_len * edge_len)
+        t = max(0.0, min(1.0, t))
+        displacement_x = point.x - (edge_start.x + edge_x * t)
+        displacement_y = point.y - (edge_start.y + edge_y * t)
+        magnitude = math.sqrt(displacement_x * displacement_x + displacement_y * displacement_y)
+        distance = max(magnitude, self.config.min_distance)
         force_mag = charge_density * edge_len / (distance * distance)
 
-        # Force direction: away from edge
-        return displacement.normalized() * force_mag
+        # Normalize using the actual displacement, independently of the force
+        # singularity clamp, exactly as Vector2D.normalized() does.
+        if magnitude < 1e-10:
+            return Vector2D(0.0 * force_mag, 0.0 * force_mag)
+        return Vector2D(
+            (displacement_x / magnitude) * force_mag,
+            (displacement_y / magnitude) * force_mag,
+        )
 
     def compute_edge_to_edge_force(
         self,

--- a/tests/test_placement_force_equivalence.py
+++ b/tests/test_placement_force_equivalence.py
@@ -1,0 +1,49 @@
+"""Keep the CPU hot-path optimization identical to the original vector formula."""
+
+import random
+
+import pytest
+
+from kicad_tools.optim.config import PlacementConfig
+from kicad_tools.optim.geometry import Polygon, Vector2D
+from kicad_tools.optim.placement import PlacementOptimizer
+
+
+def vector_force(point, start, end, charge, minimum):
+    """Original force equation, expressed independently with vector operations."""
+    edge = end - start
+    length = edge.magnitude()
+    if length < 1e-10:
+        return Vector2D(0.0, 0.0)
+    t = (point - start).dot(edge) / (length * length)
+    t = max(0.0, min(1.0, t))
+    displacement = point - (start + edge * t)
+    distance = max(displacement.magnitude(), minimum)
+    return displacement.normalized() * (charge * length / (distance * distance))
+
+
+@pytest.mark.parametrize("minimum", [1e-8, 0.1, 10.0])
+def test_cpu_force_matches_vector_equation_exactly(minimum):
+    optimizer = PlacementOptimizer(
+        Polygon.rectangle(50, 50, 50, 50), PlacementConfig(min_distance=minimum)
+    )
+    rng = random.Random(5240)
+    cases = [
+        (Vector2D(x, y), Vector2D(0, 0), Vector2D(1, 0), charge)
+        for x in (-1.0, 0.0, 0.5, 1.0, 2.0)
+        for y in (0.0, 1e-11, 1e-10, 1e-9, 0.01, 100.0)
+        for charge in (-1.0, 0.0, 1.0)
+    ]
+    for index in range(2000):
+        point, start, end = [
+            Vector2D(rng.uniform(-100, 100), rng.uniform(-100, 100)) for _ in range(3)
+        ]
+        if index % 5 == 0:
+            end = start
+        if index % 7 == 0:
+            point = start
+        cases.append((point, start, end, rng.uniform(-3, 3)))
+    for point, start, end, charge in cases:
+        actual = optimizer.compute_edge_to_point_force(point, start, end, charge)
+        expected = vector_force(point, start, end, charge, minimum)
+        assert (actual.x, actual.y) == (expected.x, expected.y)


### PR DESCRIPTION
The CPU placement fallback spends most of its sampled-force time constructing temporary vectors. Compute the same intermediate coordinates as scalars and allocate only the returned force vector. Sampling, iterations, minimum-distance handling, normalization threshold, and arithmetic order remain unchanged.

Part of #5240. This increment does **not** complete that issue's acceptance requirement for improved medians in Test, Board 06, and Diff-Pair. It changes the placement CPU path only; the separately proposed runner migration (#5252) must be accounted for in future CI comparisons.

Validation:
- 145 placement and force-equivalence tests passed. The regression test checks exact equality with the original vector equation across 6,270 cases covering random geometry, degenerate edges, projection endpoints, near-zero displacement, signed charges and three minimum-distance settings.
- Related force-engine/containment tests: 22 passed, 11 skipped because the optional placement native backend is unavailable locally.
- Locked repository-wide Ruff checks and mypy baseline passed (1,437 existing errors within the 1,472 baseline); whitespace clean.
- Same-host benchmark, three trials of 20 iterations on the original 20-component courtyard fixture with the CPU backend forced: original median 1.6997s, scalar median 1.0184s (40.1% reduction, 1.67x). All 2,000 sampled force outputs and all 20 final component states matched exactly. This is a local diagnostic, not a hosted-CI median.

The full-suite diagnostic that selected this hotspot was not clean: 29,495 passes, seven failures and one setup error, including four worker crashes. Its 953.06s wall time is not a performance acceptance result. Raw profile and benchmark evidence is recorded in the #5240 comments and locally under `/tmp/kicad-ci-profile-20260911/`.