### PR TITLE
fix(router): preserve copper across routing cache replay

### DIFF
--- a/src/kicad_tools/cli/route_cmd.py
+++ b/src/kicad_tools/cli/route_cmd.py
@@ -15716,11 +15716,8 @@ def _main_impl(argv: list[str] | None = None) -> int:
                 # Deserialize and apply cached routes
                 cached_routes = cache.deserialize_routes(cached_result.routes_data)
 
-                # Apply cached routes to router
-                router.routes = cached_routes
+                cached_usage = cache.deserialize_route_usage(cached_result.routes_data)
 
-                if not quiet:
-                    print("  Using cached routing result")
             else:
                 if not quiet:
                     print(f"  Cache MISS (key: {cache_key.full_key[:32]}...)")
@@ -15736,6 +15733,18 @@ def _main_impl(argv: list[str] | None = None) -> int:
             if args.cache_only:
                 print("Error: --cache-only specified but cache lookup failed", file=sys.stderr)
                 return 1
+
+    if cached_result is not None:
+        # Applying geometry can fail after partial mutation. Never turn that
+        # into a fresh search with a contaminated grid or publish its copper.
+        try:
+            router.grid.import_route_usage(cached_usage)
+            router.restore_route_snapshot(cached_routes)
+            if not quiet:
+                print("  Using cached routing result")
+        except Exception as exc:
+            print(f"Error: cannot restore cached routing state: {exc}", file=sys.stderr)
+            return 1
 
     # Track nets that needed clearance relaxation (for --progressive-clearance)
     relaxed_nets_report: dict[int, float] = {}
@@ -16307,6 +16316,10 @@ def _main_impl(argv: list[str] | None = None) -> int:
                 pcb_path = _moved_placement_path
 
         _rss.mark("post-negotiation")
+        # Canonicalize the committed-copper boundary for every strategy,
+        # whether caching is enabled or not. Post-passes must not retain
+        # discarded search geometry in indexes or pathfinder caches.
+        router.restore_route_snapshot(router.routes)
 
         # Cache the routing result (if caching enabled and routing succeeded)
         if use_cache and cache_key is not None and router.routes:
@@ -16317,7 +16330,13 @@ def _main_impl(argv: list[str] | None = None) -> int:
                     int((time.time() - routing_start_time) * 1000) if routing_start_time else 0
                 )
                 stats = router.get_statistics()
-                cache.put(cache_key, router.routes, stats, routing_time_ms)
+                cache.put(
+                    cache_key,
+                    router.routes,
+                    stats,
+                    routing_time_ms,
+                    route_usage=router.grid.export_route_usage(),
+                )
                 if not quiet:
                     print(f"  Cached routing result ({routing_time_ms}ms compute time)")
             except Exception as e:

--- a/src/kicad_tools/router/cache.py
+++ b/src/kicad_tools/router/cache.py
@@ -61,7 +61,7 @@ def routing_cache_context(options: Mapping[str, object], net_class_map: dict) ->
 # Bump this constant whenever routing logic is modified to ensure stale
 # cached results are not reused.  The value is included in every cache key
 # so incrementing it automatically invalidates all existing entries.
-CACHE_VERSION = "2.3.0"
+CACHE_VERSION = "2.3.1"
 
 
 def get_default_cache_path() -> Path:

--- a/src/kicad_tools/router/cache.py
+++ b/src/kicad_tools/router/cache.py
@@ -61,7 +61,7 @@ def routing_cache_context(options: Mapping[str, object], net_class_map: dict) ->
 # Bump this constant whenever routing logic is modified to ensure stale
 # cached results are not reused.  The value is included in every cache key
 # so incrementing it automatically invalidates all existing entries.
-CACHE_VERSION = "2.2.0"
+CACHE_VERSION = "2.3.0"
 
 
 def get_default_cache_path() -> Path:
@@ -740,7 +740,7 @@ class RoutingCache:
         created_time = datetime.fromisoformat(created_at)
         return datetime.now() - created_time > self.ttl
 
