### PR TITLE
fix(reinforce): preserve force-path eligibility through segment chaining

### DIFF
--- a/src/kicad_tools/pcb/reinforce.py
+++ b/src/kicad_tools/pcb/reinforce.py
@@ -237,12 +237,15 @@ def _to_router_segment(seg: Segment) -> RouterSegment:
     )
 
 
-def _chain_polylines(segments: list[Segment]) -> list[list[Segment]]:
+def _chain_polylines(
+    segments: list[Segment], *, original_ids: dict[int, int] | None = None
+) -> list[list[Segment]]:
     """Chain schema segments into ordered, junction-split polylines.
 
-    Returns a list of runs, each an ordered list of the *original* schema
-    ``Segment`` objects walked endpoint-to-endpoint. Junctions (degree>=3)
-    split runs so branched nets are not silently merged.
+    Returns ordered schema segments walked endpoint-to-endpoint, copying
+    segments that need reversing. When supplied, ``original_ids`` maps each
+    returned object's id to its original PCB object's id. Junctions
+    (degree>=3) split runs so branched nets are not silently merged.
     """
     if not segments:
         return []
@@ -311,6 +314,8 @@ def _chain_polylines(segments: list[Segment]) -> list[list[Segment]]:
                         uuid=orig.uuid,
                     )
                 )
+            if original_ids is not None:
+                original_ids[id(run[-1])] = id(orig)
         if run:
             result.append(run)
     return result
