### PR TITLE
fix(site): show verified development readiness without board summary

### DIFF
--- a/site/README.md
+++ b/site/README.md
@@ -207,3 +207,29 @@ site/
 This site ships the scaffold, the board data loader, the gallery index page
 (cards, renders, metric badges), and the per-board detail page (render gallery,
 metrics table, downloads, and the interactive KiCanvas PCB viewer).
+
+### Development readiness without a board summary
+
+`kct board-metrics` (`src/kicad_tools/cli/board_metrics_cmd.py`) already
+extracts static development metadata without a manufacturing directory and
+reads readiness through `board_readiness.py`; it does not manufacture passing
+checks or an export. Its `emit_board_json` writes the optional gallery summary.
+The readiness command/board-specific producer writes `output/readiness.json`
+independently. See `docs/board-json-schema.md`, “Development boards without
+manufacturing export”.
+
+The site also loads readiness when that summary is absent, unreadable, malformed,
+or unsupported. `loadReadiness` validates report shape, each recorded input's
+SHA-256 and board-relative path, and coverage of current project/rule files.
+Rejected evidence exposes no passing checks. A valid fallback record retains
+`no_artifacts` internally and displays **In development**, never a release-ready
+badge or inferred download. Full summaries retain their existing readiness gates.
+Gallery and detail pages share per-check labels and status explanations; absent
+checks are unreported, not passes. Evidence dates remain report dates.
+
+At main `696315f0`, Board09 (`09-usbc-pd-power`) has no `board.json` or
+manufacturing package but its September 10 readiness report validates all 20
+input hashes: eight checks passed, manufacturer rules failed, and manufacturing
+release was not run. This is a real ingestion example, not new board qualification.
+Refresh the readiness evidence against current files before rebuilding; do not
+edit hashes or statuses to make stale evidence appear current.

--- a/site/src/components/BoardCard.astro
+++ b/site/src/components/BoardCard.astro
@@ -11,6 +11,7 @@
  * The whole card links to `/<slug>` — the per-board detail route built in
  * issue #3681. Until that page exists the link 404s, which is expected.
  */
+import ReadinessProgress from "./ReadinessProgress.astro";
 import type { Board } from "../data/types.ts";
 import { displayStatus, displayStatusLabel } from "../data/boardStatus.ts";
 
@@ -73,6 +74,7 @@ const statusLabel = displayStatusLabel(board);
   <div class="body">
     <h2 class="name">{displayName}</h2>
     {board.description && <p class="desc">{board.description}</p>}