-    def serialize_routes(self, routes: list[Route]) -> bytes:
+    def serialize_routes(self, routes: list[Route], *, route_usage: dict | None = None) -> bytes:
         """Serialize routes to compressed bytes for storage.
 
         Args:
@@ -755,6 +755,7 @@ class RoutingCache:
             route_dict = {
                 "net": route.net,
                 "net_name": route.net_name,
+                "is_escape": route.is_escape,
                 "segments": [
                     {
                         "x1": seg.x1,
@@ -792,8 +793,23 @@ class RoutingCache:
             }
             routes_data.append(route_dict)
 
-        json_bytes = json.dumps(routes_data).encode("utf-8")
+        payload = (
+            routes_data
+            if route_usage is None
+            else {"routes": routes_data, "route_usage": route_usage}
+        )
+        json_bytes = json.dumps(payload).encode("utf-8")
         return zlib.compress(json_bytes)
+
+    @staticmethod
+    def deserialize_route_usage(data: bytes) -> dict:
+        """Read the full-run congestion snapshot; legacy entries are misses."""
+        payload = json.loads(zlib.decompress(data))
+        if not isinstance(payload, dict) or not isinstance(payload.get("route_usage"), dict):
+            raise ValueError("Cached routes have no congestion snapshot")
+        usage = payload["route_usage"]
+        assert isinstance(usage, dict)
+        return usage
 
     def deserialize_routes(self, data: bytes) -> list[Route]:
         """Deserialize routes from compressed bytes.
@@ -808,7 +824,8 @@ class RoutingCache:
         from .primitives import Route, Segment, Via
 
         json_bytes = zlib.decompress(data)
-        routes_data = json.loads(json_bytes.decode("utf-8"))
+        payload = json.loads(json_bytes.decode("utf-8"))
+        routes_data = payload["routes"] if isinstance(payload, dict) else payload
 
         routes = []
         for route_dict in routes_data:
@@ -847,6 +864,7 @@ class RoutingCache:
                 net_name=route_dict["net_name"],
                 segments=segments,
                 vias=vias,
+                is_escape=route_dict.get("is_escape", False),
             )
             routes.append(route)
 
@@ -906,6 +924,8 @@ class RoutingCache:
         routes: list[Route],
         statistics: dict,
         compute_time_ms: int = 0,
+        *,
+        route_usage: dict | None = None,
     ) -> None:
         """
         Store routing result in cache.
@@ -916,7 +936,7 @@ class RoutingCache:
             statistics: Routing statistics dict
             compute_time_ms: Time taken for routing in milliseconds
         """
-        routes_data = self.serialize_routes(routes)
+        routes_data = self.serialize_routes(routes, route_usage=route_usage)
         data_size = len(routes_data)
         now = datetime.now().isoformat()
 

--- a/src/kicad_tools/router/core.py
+++ b/src/kicad_tools/router/core.py
@@ -1923,6 +1923,29 @@ class Autorouter:
         if hasattr(self.router, "update_layer_fill_ratios"):
             self.router.update_layer_fill_ratios()
 
+    def restore_route_snapshot(self, routes: list[Route]) -> None:
+        """Replace managed copper while retaining fixed input-board copper.
+
+        Best-iteration rollback and cache replay must update the same grids,
+        indexes and pathfinder caches. Negotiated usage is restored separately
+        by the caller, since ordinary routing does not populate those counts.
+        """
+        restored = list(routes)
+        fixed_ids = {id(route) for route in self.existing_routes}
+        self.grid.resync_route_occupancy(
+            [(route, None) for route in list(self.grid.routes) if id(route) not in fixed_ids]
+            + [(None, route) for route in restored]
+        )
+        self.routes[:] = restored
+        if hasattr(self.router, "clear_routed_segments") and hasattr(
+            self.router, "add_routed_segments"
+        ):
+            self.router.clear_routed_segments()
+            for route in self.grid.routes:
+                self.router.add_routed_segments(route.segments)
+        if hasattr(self.router, "update_layer_fill_ratios"):
+            self.router.update_layer_fill_ratios()
+
     @property
     def physics_available(self) -> bool:
         """Check if physics calculations are available."""
@@ -12367,8 +12390,7 @@ class Autorouter:
                 for route in list(self.routes):
                     self.grid.unmark_route_usage(route)
                 # Replace with best-state routes
-                self.routes.clear()
-                self.routes.extend(best_routes)
+                self.restore_route_snapshot(best_routes)
                 # Re-mark best routes on the grid
                 for route in self.routes:
                     self.grid.mark_route_usage(route)