@@ -668,40 +673,41 @@ def reinforce_net(
         target_layer = max(by_layer, key=lambda lay: sum(_seg_length(s) for s in by_layer[lay]))
     result.layer = target_layer
 
-    runs = _chain_polylines(by_layer[target_layer])
-    if not runs:
+    # Chaining can reverse a segment by copying it. Carry its original PCB
+    # identity through the walk so path eligibility remains physical.
+    original_ids: dict[int, int] = {}
+    runs = _chain_polylines(by_layer[target_layer], original_ids=original_ids)
+    net_path_specs = [spec for spec in (current_paths or ()) if spec.net_name == net_name]
+    classified_runs: list[tuple[list[Segment], str | None]] = []
+    if net_path_specs:
+        allowed_ids = reinforcement_eligible_segment_ids(pcb, net_path_specs)
+        excluded_reason = (
+            "excluded by declared current-path intent (Issue #4980): not fully "
+            "covered by a resolved, reinforcement-eligible CurrentPathSpec for "
+            f"net {net_name!r}"
+        )
+        for run in runs:
+            parts: list[tuple[list[Segment], str | None]] = []
+            for seg in run:
+                reason = None if original_ids[id(seg)] in allowed_ids else excluded_reason
+                # A degree-two force pad can continue into a sense stub.
+                # Split that eligibility boundary while retaining all of the
+                # chainer's existing physical-junction boundaries.
+                if not parts or parts[-1][1] != reason:
+                    parts.append(([], reason))
+                parts[-1][0].append(seg)
+            classified_runs.extend(parts)
+    else:
+        classified_runs = [(run, None) for run in runs]
+    if not classified_runs:
         raise ReinforceError(f"net {net_name!r} produced no walkable polyline")
 
-    # Longest-first so the "primary" run (default mode) is runs[0] and the
-    # per-run summary is stably ordered.
-    runs.sort(key=_run_length, reverse=True)
-
-    # Tier 3: coalesce contiguous collinear fragments within each run so the
-    # reported segment count reflects true geometric runs (anchor positions
-    # unchanged -- merge only removes collinear interior vertices).
+    classified_runs.sort(key=lambda item: _run_length(item[0]), reverse=True)
+    runs = [run for run, _ in classified_runs]
     geoms = [_run_geometry(run) for run in runs]
-
-    # Issue #4980: declared current-path gating. When at least one spec
-    # targets this net, reinforcement flips to an ALLOW-list -- a run may
-    # only be anchored when every one of its segments is covered by a
-    # resolved, reinforcement-eligible CurrentPathSpec. This is what keeps a
-    # Kelvin sense tap (or any branch declared reinforcement_eligible=False)
-    # from ever being anchored/bridged, and what makes a broken/moved
-    # endpoint mapping fail closed (a spec that no longer resolves simply
-    # never contributes segments to the allow-list, rather than falling
-    # back to "anchor it anyway").
-    path_excluded_reasons: dict[int, str] = {}
-    net_path_specs = [spec for spec in (current_paths or ()) if spec.net_name == net_name]
-    if net_path_specs:
-        eligible_segment_ids = reinforcement_eligible_segment_ids(pcb, net_path_specs)
-        for i, run in enumerate(runs):
-            run_segment_ids = {id(s) for s in run}
-            if not run_segment_ids.issubset(eligible_segment_ids):
-                path_excluded_reasons[i] = (
-                    "excluded by declared current-path intent (Issue #4980): not fully "
-                    "covered by a resolved, reinforcement-eligible CurrentPathSpec for "
-                    f"net {net_name!r}"
-                )
+    path_excluded_reasons = {
+        index: reason for index, (_, reason) in enumerate(classified_runs) if reason is not None
+    }
 
     # Selection: filter by min length (report -- do not drop -- shorter runs),
     # then by the current-path gate (report -- do not drop -- excluded runs),

--- a/src/kicad_tools/router/current_paths.py
+++ b/src/kicad_tools/router/current_paths.py
@@ -995,23 +995,10 @@ def _endpoint_via_array(
 def _candidate_via_array_leg_count(
     graph: _CopperGraph, pcb: PCB, hub: _Node, pad: Pad, net_name: str
 ) -> int:
-    """Count arms at ``hub`` that individually look like a via-array leg.
+    """Count intact local via arms; fewer than two does not prove safe branching.
 
-    A damaged/incomplete parallel via array (Issue #4980 upstream fanout
-    diagnosis) is only a meaningful concept when at least *two* surviving
-    arms each independently resemble one leg of that motif: a short,
-    same-layer stub (bounded by the pad diagonal, matching
-    :func:`_endpoint_via_array`'s own supported-subset limit) that
-    terminates at a real plated via on this net.
-
-    This is deliberately narrower than "any arm anywhere touches a via" --
-    that broader check also fires on an ordinary branching pad where one
-    arm is ,e.g., a force trunk trace and the *other*, unrelated, arm just
-    happens to drop through a via to reach an inner layer (a common,
-    completely ordinary sense/feedback-tap pattern). Requiring two or more
-    candidate legs keeps the "this might be a damaged fanout" suspicion
-    scoped to boards that actually attempted the parallel-via motif, without
-    inferring or assuming any current split between legs.
+    Ordinary single-via branches also require terminal proof for every exit.
+    Missing, wrong-net or distant vias must not erase damaged-array evidence.
     """
     bound = math.hypot(*pad.size)
     net = pcb.get_net_by_name(net_name)
@@ -1288,22 +1275,27 @@ def resolve_current_path(pcb: PCB, spec: CurrentPathSpec) -> PathResolution:
                 else None
             )
             arms = adjacency.adjacency.get(hub, []) if hub is not None else []
-            # A broken fanout may become acyclic when receiving copper is
-            # removed. It must not fall back to checking one surviving arm --
-            # but "a fanout" is only a meaningful suspicion once at least two
-            # arms independently resemble a via-array leg
-            # (:func:`_candidate_via_array_leg_count`). An ordinary branching
-            # pad -- e.g. one force-trunk arm plus one unrelated sense/
-            # feedback arm that happens to drop through a single via to
-            # reach an inner layer -- is not a damaged array and must not be
-            # forced ambiguous just because *some* arm touches *some* via.
+            # A single-via ordinary branch is supported only when all arms
+            # lead through acyclic copper to actual pad terminals. Counting
+            # surviving vias alone would accept a damaged array after missing
+            # barrels or receiving copper turn other arms into dangling ends.
             if (
                 hub is not None
                 and endpoint_pad is not None
                 and endpoint_pad.type == "smd"
                 and len(arms) >= 2
-                and _candidate_via_array_leg_count(adjacency, pcb, hub, endpoint_pad, spec.net_name)
-                >= 2
+                and any(
+                    edge.segment is not None
+                    and any(_node_key(v.position) == node[:2] for v in pcb.vias)
+                    for node, edge in arms
+                )
+                and (
+                    _candidate_via_array_leg_count(adjacency, pcb, hub, endpoint_pad, spec.net_name)
+                    >= 2
+                    or not _proved_load_exits(
+                        adjacency, {hub}, [(hub, node, edge) for node, edge in arms]
+                    )
+                )
             ):
                 return PathResolution(
                     spec=spec,

--- a/src/kicad_tools/router/current_paths.py
+++ b/src/kicad_tools/router/current_paths.py
@@ -992,6 +992,48 @@ def _endpoint_via_array(
     return _ViaArray(nodes, edges, list({id(seg): seg for seg in members}.values()))
 
 
+def _candidate_via_array_leg_count(
+    graph: _CopperGraph, pcb: PCB, hub: _Node, pad: Pad, net_name: str
+) -> int:
+    """Count arms at ``hub`` that individually look like a via-array leg.
+
+    A damaged/incomplete parallel via array (Issue #4980 upstream fanout
+    diagnosis) is only a meaningful concept when at least *two* surviving
+    arms each independently resemble one leg of that motif: a short,
+    same-layer stub (bounded by the pad diagonal, matching
+    :func:`_endpoint_via_array`'s own supported-subset limit) that
+    terminates at a real plated via on this net.
+
+    This is deliberately narrower than "any arm anywhere touches a via" --
+    that broader check also fires on an ordinary branching pad where one
+    arm is ,e.g., a force trunk trace and the *other*, unrelated, arm just
+    happens to drop through a via to reach an inner layer (a common,
+    completely ordinary sense/feedback-tap pattern). Requiring two or more
+    candidate legs keeps the "this might be a damaged fanout" suspicion
+    scoped to boards that actually attempted the parallel-via motif, without
+    inferring or assuming any current split between legs.
+    """
+    bound = math.hypot(*pad.size)
+    net = pcb.get_net_by_name(net_name)
+    count = 0
+    for top, edge in graph.adjacency.get(hub, []):
+        seg = edge.segment
+        if seg is None or seg.layer != hub[2]:
+            continue
+        if _seg_length(seg) > bound + _PAD_EPS:
+            continue
+        matching = [v for v in pcb.vias if _node_key(v.position) == top[:2]]
+        if len(matching) != 1:
+            continue
+        via = matching[0]
+        if len(via.layers) < 2 or not (
+            via.net_name == net_name or (net is not None and via.net_number == net.number)
+        ):
+            continue
+        count += 1
+    return count
+
+
 def _component_has_cycle(
     graph: _CopperGraph, start: _Node, arrays: Sequence[_ViaArray] = ()
 ) -> bool:
@@ -1247,16 +1289,21 @@ def resolve_current_path(pcb: PCB, spec: CurrentPathSpec) -> PathResolution:
             )
             arms = adjacency.adjacency.get(hub, []) if hub is not None else []
             # A broken fanout may become acyclic when receiving copper is
-            # removed. It must not fall back to checking one surviving arm.
+            # removed. It must not fall back to checking one surviving arm --
+            # but "a fanout" is only a meaningful suspicion once at least two
+            # arms independently resemble a via-array leg
+            # (:func:`_candidate_via_array_leg_count`). An ordinary branching
+            # pad -- e.g. one force-trunk arm plus one unrelated sense/
+            # feedback arm that happens to drop through a single via to
+            # reach an inner layer -- is not a damaged array and must not be
+            # forced ambiguous just because *some* arm touches *some* via.
             if (
-                endpoint_pad is not None
+                hub is not None
+                and endpoint_pad is not None
                 and endpoint_pad.type == "smd"
                 and len(arms) >= 2
-                and any(
-                    edge.segment is not None
-                    and any(_node_key(v.position) == node[:2] for v in pcb.vias)
-                    for node, edge in arms
-                )
+                and _candidate_via_array_leg_count(adjacency, pcb, hub, endpoint_pad, spec.net_name)
+                >= 2
             ):
                 return PathResolution(
                     spec=spec,

--- a/tests/test_current_paths.py
+++ b/tests/test_current_paths.py
@@ -741,6 +741,59 @@ class TestPhysicalLayerGraph:
 
         assert board.read_bytes() == before
 
+    def test_board09_ordinary_branch_endpoint_is_not_a_fanout(self):
+        """Issue #4980: an ordinary branching pad must not be forced 'ambiguous'.
+
+        ``RSH1.1`` (the ``VOUT_PRE`` force-in shunt terminal) has exactly two
+        arms: the 2.0 mm force trunk continuing to ``L1.2``, and an unrelated
+        0.25 mm sense/feedback tap that happens to drop through a single via
+        to reach an inner layer. That single via-tap arm is not a second
+        via-array leg -- ``_endpoint_via_array``'s own proof correctly
+        rejects it as an array, but the coarser "any arm touches any via"
+        fallback in ``resolve_current_path`` used to treat the mere presence
+        of one via anywhere on the endpoint's arms as an unproved *damaged*
+        array and force the whole declaration ambiguous. ``R7.1`` (the
+        feedback-tap endpoint) has the same shape: one dangling stub to a
+        pad with nothing else attached, plus one single via-tap arm.
+        Neither hub has two independent via-array-leg candidates, so neither
+        should trip the fanout fallback.
+        """
+        from pathlib import Path
+
+        from kicad_tools.schema.pcb import PCB
+
+        board = (
+            Path(__file__).resolve().parents[1]
+            / "boards/09-usbc-pd-power/output/usbc_pd_power.kicad_pcb"
+        )
+        before = board.read_bytes()
+        pcb = PCB.load(board)
+
+        force = CurrentPathSpec(
+            name="vout_pre_force",
+            net_name="VOUT_PRE",
+            source=PathEndpoint("L1", "2"),
+            sink=PathEndpoint("RSH1", "1"),
+            continuous_a=3,
+        )
+        force_result = resolve_current_path(pcb, force)
+        assert force_result.status == "resolved"
+        assert force_result.segments
+        assert force_result.length_mm > 0.0
+
+        feedback = CurrentPathSpec(
+            name="vout_pre_feedback",
+            net_name="VOUT_PRE",
+            source=PathEndpoint("L1", "2"),
+            sink=PathEndpoint("R7", "1"),
+            continuous_a=0.001,
+            reinforcement_eligible=False,
+        )
+        feedback_result = resolve_current_path(pcb, feedback)
+        assert feedback_result.status == "resolved"
+
+        assert board.read_bytes() == before
+
     def test_transitive_pad_union_does_not_erase_external_return(self):
         pcb = _t_network_pcb()
         pcb.get_footprint("J1").pads[0].size = (1.6, 1.6)

--- a/tests/test_current_paths_via_array.py
+++ b/tests/test_current_paths_via_array.py
@@ -113,6 +113,23 @@ def test_unproved_fanout_remains_nonresolved(mutation):
     assert not reinforcement_eligible_segment_ids(pcb, [spec()])
 
 
+@pytest.mark.parametrize("damage", ["two_missing_vias", "long_missing_trunk", "two_wrong_net_vias"])
+def test_compound_array_damage_cannot_become_eligible_ordinary_branch(damage):
+    pcb = fixture(depth=20 if damage == "long_missing_trunk" else 2)
+    if damage == "two_missing_vias":
+        pcb._vias = pcb._vias[-1:]
+    elif damage == "long_missing_trunk":
+        pcb._segments.pop(3)
+    else:
+        other = pcb.add_net("OTHER")
+        for via in pcb.vias[:2]:
+            via.net_number, via.net_name = other.number, "OTHER"
+    declaration = replace(spec(), continuous_a=1)
+    assert resolve_current_path(pcb, declaration).status == "ambiguous"
+    assert PathAmpacityRule([declaration]).check(pcb, _design_rules_2oz()).errors
+    assert not reinforcement_eligible_segment_ids(pcb, [declaration])
+
+
 @pytest.mark.parametrize("delta,expected", [(0, True), (0.001, False)])
 def test_explicit_pad_diagonal_locality_boundary(delta, expected):
     assert resolve_current_path(fixture(depth=math.hypot(2.4, 2.4) + delta), spec()).ok is expected

--- a/tests/test_current_paths_via_array.py
+++ b/tests/test_current_paths_via_array.py
@@ -191,6 +191,70 @@ def test_load_tree_with_dangling_branch_is_unproved():
     assert not resolve_current_path(pcb, spec()).ok
 
 
+def test_single_via_tap_arm_is_not_a_fanout():
+    """Issue #4980: one via-tap arm plus one ordinary trunk arm must resolve.
+
+    A hub with exactly one arm that happens to drop through a via is not
+    "a fanout" -- ``_endpoint_via_array``'s own proof correctly rejects it
+    (it needs >= 2 legs), but the endpoint-fanout fallback in
+    ``resolve_current_path`` must not treat the mere presence of *one* via
+    anywhere on the hub's arms as evidence of a *damaged* parallel array.
+    This shape (a force trunk plus a single sense/feedback tap through one
+    via to an inner layer) is completely ordinary and ships on real boards
+    (see the ``VOUT_PRE``/``RSH1.1`` real-board regression in
+    ``tests/test_current_paths.py::TestPhysicalLayerGraph::
+    test_board09_ordinary_branch_endpoint_is_not_a_fanout``).
+    """
+    pcb = fixture()
+    pcb._segments = []
+    pcb._vias = []
+    # Force trunk: straight from J1 to J2, no via at all.
+    pcb.add_trace(("J1", "1"), ("J2", "1"), width=2.0, layer="F.Cu", net="NET1")
+    # Unrelated sense/feedback tap: a single via-tap arm off the same J1
+    # pad, landing on a completely different pad via B.Cu.
+    pcb.add_trace((20, 50), (20, 52), width=0.2, layer="F.Cu", net="NET1")
+    # dedupe=False: the fixture's own vias (already cleared from `_vias`
+    # above) left dedup keys at these exact reused coordinates -- without
+    # this, `add_via` silently treats the new via as an already-seen
+    # duplicate and skips it.
+    pcb.add_via(20, 52, net="NET1", dedupe=False)
+    pcb.add_trace((20, 52), (60, 60), width=0.2, layer="B.Cu", net="NET1")
+    _add_pad_footprint(pcb, ref="TAP", x=60, y=60, net="NET1")
+    result = resolve_current_path(pcb, spec())
+    assert result.ok, result.reason
+
+
+def test_two_unrelated_via_arms_still_ambiguous_without_array_proof():
+    """Two candidate via-legs that fail the full array proof stay ambiguous.
+
+    Unlike the single-via-tap case above, a hub with *two* independent
+    candidate via-array legs is exactly the "might be a damaged fanout"
+    shape the fallback exists to catch -- even though these two legs go
+    off in unrelated directions (never a real parallel-via motif), the
+    fallback's job is only to detect the *suspicious shape*, not to prove
+    or disprove a specific current split.
+    """
+    pcb = fixture()
+    pcb._segments = []
+    pcb._vias = []
+    pcb.add_trace(("J1", "1"), ("J2", "1"), width=2.0, layer="F.Cu", net="NET1")
+    # Two short, non-parallel via-tap arms off the same hub -- each looks
+    # like an array leg in isolation, but they never converge on one
+    # receiving trunk.
+    pcb.add_trace((20, 50), (20, 52), width=0.2, layer="F.Cu", net="NET1")
+    # dedupe=False: see the comment in test_single_via_tap_arm_is_not_a_fanout.
+    pcb.add_via(20, 52, net="NET1", dedupe=False)
+    pcb.add_trace((20, 52), (60, 60), width=0.2, layer="B.Cu", net="NET1")
+    _add_pad_footprint(pcb, ref="TAP1", x=60, y=60, net="NET1")
+
+    pcb.add_trace((21, 49), (21, 47), width=0.2, layer="F.Cu", net="NET1")
+    pcb.add_via(21, 47, net="NET1", dedupe=False)
+    pcb.add_trace((21, 47), (60, 40), width=0.2, layer="B.Cu", net="NET1")
+    _add_pad_footprint(pcb, ref="TAP2", x=60, y=40, net="NET1")
+
+    assert not resolve_current_path(pcb, spec()).ok
+
+
 @pytest.mark.parametrize("net_token", ["1", '"NET1"'])
 def test_same_net_custom_via_padstack_is_unproved(net_token):
     from kicad_tools.sexp import parse_string

--- a/tests/test_pcb_reinforce.py
+++ b/tests/test_pcb_reinforce.py
@@ -1095,3 +1095,105 @@ class TestCurrentPathGating:
         )
         assert all(rs.path_excluded_reason is None for rs in result.runs)
         assert result.placed_count > 0
+
+
+@pytest.mark.parametrize("reverse_mask", range(8))
+def test_current_path_anchors_ignore_segment_orientation(reverse_mask, tmp_path):
+    """A serialized direction change cannot remove physical force eligibility."""
+
+    def anchors(pcb):
+        result = reinforce_net(
+            pcb,
+            "PGND",
+            spacing_mm=10.0,
+            all_runs=True,
+            dry_run=True,
+            current_paths=[_force_spec(), _kelvin_sense_spec()],
+        )
+        return sorted((round(a.x, 6), round(a.y, 6)) for a in result.placed)
+
+    import re
+
+    from tests.test_cli_route_current_paths import _T_NETWORK_PCB_TEMPLATE
+
+    text = (
+        _T_NETWORK_PCB_TEMPLATE.format(trunk_width=3.0, sense_width=0.2)
+        .replace("J1", "RSH1")
+        .replace("NET1", "PGND")
+    )
+    path = tmp_path / "reversed.kicad_pcb"
+    path.write_text(text)
+    expected = anchors(PCB.load(path))
+    assert expected
+    index = 0
+
+    def reverse(match):
+        nonlocal index
+        swapped = bool(reverse_mask & (1 << index))
+        index += 1
+        start, end = match.groups()
+        if swapped:
+            start, end = end, start
+        return f"(segment (start {start}) (end {end})"
+
+    path.write_text(re.sub(r"\(segment \(start ([^)]*)\) \(end ([^)]*)\)", reverse, text))
+    assert index == 3
+    assert anchors(PCB.load(path)) == expected
+
+
+def test_current_path_boundary_splits_force_from_continuing_sense():
+    """A degree-two force pad must end the eligible run before the sense tap."""
+    pcb = PCB.create(width=160, height=100, center=False)
+    for ref, x in [("RSH1", 20), ("J2", 80), ("U3", 120)]:
+        _add_pad_footprint(pcb, ref=ref, x=x, y=50, net="PGND")
+    pcb.add_trace((20, 50), (60, 50), width=3, layer="F.Cu", net="PGND")
+    pcb.add_trace((60, 50), (80, 50), width=3, layer="F.Cu", net="PGND")
+    pcb.add_trace((80, 50), (120, 50), width=0.2, layer="F.Cu", net="PGND")
+    result = reinforce_net(
+        pcb,
+        "PGND",
+        spacing_mm=10,
+        all_runs=True,
+        dry_run=True,
+        current_paths=[_force_spec(), _kelvin_sense_spec()],
+    )
+    assert result.placed
+    assert all(a.x <= 80 for a in result.placed)
+    assert any(r.length_mm == 60 and r.path_excluded_reason is None for r in result.runs)
+    assert any(r.length_mm == 40 and r.path_excluded_reason for r in result.runs)
+
+
+def test_board09_force_runs_survive_current_path_gate():
+    """Separate eligibility from clearance refusals on the real shunt fixture."""
+    board = (
+        Path(__file__).resolve().parents[1]
+        / "boards/09-usbc-pd-power/output/usbc_pd_power.kicad_pcb"
+    )
+    before = board.read_bytes()
+    pcb = PCB.load(board)
+    specs = [
+        CurrentPathSpec(
+            name="force",
+            net_name="VOUT_PRE",
+            source=PathEndpoint("L1", "2"),
+            sink=PathEndpoint("RSH1", "1"),
+            continuous_a=3,
+            reinforcement_eligible=True,
+        ),
+        CurrentPathSpec(
+            name="feedback",
+            net_name="VOUT_PRE",
+            source=PathEndpoint("L1", "2"),
+            sink=PathEndpoint("R7", "1"),
+            continuous_a=0.001,
+            reinforcement_eligible=False,
+        ),
+    ]
+    result = reinforce_net(
+        pcb, "VOUT_PRE", layer="F.Cu", all_runs=True, dry_run=True, current_paths=specs
+    )
+    eligible = [r for r in result.runs if r.path_excluded_reason is None]
+    assert eligible
+    assert sum(r.length_mm for r in eligible) > 20
+    assert any(r.path_excluded_reason for r in result.runs)
+    assert board.read_bytes() == before


### PR DESCRIPTION
Reinforcement could reject a valid force path when chaining reversed a segment, because its oriented copy lost the identity used by the path allow-list. It also rejected eligible force copper when a degree-two force pad continued into an ineligible sense stub.

Carry original PCB segment identity through chaining, then split each existing run where declared eligibility changes. This preserves physical-junction boundaries, reports excluded subruns, and confines anchor placement and clearance checks to eligible force copper.

This branch includes the required resolver repair from #5260 at `1f0b542e`. That parent is now merged, and this PR targets `main`. Current-main integration checks, completed CI, and final exact-head review remain required before merging.

Validation at `5477b3b3`: **163 passed, 1 skipped** across `test_pcb_reinforce.py`, `test_current_paths.py`, and `test_current_paths_via_array.py` (1.97s). This includes the Board09 force-run regression, serialized orientation and force/sense-boundary controls, and the parent damaged-fanout rejection controls. The skipped test requires native KiCad; no fresh native run is claimed for this revision. Whitespace check passed and the checkout is clean.

The Board09 regression verifies eligible force runs. Actual anchor clearance, physical reinforcement, and manufacturing qualification remain separate acceptance work under #4980.

Closes #5263.
Part of #4980.

