### PR TITLE
fix(router): preserve split-net copper during match tuning

### DIFF
--- a/src/kicad_tools/router/core.py
+++ b/src/kicad_tools/router/core.py
@@ -16361,14 +16361,31 @@ class Autorouter:
             :func:`tune_match_group_v2` per-group, keyed by
             :attr:`MatchGroup.name`.  The per-member ``result`` values
             are :class:`~kicad_tools.router.match_group_tuning.TuneResult`
-            instances.
+            instances. Returned routes describe complete nets; ``self.routes``
+            retains separate fixed escape fragments when present.
         """
         from .match_group_tuning import TuneResult, tune_match_group_v2
 
         results: dict[str, dict[int, tuple[Route, TuneResult]]] = {}
 
-        # Build routes_by_net lookup from the autorouter's current state.
-        routes_by_net: dict[int, Route] = {r.net: r for r in self.routes}
+        # A net can contain separate escape and channel Route objects. The
+        # tuner needs their complete geometry for lengths and foreign clearance.
+        fragments_by_net: dict[int, list[Route]] = {}
+        for route in self.routes:
+            fragments_by_net.setdefault(route.net, []).append(route)
+        routes_by_net = {
+            net: fragments[0]
+            if len(fragments) == 1
+            else Route(
+                net=net,
+                net_name=fragments[0].net_name,
+                segments=[s for r in fragments for s in r.segments],
+                vias=[v for r in fragments for v in r.vias],
+                is_escape=all(r.is_escape for r in fragments),
+            )
+            for net, fragments in fragments_by_net.items()
+        }
+        fixed_segment_ids = {id(s) for r in self.routes if r.is_escape for s in r.segments}
 
         # Update the match-group skew tracker so the post-tuning results are
         # queryable.  Use the layer-stack count when available, else default
@@ -16494,6 +16511,7 @@ class Autorouter:
             # single-ended path inside tune_match_group_v2 ignores it
             # (see match_group_tuning.py docstring).  We pass it
             # unconditionally so the dispatch is fully transparent here.
+            before_by_net = dict(routes_by_net)
             try:
                 group_results = tune_match_group_v2(
                     group=group,
@@ -16509,6 +16527,7 @@ class Autorouter:
                     board_thickness_mm=board_thickness_mm,
                     num_copper_layers=num_layers,
                     blind_buried_supported=blind_buried_supported,
+                    fixed_segment_ids=fixed_segment_ids,
                 )
             except ValueError as exc:
                 # Defensive: a malformed group (e.g. mixed pair/scalar
@@ -16519,27 +16538,37 @@ class Autorouter:
                 results[group.name] = {}
                 continue
 
-            # Commit any new Route references back into self.routes and the
-            # working ``routes_by_net`` map so subsequent groups' DRC
-            # self-checks see the updated geometry.  Mirrors the
-            # apply_diffpair_length_tuning per-pair commit-back loop.
-            #
-            # Issue #3440: compare against the CURRENT self.routes entry,
-            # not routes_by_net -- the tuner now publishes committed
-            # meanders into routes_by_net in place (the staleness fix),
-            # so ``new_route is not routes_by_net[net_id]`` is False for
-            # every tuned member and the legacy identity guard silently
-            # dropped all meanders from self.routes (they never reached
-            # the saved PCB).
-            for net_id, (new_route, _result) in group_results.items():
-                if net_id not in routes_by_net:
-                    continue  # unrouted member (empty-route placeholder)
-                routes_by_net[net_id] = new_route
-                for i, r in enumerate(self.routes):
-                    if r.net == net_id:
-                        if self.routes[i] is not new_route:
-                            self.routes[i] = new_route
-                        break
+            # The tuner mutates its lookup as members commit. Compare against
+            # the pre-call view, preserving original fragments on no-op/rollback.
+            changed = {
+                net: route
+                for net, (route, _) in group_results.items()
+                if net in before_by_net and route is not before_by_net[net]
+            }
+            routes_by_net.update(changed)
+            if changed:
+                previous_routes = list(self.routes)
+                replacements: dict[int, Route] = {}
+                for net, route in changed.items():
+                    escapes = [r for r in previous_routes if r.net == net and r.is_escape]
+                    escape_via_ids = {id(v) for r in escapes for v in r.vias}
+                    replacements[net] = (
+                        Route(
+                            net=route.net,
+                            net_name=route.net_name,
+                            segments=[s for s in route.segments if id(s) not in fixed_segment_ids],
+                            vias=[v for v in route.vias if id(v) not in escape_via_ids],
+                        )
+                        if escapes
+                        else route
+                    )
+                published: list[Route] = []
+                for fragment in previous_routes:
+                    if fragment.net not in changed or fragment.is_escape:
+                        published.append(fragment)
+                    elif fragment.net in replacements:
+                        published.append(replacements.pop(fragment.net))
+                self.restore_route_snapshot(published, replaced_routes=previous_routes)
 
             results[group.name] = group_results
 

--- a/src/kicad_tools/router/match_group_tuning.py
+++ b/src/kicad_tools/router/match_group_tuning.py
@@ -2587,6 +2587,7 @@ def _tune_match_group_of_pairs(
 
     # --- Measure every member length ------------------------------------
     from .length import LengthTracker  # avoid cycle
+    from .primitives import Route
 
     member_lengths: dict[int, float] = {}
     for net_id in group.net_ids:
@@ -2898,9 +2899,27 @@ def _tune_match_group_of_pairs(
                 outer_normal_hint=hint,
             )
             attempt_generator = SerpentineGenerator(attempt_config)
-            candidate_p_route, p_serp_result = attempt_generator.add_serpentine(
-                current_p, target_length
-            )
+            if fixed_segment_ids:
+                # Honor the selected mutable host. add_serpentine would rank
+                # the full route again and could select a longer fixed escape.
+                p_serp_result = attempt_generator.generate_trombone(
+                    p_insertion_segment, target_length - current_p_length
+                )
+                candidate_p_route = Route(
+                    net=current_p.net,
+                    net_name=current_p.net_name,
+                    segments=(
+                        current_p.segments[:_p_seg_idx]
+                        + p_serp_result.new_segments
+                        + current_p.segments[_p_seg_idx + 1 :]
+                    ),
+                    vias=current_p.vias.copy(),
+                    is_escape=current_p.is_escape,
+                )
+            else:
+                candidate_p_route, p_serp_result = attempt_generator.add_serpentine(
+                    current_p, target_length
+                )
             per_pair_result_p.serpentine_results.append(p_serp_result)
             per_pair_result_n.serpentine_results.append(p_serp_result)
 

--- a/src/kicad_tools/router/match_group_tuning.py
+++ b/src/kicad_tools/router/match_group_tuning.py
@@ -488,6 +488,7 @@ def tune_match_group_v2(
     board_thickness_mm: float | None = None,
     num_copper_layers: int = 4,
     blind_buried_supported: bool = True,
+    fixed_segment_ids: set[int] | None = None,
 ) -> dict[int, tuple[Route, TuneResult]]:
     """Tune the lengths of an N-trace match group to within tolerance.
 