--- a/src/kicad_tools/router/core.py
+++ b/src/kicad_tools/router/core.py
@@ -1923,17 +1923,23 @@ class Autorouter:
         if hasattr(self.router, "update_layer_fill_ratios"):
             self.router.update_layer_fill_ratios()
 
-    def restore_route_snapshot(self, routes: list[Route]) -> None:
+    def restore_route_snapshot(
+        self, routes: list[Route], *, replaced_routes: list[Route] | None = None
+    ) -> None:
         """Replace managed copper while retaining fixed input-board copper.
 
         Best-iteration rollback and cache replay must update the same grids,
         indexes and pathfinder caches. Negotiated usage is restored separately
         by the caller, since ordinary routing does not populate those counts.
+        Negotiated rollback supplies the routes it owns so independently
+        registered grid obstacles survive. Cache replay replaces the complete
+        managed snapshot, including discarded grid routes absent from self.routes.
         """
         restored = list(routes)
         fixed_ids = {id(route) for route in self.existing_routes}
+        replaced = list(self.grid.routes) if replaced_routes is None else list(replaced_routes)
         self.grid.resync_route_occupancy(
-            [(route, None) for route in list(self.grid.routes) if id(route) not in fixed_ids]
+            [(route, None) for route in replaced if id(route) not in fixed_ids]
             + [(None, route) for route in restored]
         )
         self.routes[:] = restored
@@ -12648,9 +12654,10 @@ class Autorouter:
 
     def _restore_negotiated_route_snapshot(self, restored_routes: list[Route]) -> None:
         """Restore all route state and negotiated usage after a best-state rollback."""
-        for route in list(self.routes):
+        stale_routes = list(self.routes)
+        for route in stale_routes:
             self.grid.unmark_route_usage(route)
-        self.restore_route_snapshot(restored_routes)
+        self.restore_route_snapshot(restored_routes, replaced_routes=stale_routes)
         for route in self.routes:
             self.grid.mark_route_usage(route)
 

--- a/src/kicad_tools/router/grid.py
+++ b/src/kicad_tools/router/grid.py
@@ -30,6 +30,7 @@ Thread Safety:
 
 from __future__ import annotations
 
+import base64
 import logging
 import math
 import threading
@@ -5303,6 +5304,27 @@ class RoutingGrid:
     # =========================================================================
     # NEGOTIATED CONGESTION ROUTING SUPPORT
     # =========================================================================
+
+    def export_route_usage(self) -> dict[str, Any]:
+        """Capture exact congestion counts, including all-zero basic routing."""
+        with self._acquire_lock():
+            counts = to_numpy(self._usage_count).astype("<i2", copy=False)
+            return {
+                "shape": list(counts.shape),
+                "counts": base64.b64encode(counts.tobytes()).decode("ascii"),
+            }
+
+    def import_route_usage(self, state: dict[str, Any]) -> None:
+        """Validate and restore a cache snapshot without guessing a strategy."""
+        if state.get("shape") != list(self._usage_count.shape):
+            raise ValueError("Cached congestion grid dimensions do not match routing grid")
+        raw = base64.b64decode(state["counts"], validate=True)
+        expected = math.prod(self._usage_count.shape) * 2
+        if len(raw) != expected:
+            raise ValueError("Cached congestion grid byte count does not match routing grid")
+        counts = np.frombuffer(raw, dtype="<i2").reshape(self._usage_count.shape)
+        with self._acquire_lock():
+            self._usage_count[...] = self._backend.asarray(counts)
 
     def reset_route_usage(self) -> None:
         """Reset all usage counts (start of new negotiation iteration).

--- a/src/kicad_tools/router/pathfinder.py
+++ b/src/kicad_tools/router/pathfinder.py
@@ -833,6 +833,9 @@ class Router:
         have been removed.
         """
         self._routed_segments.clear()
