### PR TITLE
ci: require native mask-to-copper tests without skips

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -207,6 +207,20 @@ jobs:
         # 120-second subprocess cap and every manufacturing assertion.
         run: uv run pytest tests/test_board_05_drc_allowlist.py -o addopts= --benchmark-disable --timeout=60 -m "not slow"
 
+      - name: Run native mask-to-copper gate
+        env:
+          KCT_MASK_NATIVE_PYTHON: '["/usr/bin/python3"]'
+        run: uv run --frozen python scripts/ci/check_mask_copper_native.py --artifacts "$RUNNER_TEMP/mask-copper-native"
+
+      - name: Retain native mask diagnostics
+        if: ${{ failure() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: mask-copper-native-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ runner.temp }}/mask-copper-native/
+          if-no-files-found: ignore
+          retention-days: 7
+
       - name: Run tests
         # Issue #3436: continue-on-error was removed from this step. It
         # made the job green regardless of pytest's exit code, hiding 162
@@ -220,7 +234,7 @@ jobs:
         env:
           BOARD_07_CI_ENABLED: ${{ vars.BOARD_07_CI_ENABLED }}
         run: |
-          test_args=(--ignore=tests/test_board_05_drc_allowlist.py)
+          test_args=(--ignore=tests/test_board_05_drc_allowlist.py --ignore=tests/test_mask_copper_native.py)
           if [[ "$BOARD_07_CI_ENABLED" != "true" ]]; then
             test_args+=(--ignore=tests/test_board_07_matchgroup_test.py)
           fi

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -35,6 +35,21 @@ end-to-end checks, the mypy baseline, and route determinism:
 `local-gate.sh` (local CI-equivalent gate, Actions-outage backstop),
 `net_class_map_resolver.py`.
 