@@ -616,6 +617,10 @@ def tune_match_group_v2(
             had, so ``kct check`` re-derived a nonzero skew from the
             promoted through-vias (board 07 ADDR_BUS 0.000 vs 1.069mm).
             Defaults to ``True`` (legacy partial-span behavior).
+        fixed_segment_ids: Identities of escape segments included in the
+            complete-net view. These contribute length and block foreign
+            copper, but cannot be merged or replaced by a meander. The caller
+            keeps the referenced segments alive throughout tuning.
 
     Returns:
         ``{net_id: (route, result)}`` for every member of ``group``.
@@ -697,6 +702,7 @@ def tune_match_group_v2(
             max_inserts_per_member=max_inserts_per_member,
             length_critical=length_critical,
             grid_resolution_mm=grid_resolution_mm,
+            fixed_segment_ids=fixed_segment_ids,
         )
 
     return _tune_match_group_single_ended(
@@ -715,6 +721,7 @@ def tune_match_group_v2(
         board_thickness_mm=board_thickness_mm,
         num_copper_layers=num_copper_layers,
         blind_buried_supported=blind_buried_supported,
+        fixed_segment_ids=fixed_segment_ids,
     )
 
 
@@ -735,6 +742,7 @@ def _tune_match_group_single_ended(
     board_thickness_mm: float | None = None,
     num_copper_layers: int = 4,
     blind_buried_supported: bool = True,
+    fixed_segment_ids: set[int] | None = None,
 ) -> dict[int, tuple[Route, TuneResult]]:
     """Scalar Phase 2E path: each net in ``group.net_ids`` tuned independently.
 
@@ -985,11 +993,22 @@ def _tune_match_group_single_ended(
         # return the ORIGINAL route reference; the merged route is only
         # ever returned when at least one insert commits.
         if len(route.segments) > 1:
+            # Normalize each mutable run separately. Escape segments must keep
+            # their identity and endpoints, including at collinear boundaries.
+            from itertools import groupby
+
             from .optimizer.algorithms import merge_collinear as _merge_collinear
             from .optimizer.config import OptimizationConfig as _OptConfig
             from .primitives import Route as _RouteForMerge
 
-            merged_segments = _merge_collinear(route.segments, _OptConfig())
+            merged_segments = []
+            for fixed, run in groupby(
+                route.segments, key=lambda segment: id(segment) in (fixed_segment_ids or ())
+            ):
+                segments = list(run)
+                merged_segments.extend(
+                    segments if fixed else _merge_collinear(segments, _OptConfig())
+                )
             if len(merged_segments) < len(route.segments):
                 current_route = _RouteForMerge(
                     net=route.net,
@@ -1049,6 +1068,7 @@ def _tune_match_group_single_ended(
                 current_route,
                 min_segment_length=host_floor,
                 max_candidates=MAX_SEGMENT_RETRY_CANDIDATES,
+                fixed_segment_ids=fixed_segment_ids,
             )
             if not candidates:
                 # Issue #3440 fallback: heavily-jogged routes (post
@@ -1066,6 +1086,7 @@ def _tune_match_group_single_ended(
                         current_route,
                         min_segment_length=host_floor,
                         max_candidates=MAX_SEGMENT_RETRY_CANDIDATES,
+                        fixed_segment_ids=fixed_segment_ids,
                     )
             if not candidates:
                 per_member_result.reason = "no_suitable_segment"
@@ -1343,6 +1364,7 @@ def _rank_candidate_segments(
     route: Route,
     min_segment_length: float,
     max_candidates: int = MAX_SEGMENT_RETRY_CANDIDATES,
+    fixed_segment_ids: set[int] | None = None,
 ) -> list[tuple[int, Segment]]:
     """Return up to ``max_candidates`` segments ranked for trombone insertion.
 
@@ -1395,6 +1417,8 @@ def _rank_candidate_segments(
     last_idx = len(route.segments) - 1
 
     for i, seg in enumerate(route.segments):
+        if fixed_segment_ids and id(seg) in fixed_segment_ids:
+            continue
         dx_full = seg.x2 - seg.x1
         dy_full = seg.y2 - seg.y1
         length = math.sqrt(dx_full * dx_full + dy_full * dy_full)
@@ -2244,6 +2268,7 @@ def _find_corresponding_n_segment(
     p_seg: Segment,
     *,
     max_span_mismatch_mm: float = 0.05,
+    fixed_segment_ids: set[int] | None = None,
 ) -> tuple[int, Segment] | None:
     """Find the N-side segment "corresponding" to ``p_seg``.
 
@@ -2289,6 +2314,8 @@ def _find_corresponding_n_segment(
     best_seg: Segment | None = None
     best_d2 = float("inf")
     for i, nseg in enumerate(n_route.segments):
+        if fixed_segment_ids and id(nseg) in fixed_segment_ids:
+            continue
         if nseg.layer != p_seg.layer:
             continue
         n_length = math.hypot(nseg.x2 - nseg.x1, nseg.y2 - nseg.y1)
@@ -2493,6 +2520,7 @@ def _tune_match_group_of_pairs(
     max_inserts_per_member: int,
     length_critical: bool = True,
     grid_resolution_mm: float = 0.01,
+    fixed_segment_ids: set[int] | None = None,
 ) -> dict[int, tuple[Route, TuneResult]]:
     """Pair-aware Phase 2F path: mirrored serpentine geometry for pair members.
 
@@ -2803,7 +2831,16 @@ def _tune_match_group_of_pairs(
 
             # --- Step 1: pick a P-side segment.
             provisional = SerpentineGenerator(base_config)
-            best = provisional.find_best_segment(current_p)
+            if fixed_segment_ids:
+                hosts = _rank_candidate_segments(
+                    current_p,
+                    base_config.min_segment_length,
+                    max_candidates=1,
+                    fixed_segment_ids=fixed_segment_ids,
+                )
+                best = hosts[0] if hosts else None
+            else:
+                best = provisional.find_best_segment(current_p)
             if best is None:
                 for r in (per_pair_result_p, per_pair_result_n):
                     r.reason = "no_suitable_segment"
@@ -2818,7 +2855,9 @@ def _tune_match_group_of_pairs(
             _p_seg_idx, p_insertion_segment = best
 
             # --- Step 2: find the corresponding N-side segment.
-            n_corr = _find_corresponding_n_segment(current_n, p_insertion_segment)
+            n_corr = _find_corresponding_n_segment(
+                current_n, p_insertion_segment, fixed_segment_ids=fixed_segment_ids
+            )
             if n_corr is None:
                 for r in (per_pair_result_p, per_pair_result_n):
                     r.reason = "no_suitable_segment"
@@ -3036,6 +3075,7 @@ def _tune_match_group_of_pairs(
             config=config,
             max_inserts_per_member=max_inserts_per_member,
             length_critical=True,
+            fixed_segment_ids=fixed_segment_ids,
         )
         for nid, (r_route, r_result) in scalar_results.items():
             results[nid] = (r_route, r_result)

--- a/tests/test_match_group_split_routes.py
+++ b/tests/test_match_group_split_routes.py
@@ -1,0 +1,230 @@
+"""Tuning must preserve the complete copper of nets stored as fragments."""
+
+import copy
+
+import pytest
+from shapely.geometry import LineString, Point
+
+from kicad_tools.router.connectivity_invariant import (
+    enforce_connectivity_invariant,
+    snapshot_connectivity,
+)
+from kicad_tools.router.core import Autorouter
+from kicad_tools.router.layers import Layer
+from kicad_tools.router.length import LengthTracker
+from kicad_tools.router.match_group_length import MatchGroup, MatchGroupSource
+from kicad_tools.router.optimizer import make_collision_checker
+from kicad_tools.router.primitives import Pad, Route, Segment, Via
+from kicad_tools.router.rules import DesignRules
+
+
+def fragment(net, x1, x2, y, *, escape=False):
+    return Route(
+        net=net,
+        net_name=f"D{net}",
+        segments=[Segment(x1, y, x2, y, 0.2, Layer.F_CU, net=net)],
+        is_escape=escape,
+    )
+
+
+def setup_routes(*, force_python=True, escape=True, reference_length=12):
+    ar = Autorouter(
+        width=40,
+        height=40,
+        force_python=force_python,
+        rules=DesignRules(grid_resolution=0.1),
+    )
+    if not force_python and ar.grid._cpp_grid is None:
+        pytest.skip("C++ backend unavailable")
+    ar.net_names = {1: "D1", 2: "D2"}
+    ar.routes = [
+        fragment(1, 5, 6, 10, escape=escape),
+        fragment(1, 6, 15, 10),
+        fragment(2, 5, 6, 30, escape=escape),
+        fragment(2, 6, 5 + reference_length, 30),
+    ]
+    for route in ar.routes:
+        ar._mark_route(route)
+    group = MatchGroup(
+        name="G",
+        net_ids=[1, 2],
+        tolerance=0.1,
+        reference_net_id=2,
+        source=MatchGroupSource.LEGACY_API,
+    )
+    return ar, group
+
+
+def length(ar, net):
+    return sum(LengthTracker.calculate_route_length(r) for r in ar.routes if r.net == net)
+
+
+@pytest.mark.parametrize("force_python", [True, False])
+@pytest.mark.parametrize("escape", [True, False])
+def test_complete_net_tuning_preserves_fragments_and_refreshes_collision_views(
+    force_python, escape
+):
+    ar, group = setup_routes(force_python=force_python, escape=escape)
+    original = list(ar.routes)
+    independent = fragment(9, 2, 3, 35)
+    ar.grid.mark_route(independent)
+    checker = make_collision_checker(ar.grid, ignore_overflow=True)
+    ar.nets = {1: [("U1", "1"), ("U2", "1")]}
+    ar.pads = {
+        key: Pad(
+            x=x,
+            y=10,
+            width=0.4,
+            height=0.4,
+            layer=Layer.F_CU,
+            net=1,
+            net_name="D1",
+            ref=key[0],
+            pin=key[1],
+        )
+        for key, x in zip(ar.nets[1], (5, 15), strict=True)
+    }
+    connectivity = snapshot_connectivity(ar)
+
+    result = ar.apply_match_group_tuning([group], verbose=False)["G"][1][1]
+
+    assert result.reason == "tuned"
+    enforce_connectivity_invariant(
+        ar, connectivity, phase="split-route tuning", strict=True, quiet=True
+    )
+    assert result.length_before_mm == pytest.approx(10)
+    assert length(ar, 1) == pytest.approx(12, abs=0.1)
+    assert result.length_after_mm == pytest.approx(length(ar, 1))
+    assert any(r is original[2] for r in ar.routes)
+    assert any(r is original[3] for r in ar.routes)
+    assert not any(r is original[1] for r in ar.routes)
+    assert sum(r.net == 1 for r in ar.routes) == (2 if escape else 1)
+    if escape:
+        assert any(r is original[0] and r.is_escape for r in ar.routes)
+    assert {id(r) for r in ar.grid.routes} == {id(r) for r in ar.routes} | {id(independent)}
+
+    # Query a new meander segment through a checker created before tuning.
+    segment = next(
+        s
+        for r in ar.routes
+        if r.net == 1
+        for s in r.segments
+        if abs(s.y1 - 10) > 0.3 and abs(s.y2 - 10) > 0.3
+    )
+    assert not checker.path_is_clear(
+        segment.x1, segment.y1, segment.x2, segment.y2, Layer.F_CU, 0.2, 99
+    )
+    gx, gy = ar.grid.world_to_grid((segment.x1 + segment.x2) / 2, (segment.y1 + segment.y2) / 2)
+    assert ar.grid.grid[0][gy][gx].net == 1
+    if not force_python:
+        assert ar.grid._cpp_grid.is_blocked_for_net(gx, gy, 0, 99)
+    if ar.grid._rtree_available:
+        indexed = [s for items in ar.grid._seg_rtree_items.values() for s in items.values()]
+        assert {id(s) for s in indexed} == {id(s) for r in ar.grid.routes for s in r.segments}
+
+    committed = list(ar.routes)
+    ar.apply_match_group_tuning([group], verbose=False)
+    assert [id(r) for r in ar.routes] == [id(r) for r in committed]
+    assert length(ar, 1) == pytest.approx(12, abs=0.1)
+
+
+def test_already_matched_split_routes_are_unchanged():
+    ar, group = setup_routes(reference_length=10)
+    original = list(ar.routes)
+    ar.apply_match_group_tuning([group], verbose=False)
+    assert [id(r) for r in ar.routes] == [id(r) for r in original]
+
+
+def test_escape_only_net_cannot_become_a_completed_route():
+    ar, group = setup_routes()
+    ar.routes[1].is_escape = True
+    original = copy.deepcopy(ar.routes)
+    result = ar.apply_match_group_tuning([group], verbose=False)["G"][1][1]
+    assert result.reason == "no_suitable_segment"
+    assert ar.routes == original
+    assert all(r.is_escape for r in ar.routes if r.net == 1)
+
+
+def test_reference_via_in_first_fragment_is_counted():
+    ar, group = setup_routes(reference_length=10)
+    via = Via(x=6, y=30, diameter=0.6, drill=0.3, layers=(Layer.F_CU, Layer.B_CU), net=2)
+    ar.routes[2].vias.append(via)
+    ar.restore_route_snapshot(ar.routes)
+    expected = 10 + ar._build_manufacturer_design_rules().board_thickness_mm
+    ar.apply_match_group_tuning([group], verbose=False)
+    assert length(ar, 1) == pytest.approx(expected, abs=0.1)
+    assert sum(v is via for r in ar.routes for v in r.vias) == 1
+
+
+def test_foreign_via_in_earlier_fragment_blocks_candidate():
+    control, group = setup_routes()
+    control.apply_match_group_tuning([group], verbose=False)
+    host = next(
+        s
+        for r in control.routes
+        if r.net == 1
+        for s in r.segments
+        if abs(s.y1 - 10) > 0.3 and abs(s.y2 - 10) > 0.3
+    )
+    via = Via(
+        x=(host.x1 + host.x2) / 2,
+        y=(host.y1 + host.y2) / 2,
+        diameter=0.6,
+        drill=0.3,
+        layers=(Layer.F_CU, Layer.B_CU),
+        net=3,
+    )
+    ar, group = setup_routes()
+    foreign = [Route(net=3, net_name="D3", vias=[via], is_escape=True), fragment(3, 25, 28, 25)]
+    ar.routes.extend(foreign)
+    ar.restore_route_snapshot(ar.routes)
+    ar.apply_match_group_tuning([group], verbose=False)
+    for route in ar.routes:
+        if route.net == 1:
+            for seg in route.segments:
+                distance = Point(via.x, via.y).distance(
+                    LineString([(seg.x1, seg.y1), (seg.x2, seg.y2)])
+                )
+                assert distance + 1e-8 >= via.diameter / 2 + seg.width / 2 + ar.rules.via_clearance
+    assert all(any(r is f for r in ar.routes) for f in foreign)
+
+
+def test_failed_insertion_preserves_original_fragment_objects():
+    ar, group = setup_routes(reference_length=12)
+    ar.routes.extend([fragment(3, 0, 25, 9.5), fragment(4, 0, 25, 10.5)])
+    ar.restore_route_snapshot(ar.routes)
+    original = list(ar.routes)
+    geometry = copy.deepcopy(ar.routes)
+    result = ar.apply_match_group_tuning([group], verbose=False)["G"][1][1]
+    assert result.reason == "post_insertion_drc_violation"
+    assert result.attempts > 0
+    assert ar.routes == geometry
+    assert [id(r) for r in ar.routes] == [id(r) for r in original]
+    assert {id(r) for r in ar.grid.routes} == {id(r) for r in original}
+
+
+def test_pair_tuning_preserves_both_escape_fragments():
+    ar, _ = setup_routes()
+    ar.routes = [
+        fragment(net, 5, 6, y, escape=True) for net, y in [(1, 10), (2, 11), (3, 30), (4, 31)]
+    ] + [
+        fragment(net, 6, end, y)
+        for net, end, y in [(1, 15, 10), (2, 15, 11), (3, 17, 30), (4, 17, 31)]
+    ]
+    ar.restore_route_snapshot(ar.routes)
+    escapes = ar.routes[:4]
+    group = MatchGroup(
+        name="P",
+        net_ids=[],
+        pair_ids=[(1, 2), (3, 4)],
+        tolerance=0.1,
+        reference_net_id=3,
+        source=MatchGroupSource.LEGACY_API,
+    )
+    results = ar.apply_match_group_tuning([group], verbose=False)["P"]
+    assert results[1][1].reason == "tuned"
+    assert results[2][1].reason == "tuned"
+    for net in (1, 2):
+        assert length(ar, net) == pytest.approx(12, abs=0.1)
+        assert sum(r.net == net for r in ar.routes) == 2
+    assert all(any(r is escape for r in ar.routes) for escape in escapes)

--- a/tests/test_match_group_split_routes.py
+++ b/tests/test_match_group_split_routes.py
@@ -203,13 +203,15 @@ def test_failed_insertion_preserves_original_fragment_objects():
     assert {id(r) for r in ar.grid.routes} == {id(r) for r in original}
 
 
-def test_pair_tuning_preserves_both_escape_fragments():
+@pytest.mark.parametrize("escape_end", [6, 17])
+def test_pair_tuning_preserves_both_escape_fragments(escape_end):
     ar, _ = setup_routes()
     ar.routes = [
-        fragment(net, 5, 6, y, escape=True) for net, y in [(1, 10), (2, 11), (3, 30), (4, 31)]
+        fragment(net, 5, escape_end, y, escape=True)
+        for net, y in [(1, 10), (2, 11), (3, 30), (4, 31)]
     ] + [
-        fragment(net, 6, end, y)
-        for net, end, y in [(1, 15, 10), (2, 15, 11), (3, 17, 30), (4, 17, 31)]
+        fragment(net, escape_end, end, y)
+        for net, end, y in [(1, 25, 10), (2, 25, 11), (3, 27, 30), (4, 27, 31)]
     ]
     ar.restore_route_snapshot(ar.routes)
     escapes = ar.routes[:4]
@@ -225,6 +227,6 @@ def test_pair_tuning_preserves_both_escape_fragments():
     assert results[1][1].reason == "tuned"
     assert results[2][1].reason == "tuned"
     for net in (1, 2):
-        assert length(ar, net) == pytest.approx(12, abs=0.1)
+        assert length(ar, net) == pytest.approx(22, abs=0.1)
         assert sum(r.net == net for r in ar.routes) == 2
     assert all(any(r is escape for r in ar.routes) for escape in escapes)


### PR DESCRIPTION
## Problem and change

Match-group tuning selected the last Route fragment for a net, then overwrote its first fragment. A 10 mm split net could be reported tuned while publishing 21 mm of duplicated channel copper and losing its escape connection.

Build complete-net tuning views, keep escape segments fixed during scalar and paired host selection, and replace mutable fragments exactly once. Paired generation uses the selected channel even when an escape is longer. Preserve original fragments on no-op/rollback and restore occupancy and collision caches through the shared snapshot mechanism with explicit route ownership.

Closes #5289.

## Validation

- 153 regression tests passed with freshly built native extensions: tuning, connectivity, split fragments, snapshot replay and negotiated geometry.
- 38 split-route, CLI and grid-resync tests passed before the final paired-host amendment; these overlap with the regression suite.
- All 10 original split-route controls fail against the original orchestrator. The additional longer-escape control fails before the paired-host amendment.
- Ruff, formatting and diff checks pass. Cold mypy: 1422 existing errors within the 1472 baseline; no new errors.
- Independent local Judge review found no introduced blockers; four initial controls and both amended pair-host cases independently passed.

Existing pair-path via-length and via/pad-clearance omissions are tracked separately in #5290. Full Board07 failure investigation remains #5286; this PR does not establish its cause or claim manufacturing qualification.