+        # Buckets hold indices into the cleared list; retaining them can
+        # miss relocated routes or dereference entries that no longer exist.
+        self._crossing_grid = None
 
     def get_via_diagnostics(self) -> dict[str, int]:
         """Return via placement diagnostic counters (Issue #2325).

--- a/tests/router/test_route_cache_equivalence.py
+++ b/tests/router/test_route_cache_equivalence.py
@@ -75,6 +75,8 @@ def test_board02_cache_replays_complete_copper(tmp_path):
             )
         evidence = log.read_text()
         assert ("Cache MISS" if run == 1 else "Cache HIT") in evidence, evidence[-2000:]
+        if run == 2:
+            assert "Using cached result (skipping routing)" in evidence, evidence[-2000:]
         assert output.exists(), evidence[-2000:]
         copper.append(_copper(output.read_text()))
     assert copper[0]

--- a/tests/router/test_route_cache_equivalence.py
+++ b/tests/router/test_route_cache_equivalence.py
@@ -1,0 +1,81 @@
+"""Cache replay must preserve physical copper, not merely route counts."""
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from kicad_tools.export import find_kicad_cli
+from kicad_tools.sexp import SExp, parse_string
+
+
+def _copper(text: str) -> list[str]:
+    def canonical(node: SExp):
+        if node.name is None:
+            return node.value
+        return [
+            node.name,
+            *[canonical(c) for c in node.children if c.name not in {"uuid", "tstamp"}],
+        ]
+
+    return sorted(
+        json.dumps(canonical(node))
+        for node in parse_string(text).children
+        if node.name in {"segment", "via", "arc"}
+    )
+
+
+@pytest.mark.timeout(600)
+def test_board02_cache_replays_complete_copper(tmp_path):
+    if find_kicad_cli() is None:
+        pytest.skip("Native KiCad is required for the final copper comparison")
+    root = Path(__file__).resolve().parents[2]
+    source = root / "boards/02-charlieplex-led/output/charlieplex_3x3.kicad_pcb"
+    env = {**os.environ, "PYTHONHASHSEED": "42", "XDG_CACHE_HOME": str(tmp_path / "cache")}
+    copper = []
+    for run in (1, 2):
+        output = tmp_path / f"run-{run}.kicad_pcb"
+        log = tmp_path / f"run-{run}.log"
+        cmd = [
+            sys.executable,
+            "-m",
+            "kicad_tools.cli",
+            "route",
+            str(source),
+            "--output",
+            str(output),
+            "--strategy",
+            "negotiated",
+            "--iterations",
+            "30",
+            "--deterministic-budget",
+            "--timeout",
+            "240",
+            "--seed",
+            "42",
+            "--no-auto-pour",
+            "--no-auto-layers",
+            "--grid",
+            "0.1",
+            "--manufacturer",
+            "jlcpcb",
+        ]
+        with log.open("w") as stream:
+            subprocess.run(
+                cmd,
+                cwd=root,
+                env=env,
+                stdout=stream,
+                stderr=subprocess.STDOUT,
+                timeout=280,
+                check=False,
+            )
+        evidence = log.read_text()
+        assert ("Cache MISS" if run == 1 else "Cache HIT") in evidence, evidence[-2000:]
+        assert output.exists(), evidence[-2000:]
+        copper.append(_copper(output.read_text()))
+    assert copper[0]
+    assert copper[0] == copper[1], f"Cache changed copper; artifacts at {tmp_path}"

--- a/tests/test_route_all_negotiated_overflow_regression.py
+++ b/tests/test_route_all_negotiated_overflow_regression.py
@@ -286,10 +286,10 @@ class TestOverflowRegressionRollback:
         ar.grid.mark_route(fixed)
         restore_snapshot = ar.restore_route_snapshot
 
-        def check_restored_occupancy(winner):
+        def check_restored_occupancy(winner, *, replaced_routes=None):
             discarded_ids = {id(route) for route in ar.routes}
             assert winner and discarded_ids.isdisjoint(id(route) for route in winner)
-            restore_snapshot(winner)
+            restore_snapshot(winner, replaced_routes=replaced_routes)
             assert {id(route) for route in ar.grid.routes} == {
                 id(fixed),
                 *(id(route) for route in winner),

--- a/tests/test_route_all_negotiated_overflow_regression.py
+++ b/tests/test_route_all_negotiated_overflow_regression.py
@@ -28,6 +28,7 @@ from unittest.mock import patch
 import pytest
 
 from kicad_tools.router.core import Autorouter, IterationMetrics
+from kicad_tools.router.layers import Layer
 from kicad_tools.router.primitives import Route, Segment
 
 # =============================================================================
@@ -278,13 +279,40 @@ class TestOverflowRegressionRollback:
         reported overflow climbs but the routed-net count stays equal.
         """
         ar = trivial_autorouter