+`check_mask_copper_native.py` is the repository's mandatory native mask-to-copper
+suite gate. It probes matching KiCad 10.0.5 CLI/pcbnew and Gerbonara >=1.6.3,
+runs every case in `tests/test_mask_copper_native.py`, and rejects failures,
+empty results, missing material witnesses, or any skips. For a local equivalent
+in a KiCad environment with shared scratch paths:
+
+```bash
+KCT_MASK_NATIVE_PYTHON='["/usr/bin/python3"]' uv run --frozen python scripts/ci/check_mask_copper_native.py --artifacts /tmp/mask-copper-native
+```
+
+Each invocation retains a new run directory containing prerequisite details,
+pytest output, JUnit, and generated native artifacts. Ordinary local pytest
+execution keeps its optional-prerequisite skips. CI runs this dedicated gate
+once and excludes the file from the later general suite.
+
 ### `corpus/`
 
 Opt-in, **local-only** tooling for external KiCad corpora (network I/O; never

--- a/scripts/ci/check_mask_copper_native.py
+++ b/scripts/ci/check_mask_copper_native.py
@@ -1,0 +1,151 @@
+#!/usr/bin/env python3
+"""Run the complete native mask suite with mandatory prerequisites and no skips."""
+
+from __future__ import annotations
+
+import argparse
+import importlib.metadata
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import xml.etree.ElementTree as ET
+from pathlib import Path
+
+from packaging.version import Version
+
+from kicad_tools.cli.runner import find_kicad_cli
+
+ROOT = Path(__file__).resolve().parents[2]
+SUITE = "tests/test_mask_copper_native.py"
+REQUIRED_WITNESSES = {
+    "test_native_merged_bridge_exposes_third_copper_with_multiple_contributors",
+    "test_native_repeated_pad_numbers_do_not_share_owner_exclusion",
+}
+
+
+def probe(directory: Path) -> dict:
+    """Check the actual interpreters, oracle, versions, and shared scratch path."""
+    command = json.loads(os.environ.get("KCT_MASK_NATIVE_PYTHON", "null"))
+    if (
+        not isinstance(command, list)
+        or not command
+        or any(not isinstance(arg, str) or not arg for arg in command)
+    ):
+        raise ValueError("KCT_MASK_NATIVE_PYTHON must be a nonempty JSON argv")
+    cli = find_kicad_cli()
+    if cli is None:
+        raise ValueError("KiCad CLI is unavailable")
+    import gerbonara  # noqa: F401 -- prove importability, not just distribution metadata
+
+    oracle = importlib.metadata.version("gerbonara")
+    if Version(oracle) < Version("1.6.3"):
+        raise ValueError(f"Gerbonara >=1.6.3 required; found {oracle}")
+    marker = directory / "native-path-probe.txt"
+    native = subprocess.check_output(
+        [
+            *command,
+            "-c",
+            "import pcbnew,sys; from pathlib import Path; "
+            "Path(sys.argv[1]).write_text('shared'); "
+            "print(pcbnew.GetBuildVersion())",
+            str(marker),
+        ],
+        text=True,
+        stderr=subprocess.STDOUT,
+        timeout=30,
+    ).strip()
+    cli_version = subprocess.check_output(
+        [str(cli), "--version"], text=True, stderr=subprocess.STDOUT, timeout=30
+    ).strip()
+    info = {
+        "pytest_python": sys.executable,
+        "native_python_argv": command,
+        "pcbnew_version": native,
+        "kicad_cli": str(cli),
+        "kicad_cli_version": cli_version,
+        "gerbonara_version": oracle,
+    }
+    print(json.dumps(info, indent=2), flush=True)
+    # Match the checker profile in validate/mask_copper_geometry.py. A newer
+    # image must be qualified there before this dedicated gate can pass.
+    if native.split()[:1] != ["10.0.5"] or cli_version.split()[:1] != native.split()[:1]:
+        raise ValueError("Native mask checks require a matching KiCad 10.0.5 CLI/pcbnew pair")
+    if marker.read_text() != "shared":
+        raise ValueError("Native Python does not share the pytest scratch path")
+    return info
+
+
+def validate_results(report: Path) -> int:
+    """Require executed, successful cases and both named material witnesses."""
+    root = ET.parse(report).getroot()
+    for suite in root.iter("testsuite"):
+        if any(int(suite.get(key, "0")) for key in ("failures", "errors", "skipped")):
+            raise ValueError("Native suite reports failures, errors, or skips")
+    cases = list(root.iter("testcase"))
+    if not cases:
+        raise ValueError("Native suite produced no test cases")
+    for case in cases:
+        if any(case.find(tag) is not None for tag in ("failure", "error", "skipped")):
+            raise ValueError(f"Native case did not pass: {case.get('name')}")
+    names = {case.get("name", "").split("[")[0] for case in cases}
+    missing = REQUIRED_WITNESSES - names
+    if missing:
+        raise ValueError(f"Required material witnesses were not executed: {sorted(missing)}")
+    return len(cases)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--artifacts", type=Path, required=True)
+    args = parser.parse_args(argv)
+    args.artifacts.mkdir(parents=True, exist_ok=True)
+    directory = Path(tempfile.mkdtemp(prefix="run-", dir=args.artifacts.resolve()))
+    print(f"Native mask artifacts: {directory}", flush=True)
+    report = directory / "junit.xml"
+    try:
+        info = probe(directory)
+        (directory / "prerequisites.json").write_text(json.dumps(info, indent=2))
+        env = dict(os.environ)
+        env.pop("PYTEST_ADDOPTS", None)
+        command = [
+            sys.executable,
+            "-m",
+            "pytest",
+            SUITE,
+            "-o",
+            "addopts=",
+            "--no-cov",
+            "--benchmark-disable",
+            "--timeout=180",
+            "--junitxml",
+            str(report),
+            "--basetemp",
+            str(directory / "pytest"),
+        ]
+        with (directory / "pytest.log").open("w") as output:
+            result = subprocess.run(
+                command,
+                cwd=ROOT,
+                env=env,
+                stdout=output,
+                stderr=subprocess.STDOUT,
+                timeout=900,
+                check=False,
+            )
+        print((directory / "pytest.log").read_text(), flush=True)
+        if result.returncode:
+            raise ValueError(f"Native pytest exited {result.returncode}")
+        count = validate_results(report)
+        print(f"Native mask gate passed: {count} cases, no skips", flush=True)
+        return 0
+    except (OSError, ValueError, ImportError, subprocess.SubprocessError, ET.ParseError) as exc:
+        message = f"Native mask gate failed: {exc}"
+        (directory / "gate-error.txt").write_text(message + "\n")
+        print(message, file=sys.stderr, flush=True)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_ci_mask_copper_native.py
+++ b/tests/test_ci_mask_copper_native.py
@@ -1,0 +1,117 @@
+"""The native CI gate must reject unavailable prerequisites and incomplete runs."""
+
+import importlib.util
+import json
+import subprocess
+import sys
+import xml.etree.ElementTree as ET
+from pathlib import Path
+
+import pytest
+import yaml
+
+ROOT = Path(__file__).resolve().parents[1]
+SPEC = importlib.util.spec_from_file_location(
+    "mask_native_gate", ROOT / "scripts/ci/check_mask_copper_native.py"
+)
+assert SPEC and SPEC.loader
+helper = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(helper)
+
+
+def report(tmp_path, *, bad_tag=None, missing=False):
+    root = ET.Element("testsuites")
+    suite = ET.SubElement(root, "testsuite")
+    names = sorted(helper.REQUIRED_WITNESSES)
+    if missing:
+        names.pop()
+    for name in names:
+        case = ET.SubElement(suite, "testcase", name=name)
+        if bad_tag:
+            ET.SubElement(case, bad_tag)
+    path = tmp_path / "report.xml"
+    ET.ElementTree(root).write(path)
+    return path
+
+
+@pytest.mark.parametrize("tag", ["skipped", "failure", "error"])
+def test_result_guard_rejects_nonpassing_cases(tmp_path, tag):
+    with pytest.raises(ValueError, match="did not pass"):
+        helper.validate_results(report(tmp_path, bad_tag=tag))
+
+
+def test_result_guard_requires_material_witnesses_and_nonempty_collection(tmp_path):
+    with pytest.raises(ValueError, match="witnesses"):
+        helper.validate_results(report(tmp_path, missing=True))
+    path = tmp_path / "empty.xml"
+    path.write_text("<testsuites/>")
+    with pytest.raises(ValueError, match="no test cases"):
+        helper.validate_results(path)
+
+
+def test_result_guard_accepts_additional_parameterizations(tmp_path):
+    path = report(tmp_path)
+    root = ET.parse(path).getroot()
+    ET.SubElement(root[0], "testcase", name="future_case[extra]")
+    ET.ElementTree(root).write(path)
+    assert helper.validate_results(path) == 3
+
+
+@pytest.mark.parametrize("command", [None, '"/usr/bin/python3"', "[]", "[1]", '[""]'])
+def test_invalid_or_missing_native_argv_fails_before_tests(tmp_path, monkeypatch, command):
+    monkeypatch.delenv("KCT_MASK_NATIVE_PYTHON", raising=False)
+    if command is not None:
+        monkeypatch.setenv("KCT_MASK_NATIVE_PYTHON", command)
+    assert helper.main(["--artifacts", str(tmp_path)]) == 1
+    assert list(tmp_path.glob("run-*/gate-error.txt"))
+    assert not list(tmp_path.glob("run-*/junit.xml"))
+
+
+def test_unavailable_cli_fails(tmp_path, monkeypatch):
+    monkeypatch.setenv("KCT_MASK_NATIVE_PYTHON", json.dumps([sys.executable]))
+    monkeypatch.setattr(helper, "find_kicad_cli", lambda: None)
+    assert helper.main(["--artifacts", str(tmp_path)]) == 1
+
+
+def test_unavailable_oracle_fails(tmp_path, monkeypatch):
+    monkeypatch.setenv("KCT_MASK_NATIVE_PYTHON", json.dumps([sys.executable]))
+    monkeypatch.setattr(helper, "find_kicad_cli", lambda: Path("/unused/kicad-cli"))
+    monkeypatch.setitem(sys.modules, "gerbonara", None)
+    assert helper.main(["--artifacts", str(tmp_path)]) == 1
+
+
+@pytest.mark.parametrize(
+    "failure", ["assert False", "import missing_collection_dependency", "skip"]
+)
+def test_real_pytest_failure_is_rejected(tmp_path, failure):
+    test = tmp_path / "test_failure.py"
+    if failure.startswith("import"):
+        test.write_text(failure + "\n")
+    elif failure == "skip":
+        test.write_text("import pytest\ndef test_skip():\n    pytest.skip('deliberate')\n")
+    else:
+        test.write_text("def test_failure():\n    " + failure + "\n")
+    path = tmp_path / "failed.xml"
+    run = subprocess.run(
+        [sys.executable, "-m", "pytest", "-o", "addopts=", str(test), "--junitxml", str(path)],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert (run.returncode == 0) is (failure == "skip")
+    with pytest.raises(ValueError, match="failures|did not pass"):
+        helper.validate_results(path)
+
+
+def test_workflow_runs_full_gate_once_and_retains_diagnostics():
+    workflow = yaml.safe_load((ROOT / ".github/workflows/ci.yml").read_text())
+    steps = workflow["jobs"]["test"]["steps"]
+    gate = next(s for s in steps if s.get("name") == "Run native mask-to-copper gate")
+    assert json.loads(gate["env"]["KCT_MASK_NATIVE_PYTHON"]) == ["/usr/bin/python3"]
+    assert "check_mask_copper_native.py" in gate["run"]
+    assert not gate.get("continue-on-error")
+    general = next(s for s in steps if s.get("name") == "Run tests")
+    assert "--ignore=tests/test_mask_copper_native.py" in general["run"]
+    artifact = next(s for s in steps if s.get("name") == "Retain native mask diagnostics")
+    assert "failure()" in artifact["if"]
+    assert "mask-copper-native/" in artifact["with"]["path"]


### PR DESCRIPTION
The native mask-to-copper tests were silently skipped in CI because their explicit pcbnew interpreter was never configured. The existing KiCad Test job now runs the complete file once through a mandatory serial gate and excludes it from the later general suite.

The gate logs and probes the native Python argv, matching KiCad CLI/pcbnew 10.0.5 versions, Gerbonara availability, and shared scratch paths. It rejects missing prerequisites, collection/test failures, empty results, absent required material witnesses, and any skipped case. Pytest logs, JUnit, prerequisite metadata, and generated native artifacts are retained on failure. Ordinary optional local pytest behavior and production geometry assertions are unchanged.

Validation at `4ab78b805a4a7973c7ede4897a1f24a495a2ecef`:

- The exact workflow gate command passed all 32 native cases, zero skips, in56.78s in the official `kicad/kicad:10.0` image pinned locally by digest `sha256:182c8005cb775a2c448a4c18681d489f1ff472a761885eba3e08b07e3c0564de`, with frozen Python3.12 dependencies. Both required merged-region and repeated-pad-number UUID witnesses executed.
- In that same runtime, removing native Python configuration, making the selected CLI unavailable, and blocking the Gerbonara import each caused the gate to exit1. All16 guard tests passed there, including real pytest failure, collection-error, and skip reports.
- Host guard/workflow validation:69 passed. Ruff lint/format and whitespace pass. Mypy remains1422/1472 with no new errors.
- All3695 archived regular source files matched after validation; five repository symlinks were omitted and recorded. Evidence, raw native artifacts, JUnit, negative-control logs, and image/source hashes are retained in `/tmp/kicad-5259-native-4ab78b80/`.

The workflow still uses the repository's existing image policy; an unsupported future KiCad image fails this gate instead of silently skipping the native suite. Fresh remote CI and independent review remain required.

Closes #5259.