+    <ReadinessProgress board={board} compact />
 
     <ul class="badges">
       {
@@ -218,6 +220,8 @@ const statusLabel = displayStatusLabel(board);
   /* LVS-not-run chip (#3749): neutral gray for "unknown" — visually similar
      to no_artifacts so the message is "we have not verified" rather than "we
      verified and it is a problem". Never reads as Ready. */
+  .chip-development,
+  .chip-blocked,
   .chip-unverified {
     background: rgba(120, 134, 148, 0.85);
     color: #0c1116;

--- a/site/src/components/ReadinessProgress.astro
+++ b/site/src/components/ReadinessProgress.astro
@@ -1,0 +1,35 @@
+---
+import type { Board } from "../data/types.ts";
+import { displayStatusExplanation } from "../data/boardStatus.ts";
+interface Props { board: Board; compact?: boolean }
+const { board, compact = false } = Astro.props;
+// Only the content-validated loader may supply publishable check results.
+const verified = ["ready", "blocked"].includes(board.readiness?.status ?? "");
+const checks = verified ? board.readiness?.checks ?? [] : [];
+const labels: Record<string, string> = {
+  native_erc_clean: "Electrical rules (ERC)", native_drc: "Native design rules (DRC)",
+  native_drc_geometry_clean: "Native geometry rules (DRC)",
+  label_lvs_clean: "Schematic labels (LVS)", copper_lvs_clean: "Copper connectivity (LVS)",
+  kct_check: "Connectivity and design checks", artifacts: "Manufacturing artifacts",
+  bom: "Bill of materials", manufacturing_export: "Manufacturing export", manufacturing_release: "Manufacturing release",
+  manufacturer_rules_passed: "Manufacturer rules", analytical_screen_passed: "Analytical screening",
+};
+const label = (name: string) => labels[name] ?? name.replaceAll("_", " ");
+---
+<div class="progress">
+  <p>{displayStatusExplanation(board)}</p>
+  {checks.length > 0 && (
+    <>
+      {compact && board.readiness?.checked_at && <p>Checked <time datetime={board.readiness.checked_at}>{board.readiness.checked_at.slice(0, 10)}</time></p>}
+      <ul aria-label="Verified check progress">
+        {checks.map(check => <li><strong>{label(check.name)}: {check.status === "not_run" ? "not run" : check.status}</strong>{!compact && check.detail ? ` — ${check.detail}` : ""}</li>)}
+      </ul>
+      <p>Passed: this check passed for the recorded files. Failed: this check found a problem. Not run: no result was established. Unlisted checks have no reported result.</p>
+    </>
+  )}
+</div>
+<style>
+  .progress { font-size: 0.85rem; line-height: 1.5; overflow-wrap: anywhere; }
+  p { margin: 0.4rem 0; color: var(--muted, #9aa7b2); }
+  ul { padding-left: 1.2rem; margin: 0.5rem 0; }
+</style>

--- a/site/src/data/boardStatus.test.ts
+++ b/site/src/data/boardStatus.test.ts
@@ -51,10 +51,10 @@ describe("displayStatus", () => {
     expect(displayStatusLabel(b)).toBe("Partial");
   });
 
-  it("returns 'no_artifacts' for a stub board", () => {
+  it("shows development progress rather than ready for a stub with verified evidence", () => {
     const b = makeBoard({ status: "no_artifacts" });
-    expect(displayStatus(b)).toBe("no_artifacts");
-    expect(displayStatusLabel(b)).toBe("No artifacts");
+    expect(displayStatus(b)).toBe("development");
+    expect(displayStatusLabel(b)).toBe("In development");
   });
 
   // ── LVS gates (#3749) ───────────────────────────────────────────────────

--- a/site/src/data/boardStatus.ts
+++ b/site/src/data/boardStatus.ts
@@ -3,6 +3,7 @@ import type { Board } from "./types.ts";
 
 /** The display variants the status chip / row can take. */
 export type DisplayStatus =
+  | "development"
   | "ready"
   | "blocked"
   | "drc"
@@ -13,6 +14,7 @@ export type DisplayStatus =
 
 /** Current readiness is authoritative; historical DRC/LVS remain defensive gates. */
 export function displayStatus(board: Board): DisplayStatus {
+  if (board.status === "no_artifacts" && ["ready", "blocked"].includes(board.readiness?.status ?? "")) return "development";
   if (board.readiness?.status === "blocked") return "blocked";
   if (board.readiness?.status !== "ready") return "unverified";
   if ((board.drc_violations ?? 0) > 0) return "drc";
@@ -28,6 +30,8 @@ export function displayStatus(board: Board): DisplayStatus {
 export function displayStatusLabel(board: Board): string {
   const variant = displayStatus(board);
   switch (variant) {
+    case "development":
+      return "In development";
     case "ready":
       return board.readiness?.mode === "pcb_only" ? "PCB fabrication ready" : "Assembly ready";
     case "blocked":
@@ -49,5 +53,21 @@ export function displayStatusLabel(board: Board): string {
       return "Partial";
     case "no_artifacts":
       return "No artifacts";
+  }
+}
+
+/** Shared legend text on cards and detail pages; describes the badge's limits. */
+export function displayStatusExplanation(board: Board): string {
+  switch (displayStatus(board)) {
+    case "development": return "Verified development checks are available; complete design artifacts are not published here. This is not an ordering-ready package.";
+    case "ready": return board.readiness?.mode === "pcb_only"
+      ? "Current evidence passes the bare-PCB release checks; assembly and hardware testing are not included."
+      : "Current evidence passes the assembly release checks; this does not establish tested hardware performance.";
+    case "blocked": return "Current evidence records failed or incomplete release requirements.";
+    case "drc": return "Recorded design-rule violations need resolution before release.";
+    case "lvs": return "The recorded schematic and PCB connectivity do not agree.";
+    case "unverified": return "Current readiness evidence is missing, invalid, or no longer matches the checked files.";
+    case "partial": return "Only part of the design artifact set is available.";
+    case "no_artifacts": return "No usable design artifact summary is available.";
   }
 }

--- a/site/src/data/loadBoards.ts
+++ b/site/src/data/loadBoards.ts
@@ -107,7 +107,7 @@ export function discoverBoardDirs(root: string): string[] {
 }
 
 /** Construct a `no_artifacts` stub for a board with no parsable `board.json`. */
-function makeStub(slug: string, category: BoardCategory): Board {
+function makeStub(slug: string, category: BoardCategory, boardPath: string): Board {
   return {
     $schema: "https://kicad-tools.org/schemas/board/v1.json",
     schema_version: SCHEMA_VERSION,
@@ -115,6 +115,7 @@ function makeStub(slug: string, category: BoardCategory): Board {
     slug,
     status: "no_artifacts",
     category,
+    readiness: loadReadiness(boardPath),
   };
 }
 
@@ -168,7 +169,7 @@ export function loadBoard(boardPath: string): Board {
   const jsonPath = join(boardPath, "output", "board.json");
 
   if (!existsSync(jsonPath)) {
-    return makeStub(slug, category);
+    return makeStub(slug, category, boardPath);
   }
 
   let raw: string;
@@ -176,7 +177,7 @@ export function loadBoard(boardPath: string): Board {
     raw = readFileSync(jsonPath, "utf8");
   } catch (err) {
     console.warn(`[loadBoards] ${slug}: failed to read board.json (${String(err)}); using stub`);
-    return makeStub(slug, category);
+    return makeStub(slug, category, boardPath);
   }
 
   let parsed: unknown;
@@ -184,11 +185,11 @@ export function loadBoard(boardPath: string): Board {
     parsed = JSON.parse(raw);
   } catch (err) {
     console.warn(`[loadBoards] ${slug}: board.json is not valid JSON (${String(err)}); using stub`);
-    return makeStub(slug, category);
+    return makeStub(slug, category, boardPath);
   }
 
   const board = validateBoard(parsed, slug);
-  if (!board) return makeStub(slug, category);
+  if (!board) return makeStub(slug, category, boardPath);
   // `category` is loader-assigned (not part of board.json); always set it.
   board.category = category;
   // Always revalidate the current report: board.json itself may be months old.

--- a/site/src/data/readiness.test.ts
+++ b/site/src/data/readiness.test.ts
@@ -96,3 +96,48 @@ it.each(["missing check", "missing project hash", "malformed", "path traversal"]
   save();
   expect(displayStatus(loadBoard(root))).toBe("unverified");
 });
+
+
+it.each(["missing", "malformed", "unknown schema"])("retains verified readiness with %s board metadata", kind => {
+  if (kind === "missing") rmSync(join(root, "output/board.json"));
+  if (kind === "malformed") writeFileSync(join(root, "output/board.json"), "{");
+  if (kind === "unknown schema") writeFileSync(join(root, "output/board.json"), JSON.stringify({schema_version: 99}));
+  // Development evidence is useful independently of a manufacturing export.
+  rmSync(join(root, "output/manufacturing"), { recursive: true });
+  for (const name of Object.keys(report.inputs)) if (name.includes("manufacturing/")) delete report.inputs[name];
+  report.status = "blocked";
+  report.blockers = ["Manufacturing export not run"];
+  report.checks = [
+    { name: "native_erc_clean", status: "passed" },
+    { name: "native_drc", status: "failed" },
+    { name: "copper_lvs_clean", status: "passed" },
+    { name: "manufacturing_release", status: "not_run" },
+  ];
+  save();
+  const board = loadBoard(root);
+  expect(board.status).toBe("no_artifacts");
+  expect(displayStatus(board)).toBe("development");
+  expect(board.readiness?.checks).toEqual(report.checks);
+  expect(board.manufacturing_package).toBeUndefined();
+  expect(board.drc_violations).toBeUndefined();
+  writeFileSync(join(root, "output/demo_routed.kicad_pcb"), "changed");
+  const stale = loadBoard(root);
+  expect(displayStatus(stale)).toBe("unverified");
+  expect(stale.readiness?.checks).toBeUndefined();
+});
+
+it.each(["missing", "malformed", "bad hash"])("fails closed on %s readiness without board metadata", kind => {
+  rmSync(join(root, "output/board.json"));
+  if (kind === "missing") rmSync(join(root, "output/readiness.json"));
+  if (kind === "malformed") writeFileSync(join(root, "output/readiness.json"), "{");
+  if (kind === "bad hash") { report.inputs["output/demo_routed.kicad_pcb"] = "0".repeat(64); save(); }
+  const board = loadBoard(root);
+  expect(displayStatus(board)).toBe("unverified");
+  expect(board.readiness?.checks).toBeUndefined();
+  expect(board.manufacturing_package).toBeUndefined();
+});
+
+it("does not promote a missing summary from a ready report", () => {
+  rmSync(join(root, "output/board.json"));
+  expect(displayStatus(loadBoard(root))).toBe("development");
+});

--- a/site/src/pages/[slug].astro
+++ b/site/src/pages/[slug].astro
@@ -20,6 +20,7 @@ import { loadBoards, boardsDir, discoverBoardDirs } from "../data/loadBoards.ts"
 import { displayStatus, displayStatusLabel } from "../data/boardStatus.ts";
 import type { Board } from "../data/types.ts";
 import RenderGallery from "../components/RenderGallery.astro";
+import ReadinessProgress from "../components/ReadinessProgress.astro";
 import SiteHeader from "../components/Header.astro";
 import SiteFooter from "../components/Footer.astro";
 
@@ -218,17 +219,16 @@ if (board.manifest_generated_at !== undefined) {
         {board.readiness?.mode === "pcb_only" && <p>Scope: bare PCB fabrication. Component procurement and assembly are not included.</p>}
         {board.readiness?.mode === "assembly" && <p>Scope: PCB fabrication and assembly files.</p>}
         {board.readiness?.blockers.length ? <ul>{board.readiness.blockers.map(reason => <li>{reason}</li>)}</ul> : null}
-        {board.readiness?.checks?.length ? <ul>{board.readiness.checks.map(check => <li><strong>{check.name}: {check.status.replace("_", " ")}</strong>{check.detail ? ` — ${check.detail}` : ""}</li>)}</ul> : null}
+        <ReadinessProgress board={board} />
         {statusVariant !== "ready" && <p>Downloads are design artifacts and are not verified for ordering.</p>}
       </section>
 
       {
         !isBuilt && (
           <p class="not-built">
-            This board has not been built yet — no renders, metrics, or
-            manufacturing package are available. Run <code>uv run kct
-            board-metrics --all</code> (and the render / manufacture steps) to
-            populate its data.
+            Complete design artifacts are not published here. Any verified
+            development checks are listed above; they do not establish a
+            manufacturing package or tested hardware.
           </p>
         )
       }
@@ -574,6 +574,8 @@ if (board.manifest_generated_at !== undefined) {
     color: #1a1300;
   }
 
+  .chip-development,
+  .chip-blocked,
   .chip-no_artifacts {
     background: rgba(120, 134, 148, 0.85);
     color: #0c1116;


### PR DESCRIPTION
Boards with verified readiness evidence but no usable board.json previously became bare gallery stubs, hiding their completed and failed checks. Load readiness on every fallback path and show an In development badge with shared per-check labels and status explanations on gallery/detail pages. Missing, malformed or stale evidence stays unverified; no manufacturing download or release-ready status is inferred.

The real Board09 record validates all20 input hashes and now displays eight passed checks, one failed manufacturer-rules check and manufacturing release not run. Document the existing Python development-metadata producer and independent readiness consumer path. Closes #5296; part of #5278.

Validation:84site tests pass, including missing/malformed/unsupported board metadata and absent/malformed/hash-mismatched readiness controls;32existing producer development tests pass. Astro check0errors/0warnings (98hints), build12pages, diff check clean. Generated gallery/detail assertions and Chrome at390px/1280px verify the real Board09 labels, no document overflow, and keyboard Enter navigation from its card to detail. HTTP-served mobile screenshots inspected (/tmp/5296-card-http-390.png, /tmp/5296-detail-http-390.png). Check lists are static readable content; no new disclosure controls. No board artifacts, readiness reports, hashes, or Python production code changed.