+        fixed = Route(
+            net=99, net_name="FIXED", segments=[Segment(2, 1, 18, 1, 0.2, Layer.F_CU, net=99)]
+        )
+        ar.existing_routes.append(fixed)
+        ar.grid.mark_route(fixed)
+        restore_snapshot = ar.restore_route_snapshot
+
+        def check_restored_occupancy(winner):
+            discarded_ids = {id(route) for route in ar.routes}
+            assert winner and discarded_ids.isdisjoint(id(route) for route in winner)
+            restore_snapshot(winner)
+            assert {id(route) for route in ar.grid.routes} == {
+                id(fixed),
+                *(id(route) for route in winner),
+            }
+            assert all(id(route) not in discarded_ids for route in ar.grid.routes)
+            assert ar.routes == winner
+
         # Mock get_total_overflow to return a regression sequence:
         #   index 0 (initial pass): overflow=16
         #   index 1+ (iteration 1): overflow=36
         # The router will see iter-0 as 16, iter-1 as 36, and on exit
         # must restore the iter-0 snapshot.
         seq = _OverflowSequenceGrid(ar.grid, sequence=[16, 36, 36, 36, 36])
-        with patch.object(ar.grid, "get_total_overflow", side_effect=seq):
+        with (
+            patch.object(ar.grid, "get_total_overflow", side_effect=seq),
+            patch.object(
+                ar, "restore_route_snapshot", side_effect=check_restored_occupancy
+            ) as restore,
+            patch(
+                "kicad_tools.router.core.NegotiatedRouter.find_nets_through_overused_cells",
+                return_value={1, 2},
+            ),
+        ):
             ar.route_all_negotiated(
                 max_iterations=2,
                 timeout=10.0,
@@ -292,6 +320,7 @@ class TestOverflowRegressionRollback:
                 perturbation=False,
             )
 
+        restore.assert_called_once()
         captured = capsys.readouterr()
         out = captured.out
 

--- a/tests/test_route_snapshot_cache.py
+++ b/tests/test_route_snapshot_cache.py
@@ -139,3 +139,30 @@ def test_cli_cache_apply_failure_never_routes_or_publishes(
     assert geometry.call_count == (failure_stage == "geometry")
     search.assert_not_called()
     assert not output.exists()
+
+
+@pytest.mark.parametrize("replacement_y", [None, 5])
+def test_snapshot_replay_invalidates_built_crossing_index(replacement_y):
+    ar = Autorouter(width=20, height=20, force_python=True)
+    old = _route(12)
+    ar._mark_route(old)
+    ar.routes.append(old)
+
+    def crossings(y):
+        x1, y1 = ar.grid.world_to_grid(10, y - 1)
+        x2, y2 = ar.grid.world_to_grid(10, y + 1)
+        layer = ar.grid.layer_to_index(Layer.F_CU.value)
+        return ar.router._count_edge_crossings(x1, y1, x2, y2, layer, 2)
+
+    ar.router._build_crossing_grid()
+    assert crossings(12) == 1
+    replacement = [] if replacement_y is None else [_route(replacement_y)]
+    ar.restore_route_snapshot(replacement)
+    assert crossings(12) == 0
+    if replacement_y is not None:
+        assert crossings(replacement_y) == 1
+    # A freshly rebuilt index must agree with the immediate replay state.
+    ar.router._build_crossing_grid()
+    assert crossings(12) == 0
+    if replacement_y is not None:
+        assert crossings(replacement_y) == 1

--- a/tests/test_route_snapshot_cache.py
+++ b/tests/test_route_snapshot_cache.py
@@ -1,0 +1,141 @@
+"""Physical occupancy and congestion must survive cache/best-state replay."""
+
+import copy
+
+import numpy as np
+import pytest
+
+from kicad_tools.router import Autorouter, Route, RoutingCache, Segment
+from kicad_tools.router.layers import Layer
+
+
+def _route(y, net=1):
+    return Route(
+        net=net,
+        net_name=f"N{net}",
+        segments=[
+            Segment(2, y, 18, y, 0.2, Layer.F_CU, net=net),
+        ],
+    )
+
+
+def _router():
+    ar = Autorouter(width=20, height=20, force_python=True)
+    fixed = _route(2, 99)
+    ar.existing_routes.append(fixed)
+    ar.grid.mark_route(fixed)
+    return ar, fixed
+
+
+@pytest.mark.parametrize("negotiated", [False, True])
+def test_snapshot_replay_preserves_fixed_copper_and_exact_usage(tmp_path, negotiated):
+    expected, expected_fixed = _router()
+    winner = [_route(8), _route(8)]
+    for route in winner:
+        expected._mark_route(route)
+        if negotiated:
+            expected.grid.mark_route_usage(route)
+    expected.routes[:] = winner
+    expected.restore_route_snapshot(winner)
+    usage = expected.grid.export_route_usage()
+    cache = RoutingCache(cache_dir=tmp_path)
+    payload = cache.serialize_routes(winner, route_usage=usage)
+
+    cold, fixed = _router()
+    loser = _route(12)
+    cold._mark_route(loser)
+    cold.grid.mark_route_usage(loser)
+    cold.routes.append(loser)
+    before_fixed = copy.deepcopy(fixed)
+    cold.grid.import_route_usage(cache.deserialize_route_usage(payload))
+    cold.restore_route_snapshot(cache.deserialize_routes(payload))
+
+    assert fixed == before_fixed
+    assert any(route is fixed for route in cold.grid.routes)
+    assert not any(route is loser for route in cold.grid.routes)
+    assert cold.routes == winner
+    for name in ("_blocked", "_net", "_usage_count"):
+        np.testing.assert_array_equal(getattr(cold.grid, name), getattr(expected.grid, name))
+    assert cold.router._routed_segments == expected.router._routed_segments
+    assert (cold.grid.get_total_overflow() > 0) is negotiated
+    assert expected_fixed.segments == fixed.segments
+
+
+@pytest.mark.parametrize("damage", ["shape", "counts", "encoding"])
+def test_bad_usage_snapshot_does_not_mutate_grid(damage):
+    router, _ = _router()
+    router.grid.mark_route_usage(_route(8))
+    before = router.grid._usage_count.copy()
+    state = router.grid.export_route_usage()
+    if damage == "shape":
+        state["shape"][0] += 1
+    elif damage == "counts":
+        state["counts"] = ""
+    else:
+        state["counts"] = "not base64!"
+    with pytest.raises(ValueError):
+        router.grid.import_route_usage(state)
+    np.testing.assert_array_equal(router.grid._usage_count, before)
+
+
+def test_legacy_cache_entry_has_no_replayable_usage(tmp_path):
+    cache = RoutingCache(cache_dir=tmp_path)
+    payload = cache.serialize_routes([_route(8)])
+    assert cache.deserialize_routes(payload)
+    with pytest.raises(ValueError, match="no congestion snapshot"):
+        cache.deserialize_route_usage(payload)
+
+
+@pytest.mark.parametrize("failure_stage", ["usage", "geometry"])
+def test_cli_cache_apply_failure_never_routes_or_publishes(
+    tmp_path, monkeypatch, capsys, failure_stage
+):
+    from pathlib import Path
+    from types import SimpleNamespace
+    from unittest.mock import Mock
+
+    from kicad_tools.cli import route_cmd
+    from kicad_tools.router.grid import RoutingGrid
+
+    monkeypatch.setenv("XDG_CACHE_HOME", str(tmp_path / "cache"))
+    payload = RoutingCache(cache_dir=tmp_path / "cache").serialize_routes([], route_usage={})
+    entry = SimpleNamespace(
+        routes_data=payload,
+        success_count=0,
+        total_segments=0,
+        total_vias=0,
+        compute_time_ms=1,
+    )
+    monkeypatch.setattr(RoutingCache, "get", lambda *_: entry)
+    usage = Mock(
+        side_effect=RuntimeError("injected usage failure") if failure_stage == "usage" else None
+    )
+    geometry = Mock(side_effect=RuntimeError("injected geometry failure"))
+    search = Mock(side_effect=AssertionError("fresh routing after partial cache apply"))
+    monkeypatch.setattr(RoutingGrid, "import_route_usage", usage)
+    monkeypatch.setattr(Autorouter, "restore_route_snapshot", geometry)
+    monkeypatch.setattr(Autorouter, "route_all_negotiated", search)
+    source = (
+        Path(__file__).resolve().parents[1]
+        / "boards/02-charlieplex-led/output/charlieplex_3x3.kicad_pcb"
+    )
+    output = tmp_path / "must-not-exist.kicad_pcb"
+    result = route_cmd._in_process_main(
+        [
+            str(source),
+            "--output",
+            str(output),
+            "--strategy",
+            "negotiated",
+            "--no-auto-pour",
+            "--no-auto-layers",
+            "--grid",
+            "0.1",
+        ]
+    )
+    assert result == 1
+    assert "cannot restore cached routing state" in capsys.readouterr().err
+    usage.assert_called_once()
+    assert geometry.call_count == (failure_stage == "geometry")
+    search.assert_not_called()
+    assert not output.exists()

--- a/tests/test_router_cache.py
+++ b/tests/test_router_cache.py
@@ -351,6 +351,11 @@ class TestRoutingCache:
         assert len(routes[1].vias) == 1
         assert routes[1].vias[0].drill == 0.3
 
+    def test_cache_round_trip_preserves_escape_route_identity(self, temp_cache, sample_routes):
+        sample_routes[0].is_escape = True
+        restored = temp_cache.deserialize_routes(temp_cache.serialize_routes(sample_routes))
+        assert restored == sample_routes
+
     def test_serialize_preserves_data(self, temp_cache, sample_routes):
         """Test that serialization preserves all route data."""
         data = temp_cache.serialize_routes(sample_routes)


### PR DESCRIPTION
A cold routing run and a cache hit could produce different physical copper because best-iteration rollback restored the route list while leaving discarded geometry in occupancy indexes, and cache replay restored neither occupancy nor congestion. Restore routes through a shared boundary that retains fixed input copper, rebuilds occupancy and pathfinder caches (including the crossing index), and replays exact congestion counts. Cache application failures stop before fresh routing or output publication.

The integration with merged #5165 makes its negotiated rollback helper use that shared boundary. Rollback supplies the managed routes it replaces, retaining independently registered grid obstacles; cache replay replaces the full managed snapshot, including discarded routes absent from the current route list. Congestion remains a separate snapshot. Cache version 2.4.1 invalidates both parents and preserves escape-route identity.

The Board02 integration test compares complete segment/via/arc geometry across explicit cache MISS/HIT runs with production recipe flags, retaining nets, layers, widths, and multiplicity while excluding only UUID/timestamp identity. Unit coverage checks preserved and independent copper, discarded routes, basic versus negotiated congestion, malformed snapshots, CLI application failures, and actual best-iteration rollback.

Validation at `60a07a7ff589d1d4dfebeadf7eb5211a098de87b`:

- 296 native-enabled regression tests passed in 42.93s, with zero skips/failures/errors in JUnit. Includes negotiated geometry/deferral, preserved obstacles, crossing caches, pad-shape bindings, via transactions, and deadline controls.
- Real Board02 cold/warm comparison passed in 179.35s. Complete copper matches, both runs connect 12/12 nets, and both report five DRC errors and 62 warnings. This establishes cache equivalence, not manufacturing readiness.
- 91 targeted host tests passed after the ownership correction. The pathfinder control fails with main's previous rollback helper; all four independent-obstacle geometry cases failed in the initial integration and pass after correcting replacement ownership. Existing assertions were retained; the rollback spy now forwards the ownership keyword.
- All nine changed Python files pass Ruff lint/format; whitespace passes. Mypy reports 1,422 diagnostics within the unchanged 1,472 baseline, with no new errors.
- Frozen Linux amd64, KiCad 10.0.5, Python3.12, four configured CPUs. Native interface23 and placement binaries were freshly built from integration `f419196e`; final changes affect only Python core and a test spy. Native build sources and frozen lockfile are byte-identical, with recorded extension hashes. All 3,683 archived regular source files match after testing; five omitted repository symlinks are recorded.

Evidence: `/tmp/kicad-5265-main-native-60a07a7f/`, including source/extension provenance, JUnit, complete boards/logs, and final hash verification. The initial failed integration evidence remains separately preserved at `/tmp/kicad-5265-main-native-f419196e/`. Fresh CI and final exact-head Judge review are required.

Closes #5261.
