### PR TITLE
feat(site): refresh capability discovery and shared presentation

### DIFF
--- a/site/README.md
+++ b/site/README.md
@@ -129,6 +129,8 @@ With data present, the placeholder index lists every board's real `status`
 
 ## Deploying
 
+Deploy after site-content or release changes; there is no scheduled deployment. The footer records the site build time and source commit, separately from board and benchmark evidence dates. Project version is read from `pyproject.toml` at build time.
+
 The gallery is published **manually** to Cloudflare Pages with a locally
 authenticated `wrangler` — there is no CI auto-deploy. (The former
 `gallery-deploy.yml` GitHub Actions workflow was removed in favour of this

--- a/site/src/components/Footer.astro
+++ b/site/src/components/Footer.astro
@@ -8,6 +8,7 @@
  * disclaimer, and a link to kicad.org. Styling reuses the global CSS custom
  * properties (`--muted`, `--border`, `--accent`) so it stays small + muted.
  */
+import { projectVersion, siteBuiltAt } from "../data/siteMetadata.ts";
 import { execSync } from "node:child_process";
 
 // Capture the short SHA at build time (this frontmatter runs in Node during
@@ -31,18 +32,19 @@ const commitUrl =
     : "https://github.com/rjwalters/kicad-tools";
 
 // Copyright year is captured at build time; edit the holder name below freely.
-const year = new Date().getFullYear();
+const year = new Date(siteBuiltAt).getUTCFullYear();
 ---
 
 <footer class="site-footer">
   <p class="line">
-    Build:
+    Site commit:
     <a href={commitUrl} target="_blank" rel="noopener noreferrer">
       <code>{sha}</code>
     </a>
     <span class="sep" aria-hidden="true">·</span>
-    Milestone: <code>v0.19.0</code>
+    Project version: <code>v{projectVersion}</code>
   </p>
+  <p class="line">Site built <time datetime={siteBuiltAt}>{siteBuiltAt.replace("T", " ").replace(/\.\d+Z$/, " UTC")}</time>. Board and benchmark evidence dates are shown separately.</p>
   <p class="line">© {year} Robb Walters / kicad-tools contributors</p>
   <p class="line disclaimer">
     KiCad is a registered trademark of its respective owners; this is an
@@ -91,7 +93,7 @@ const year = new Date().getFullYear();
   .site-footer a:hover,
   .site-footer a:focus-visible {
     text-decoration: underline;
-    outline: none;
+
   }
 
   .site-footer code {

--- a/site/src/components/Header.astro
+++ b/site/src/components/Header.astro
@@ -5,16 +5,19 @@
  * Rendered at the top of every page (index + each board detail) by importing
  * this component into `index.astro` and `[slug].astro`. Carries a "View on
  * GitHub" link back to the project repo. Styling reuses the global CSS custom
- * properties (`--accent`, `--border`, `--muted`) declared on `:root` by each
- * page's `<style is:global>` block, so it inherits the dark theme.
+ * properties (`--accent`, `--border`, `--muted`) declared in the shared global stylesheet, so it inherits the dark theme.
  */
+import "../styles/global.css";
+const path = Astro.url.pathname.replace(/\/$/, "") || "/";
 const REPO = "https://github.com/rjwalters/kicad-tools";
 ---
 
+<a class="skip-link" href="#main-content">Skip to main content</a>
 <header class="site-header">
-  <a class="site-title" href="/">kicad-tools</a>
-  <nav class="site-nav">
-    <a class="nav-link" href="/benchmarks">Benchmarks</a>
+  <a class="site-title" href="/" aria-current={path === "/" ? "page" : undefined}>kicad-tools</a>
+  <nav class="site-nav" aria-label="Main navigation">
+    <a class="nav-link" href={`${REPO}/blob/main/README.md`}>Documentation</a>
+    <a class="nav-link" href="/benchmarks" aria-current={path === "/benchmarks" ? "page" : undefined}>Benchmarks</a>
     <a
       class="repo-link"
       href={REPO}
@@ -66,6 +69,13 @@ const REPO = "https://github.com/rjwalters/kicad-tools";
   .site-title:hover,
   .site-title:focus-visible {
     text-decoration: underline;
-    outline: none;
+
+  }
+  .skip-link { position: absolute; top: 0.5rem; left: 1rem; z-index: 100; padding: 0.75rem 1rem; background: var(--text); color: var(--bg); transform: translateY(-200%); }
+  .skip-link:focus { transform: translateY(0); }
+  [aria-current="page"] { text-decoration: underline; text-underline-offset: 0.3em; }
+  @media (max-width: 600px) {
+    .site-header { flex-direction: column; align-items: flex-start; gap: 0.65rem; }
+    .site-nav { flex-wrap: wrap; gap: 0.75rem 1rem; }
   }
 </style>

--- a/site/src/data/galleryConfig.mjs
+++ b/site/src/data/galleryConfig.mjs
@@ -14,4 +14,5 @@
  * it must produce no card, route, render, or staged PCB. Honored by both the
  * loader's discovery and the render-staging script so it is dropped uniformly.
  */
-export const EXCLUDED_SLUGS = new Set(["chorus-test-revA"]);
+// softstart is a local-only fixture whose sibling repository is not published.
+export const EXCLUDED_SLUGS = new Set(["chorus-test-revA", "softstart"]);

--- a/site/src/data/loadBoards.test.ts
+++ b/site/src/data/loadBoards.test.ts
@@ -54,12 +54,12 @@ describe("discoverBoardDirs", () => {
   it("lists immediate board dirs and descends into external/", () => {
     makeBoardDir("00-simple-led");
     makeBoardDir("01-voltage-divider");
-    mkdirSync(join(root, "external", "softstart", "output"), { recursive: true });
+    mkdirSync(join(root, "external", "example-project", "output"), { recursive: true });
 
     const dirs = discoverBoardDirs(root).map((d) => d.replace(root + "/", ""));
     expect(dirs).toContain("00-simple-led");
     expect(dirs).toContain("01-voltage-divider");
-    expect(dirs).toContain(join("external", "softstart"));
+    expect(dirs).toContain(join("external", "example-project"));
   });
 
   it("skips hidden and underscore-prefixed directories", () => {
@@ -159,15 +159,18 @@ describe("loadBoards", () => {
 });
 
 describe("excluded slugs (#3696)", () => {
-  it("drops chorus-test-revA from discovery under external/", () => {
-    mkdirSync(join(root, "external", "softstart", "output"), { recursive: true });
+  it("drops local-only designs from discovery under external/", () => {
+    mkdirSync(join(root, "external", "example-project", "output"), { recursive: true });
     mkdirSync(join(root, "external", "chorus-test-revA", "output"), { recursive: true });
 
     const slugs = discoverBoardDirs(root).map((d) =>
       d.split(/[\\/]/).filter(Boolean).pop(),
     );
-    expect(slugs).toContain("softstart");
+    expect(slugs).toContain("example-project");
     expect(slugs).not.toContain("chorus-test-revA");
+    const before = discoverBoardDirs(root);
+    mkdirSync(join(root, "external", "softstart", "output"), { recursive: true });
+    expect(discoverBoardDirs(root)).toEqual(before);
   });
 
   it("emits no Board for an excluded slug", () => {
@@ -187,22 +190,22 @@ describe("board category (#3696)", () => {
   });
 
   it("tags boards under external/ as project", () => {
-    mkdirSync(join(root, "external", "softstart", "output"), { recursive: true });
-    const board = loadBoard(join(root, "external", "softstart"));
+    mkdirSync(join(root, "external", "example-project", "output"), { recursive: true });
+    const board = loadBoard(join(root, "external", "example-project"));
     expect(board.category).toBe("project");
   });
 
   it("assigns category across a mixed set", () => {
     writeBoardJson("01-voltage-divider", validBoard("01-voltage-divider"));
-    mkdirSync(join(root, "external", "softstart", "output"), { recursive: true });
+    mkdirSync(join(root, "external", "example-project", "output"), { recursive: true });
     writeFileSync(
-      join(root, "external", "softstart", "output", "board.json"),
-      JSON.stringify(validBoard("softstart")),
+      join(root, "external", "example-project", "output", "board.json"),
+      JSON.stringify(validBoard("example-project")),
     );
 
     const boards = loadBoards(root);
     const bySlug = Object.fromEntries(boards.map((b) => [b.slug, b.category]));
     expect(bySlug["01-voltage-divider"]).toBe("demo");
-    expect(bySlug["softstart"]).toBe("project");
+    expect(bySlug["example-project"]).toBe("project");
   });
 });

--- a/site/src/data/siteMetadata.test.ts
+++ b/site/src/data/siteMetadata.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+import { parseProjectVersion, projectVersion, siteBuiltAt } from "./siteMetadata.ts";
+
+describe("site metadata", () => {
+  it("reads the repository project version, not another table's version", () => {
+    const source = readFileSync(new URL("../../../pyproject.toml", import.meta.url), "utf8");
+    expect(projectVersion).toBe(parseProjectVersion(source));
+    expect(projectVersion).toMatch(/^\d+\.\d+\.\d+/);
+    expect(parseProjectVersion('[tool.other]\nversion="9.9.9"\n[project]\nversion="1.2.3"\n[other]\nversion="8.8.8"')).toBe("1.2.3");
+  });
+  it("fails visibly when the project version is absent or malformed", () => {
+    for (const source of ['[tool.other]\nversion="1.2.3"', '[project]\nname="x"\n[other]\nversion="1.2.3"', '[project]\nversion=""']) {
+      expect(() => parseProjectVersion(source)).toThrow();
+    }
+  });
+  it("records a parseable build timestamp independently of report metadata", () => {
+    expect(new Date(siteBuiltAt).toISOString()).toBe(siteBuiltAt);
+  });
+});

--- a/site/src/data/siteMetadata.ts
+++ b/site/src/data/siteMetadata.ts
@@ -1,0 +1,17 @@
+/** Build metadata, separate from measurement/report dates. */
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+export function parseProjectVersion(toml: string): string {
+  const project = toml.split(/^\[project\][ \t]*$/m)[1]?.split(/^\[/m)[0];
+  const version = project?.match(/^version\s*=\s*["']([^"']+)["']\s*$/m)?.[1];
+  if (!version || !/^\d+\.\d+\.\d+(?:[a-zA-Z0-9.+-]*)$/.test(version)) {
+    throw new Error("pyproject.toml must declare a valid project.version");
+  }
+  return version;
+}
+
+export const projectVersion = parseProjectVersion(
+  readFileSync(resolve(process.cwd(), "..", "pyproject.toml"), "utf8"),
+);
+export const siteBuiltAt = new Date().toISOString();

--- a/site/src/pages/[slug].astro
+++ b/site/src/pages/[slug].astro
@@ -198,7 +198,7 @@ if (board.manifest_generated_at !== undefined) {
   </head>
   <body>
     <SiteHeader />
-    <main>
+    <main id="main-content" tabindex="-1">
       <p class="back-top">
         <a href="/">← Back to gallery</a>
       </p>
@@ -464,42 +464,7 @@ if (board.manifest_generated_at !== undefined) {
   </body>
 </html>
 
-<style is:global>
-  :root {
-    color-scheme: dark;
-    --bg: #0a0e12;
-    --text: #e6edf3;
-    --muted: #9aa7b2;
-    --accent: #3fae7a;
-    --border: #25303a;
-    --card-bg: #11171d;
-    --badge-bg: #1b2530;
-  }
 
-  * {
-    box-sizing: border-box;
-  }
-
-  html,
-  body {
-    margin: 0;
-    padding: 0;
-  }
-
-  body {
-    background: var(--bg);
-    color: var(--text);
-    font-family:
-      system-ui,
-      -apple-system,
-      "Segoe UI",
-      Roboto,
-      Helvetica,
-      Arial,
-      sans-serif;
-    line-height: 1.5;
-  }
-</style>
 
 <style>
   main {

--- a/site/src/pages/benchmarks.astro
+++ b/site/src/pages/benchmarks.astro
@@ -136,7 +136,7 @@ const FAILURE_NOTES: Record<string, { issue: string; url: string; summary: strin
   </head>
   <body>
     <SiteHeader />
-    <main>
+    <main id="main-content" tabindex="-1">
       <header class="page-header">
         <p class="snapshot-bar" role="note">
           <strong>Archived historical snapshot</strong>
@@ -471,42 +471,7 @@ uv run kct bench external --board strf --tuned`}</code></pre>
   </body>
 </html>
 
-<style is:global>
-  :root {
-    color-scheme: dark;
-    --bg: #0a0e12;
-    --text: #e6edf3;
-    --muted: #9aa7b2;
-    --accent: #3fae7a;
-    --border: #25303a;
-    --card-bg: #11171d;
-    --badge-bg: #1b2530;
-  }
 
-  * {
-    box-sizing: border-box;
-  }
-
-  html,
-  body {
-    margin: 0;
-    padding: 0;
-  }
-
-  body {
-    background: var(--bg);
-    color: var(--text);
-    font-family:
-      system-ui,
-      -apple-system,
-      "Segoe UI",
-      Roboto,
-      Helvetica,
-      Arial,
-      sans-serif;
-    line-height: 1.5;
-  }
-</style>
 
 <style>
   main {

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -7,6 +7,7 @@
 // degrade gracefully when board.json / renders are absent.
 import { join, resolve } from "node:path";
 import { existsSync } from "node:fs";
+import { projectVersion } from "../data/siteMetadata.ts";
 import { loadBoards } from "../data/loadBoards.ts";
 import BoardCard from "../components/BoardCard.astro";
 import SiteHeader from "../components/Header.astro";
@@ -37,21 +38,27 @@ const hasPcbFor = (slug: string): boolean =>
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>kicad-tools demo gallery</title>
+    <title>kicad-tools — tools for KiCad projects and AI agents</title>
     <meta
       name="description"
-      content="A gallery of PCB designs produced end-to-end by kicad-tools' automated agent pipeline, with design-verification and HV-isolation capabilities (v0.19.0)."
+      content={`Inspect, generate, route and check KiCad projects with Python, the command line and AI agents. Explore examples and their recorded validation. kicad-tools v${projectVersion}.`}
     />
   </head>
   <body>
     <SiteHeader />
-    <main>
+    <main id="main-content" tabindex="-1">
       <header class="page-header">
-        <h1>kicad-tools demo gallery</h1>
+        <p class="eyebrow">Python · Command line · AI agents</p>
+        <h1>Build and understand<br />your KiCad projects.</h1>
         <p class="tagline">
-          PCB designs produced end-to-end by the kicad-tools automated
-          pipeline — with design-verification and HV-isolation capabilities.
+          kicad-tools gives developers and AI agents tools to inspect schematics,
+          generate PCB designs, route connections and check the results.
+          Explore the examples below to see the work and the evidence behind it.
         </p>
+        <div class="hero-links">
+          <a class="primary-link" href="https://github.com/rjwalters/kicad-tools#quick-start">Get started</a>
+          {demoBoards.length > 0 && <a href="#demo-boards">Explore demo boards ↓</a>}
+        </div>
         <p class="count">
           {boards.length} board{boards.length === 1 ? "" : "s"}
           {withData > 0 && ` · ${withData} with generated artifacts`}
@@ -65,52 +72,49 @@ const hasPcbFor = (slug: string): boolean =>
         </p>
       )}
 
-      <section class="capabilities">
+      <section class="capabilities" aria-labelledby="capabilities-heading">
         <div class="capabilities-head">
-          <h2>Capabilities</h2>
-          <span class="version-badge">v0.19.0</span>
+          <h2 id="capabilities-heading">From design data to checked copper</h2>
+          <span class="version-badge">v{projectVersion}</span>
         </div>
         <p class="section-copy">
-          Beyond placement and routing, the 0.19.0 pipeline adds a
-          high-voltage isolation design loop and electrical-rating checks that
-          run against real KiCad designs.
+          Use the CLI for a single check, the Python API for a repeatable workflow,
+          or the MCP server to give an agent access to your design tools.
         </p>
         <ul class="capability-list" role="list">
           <li>
-            <strong>HV-isolation design loop</strong> —
-            <code>kct creepage --voltage-map</code>,
-            <code>kct zones hv-keepout</code>, HV-aware
-            <code>optimize-placement</code>, and the
-            <code>/kct:hv-isolation-loop</code> skill.
+            <h3>Inspect and automate</h3>
+            <p>Read KiCad design data and build repeatable workflows with Python
+              or an AI agent.</p>
+            <a href="https://github.com/rjwalters/kicad-tools#python-api">Python examples</a>
+            <a href="https://github.com/rjwalters/kicad-tools#mcp-server-for-ai-agents">MCP setup</a>
           </li>
           <li>
-            <strong>Electrical-rating analysis</strong> —
-            <code>kct analyze electrical-rating</code> flags LED overcurrent
-            and capacitor voltage-derating violations.
+            <h3>Place and route</h3>
+            <p>Generate layouts and route connections with configurable design
+              rules. Automated routing is experimental; inspect connectivity and
+              clearance results for each design.</p>
+            <a href="https://github.com/rjwalters/kicad-tools#pcb-autorouter">Routing example</a>
+            <a href="/benchmarks">Recorded external-board attempts</a>
           </li>
           <li>
-            <strong>Design-rule constraint export</strong> —
-            <code>kct check --emit-dru</code> /
-            <code>--emit-drc-constraints</code> emit KiCad design-rule and DRC
-            constraint files.
-          </li>
-          <li>
-            <strong>Smarter via repair</strong> —
-            <code>kct fix-vias</code> relocates off-pad vias and repairs
-            through-hole hole-to-hole clearance.
-          </li>
-          <li>
-            <strong>KiCad-10 format-stamp centralization</strong> — a
-            single-source format stamp guarded by DRC and round-trip tests.
+            <h3>Check the design</h3>
+            <p>Run geometric checks, electrical-rating analysis and high-voltage
+              creepage audits. These checks support design review; they do not
+              certify hardware or establish manufacturing readiness.</p>
+            <code>kct check board.kicad_pcb --mfr jlcpcb</code>
+            <a href="https://github.com/rjwalters/kicad-tools#pure-python-drc">Design-check examples</a>
+            <a href="https://github.com/rjwalters/kicad-tools#cli-commands">Analysis and repair commands</a>
           </li>
         </ul>
       </section>
 
       {demoBoards.length > 0 && (
-        <section class="board-section">
+        <section class="board-section" id="demo-boards">
           <h2>Demo boards</h2>
           <p class="section-copy">
-            Reference designs that exercise the kicad-tools pipeline end-to-end.
+            Reference designs that exercise the workflow. Each board reports its own
+            available artifacts and validation; inclusion here is not a readiness claim.
           </p>
           <ul class="grid" role="list">
             {demoBoards.map((board) => (
@@ -126,8 +130,8 @@ const hasPcbFor = (slug: string): boolean =>
         <section class="board-section">
           <h2>Project gallery</h2>
           <p class="section-copy">
-            Real-world boards built with kicad-tools. More designs — including
-            contributed work from others — will land here over time.
+            Additional projects used with kicad-tools. Open a board to inspect its
+            available design files, measurements and recorded checks.
           </p>
           <ul class="grid" role="list">
             {projectBoards.map((board) => (
@@ -143,42 +147,7 @@ const hasPcbFor = (slug: string): boolean =>
   </body>
 </html>
 
-<style is:global>
-  :root {
-    color-scheme: dark;
-    --bg: #0a0e12;
-    --text: #e6edf3;
-    --muted: #9aa7b2;
-    --accent: #3fae7a;
-    --border: #25303a;
-    --card-bg: #11171d;
-    --badge-bg: #1b2530;
-  }
 
-  * {
-    box-sizing: border-box;
-  }
-
-  html,
-  body {
-    margin: 0;
-    padding: 0;
-  }
-
-  body {
-    background: var(--bg);
-    color: var(--text);
-    font-family:
-      system-ui,
-      -apple-system,
-      "Segoe UI",
-      Roboto,
-      Helvetica,
-      Arial,
-      sans-serif;
-    line-height: 1.5;
-  }
-</style>
 
 <style>
   main {
@@ -193,13 +162,17 @@ const hasPcbFor = (slug: string): boolean =>
 
   h1 {
     margin: 0 0 0.4rem;
-    font-size: clamp(1.6rem, 4vw, 2.4rem);
+    font-size: clamp(2rem, 5vw, 3.8rem);
+    line-height: 1.12;
+    letter-spacing: -0.035em;
+    margin-bottom: 1.25rem;
   }
 
   .tagline {
     margin: 0;
     color: var(--muted);
-    font-size: 1rem;
+    font-size: 1.1rem;
+    max-width: 65ch;
   }
 
   .count {
@@ -219,6 +192,7 @@ const hasPcbFor = (slug: string): boolean =>
   .capabilities-head {
     display: flex;
     align-items: center;
+    flex-wrap: wrap;
     gap: 0.6rem;
     margin: 0 0 0.3rem;
   }
@@ -245,12 +219,15 @@ const hasPcbFor = (slug: string): boolean =>
     padding: 0;
     display: grid;
     gap: 0.75rem;
-    max-width: 80ch;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
   }
 
   .capability-list li {
     color: var(--muted);
     font-size: 0.92rem;
+    padding: 1.1rem;
+    border: 1px solid var(--border);
+    border-radius: 6px;
   }
 
   .capability-list strong {
@@ -310,6 +287,14 @@ const hasPcbFor = (slug: string): boolean =>
     font-size: 0.85em;
   }
 
+  .eyebrow { color: var(--accent); font-size: 0.85rem; margin: 0 0 1rem; }
+  .hero-links { display: flex; flex-wrap: wrap; align-items: center; gap: 1.25rem; margin: 1.5rem 0; }
+  .hero-links a, .capability-list a { color: var(--accent); text-underline-offset: 0.2em; }
+  .hero-links .primary-link { background: var(--accent); color: var(--bg); padding: 0.7rem 1rem; border-radius: 5px; font-weight: 600; text-decoration: none; }
+  .capability-list h3 { color: var(--text); font-size: 1.05rem; margin: 0; }
+  .capability-list p { margin: 0.75rem 0; }
+  .capability-list a { display: block; margin-top: 0.7rem; }
+  @media (max-width: 800px) { .capability-list { grid-template-columns: 1fr; } }
   @media (max-width: 480px) {
     .grid {
       grid-template-columns: 1fr;

--- a/site/src/styles/global.css
+++ b/site/src/styles/global.css
@@ -1,0 +1,38 @@
+:root {
+    color-scheme: dark;
+    --bg: #0a0e12;
+    --text: #e6edf3;
+    --muted: #9aa7b2;
+    --accent: #3fae7a;
+    --border: #25303a;
+    --card-bg: #11171d;
+    --badge-bg: #1b2530;
+  }
+
+  * {
+    box-sizing: border-box;
+  }
+
+  html,
+  body {
+    margin: 0;
+    padding: 0;
+  }
+
+  body {
+    background: var(--bg);
+    color: var(--text);
+    font-family:
+      system-ui,
+      -apple-system,
+      "Segoe UI",
+      Roboto,
+      Helvetica,
+      Arial,
+      sans-serif;
+    line-height: 1.5;
+  }
+
+:focus-visible { outline: 2px solid var(--accent); outline-offset: 4px; }
+html { scroll-padding-top: 1rem; }
+main { overflow-wrap: anywhere; }

--- a/site/tests/manufacturing-downloads.test.ts
+++ b/site/tests/manufacturing-downloads.test.ts
@@ -44,6 +44,7 @@ beforeAll(() => {
   fixtureSite = join(root, "site");
   boards = join(root, "boards");
   mkdirSync(fixtureSite);
+  cpSync(join(site, "..", "pyproject.toml"), join(root, "pyproject.toml"));
   for (const entry of ["src", "scripts", "astro.config.mjs", "package.json", "tsconfig.json"]) {
     cpSync(join(site, entry), join(fixtureSite, entry), { recursive: true });
   }
@@ -107,5 +108,21 @@ describe("source and fabrication download presence", () => {
       expect(html("both")).not.toContain(`href="/boards/both/manufacturing/${file}"`);
       expect(existsSync(join(fixtureSite, "dist/boards/both/manufacturing", file))).toBe(false);
     }
+  }, 120_000);
+});
+
+
+describe("local-only gallery fixture", () => {
+  it("publishes identical pages with softstart absent or present", () => {
+    const indexBefore = readFileSync(join(fixtureSite, "dist/index.html"), "utf8");
+    const output = join(boards, "external/softstart/output");
+    mkdirSync(join(output, "manufacturing"), { recursive: true });
+    writeFileSync(join(output, "board.json"), JSON.stringify({schema_version: 1, slug: "softstart", status: "ok"}));
+    writeFileSync(join(output, "manufacturing/kicad_project.zip"), "local design");
+    build();
+    const normalizeBuildTime = (html: string) => html.replace(/\d{4}-\d{2}-\d{2}[T ][\d:.]+(?:Z| UTC)/g, "BUILD_TIME");
+    expect(normalizeBuildTime(readFileSync(join(fixtureSite, "dist/index.html"), "utf8"))).toBe(normalizeBuildTime(indexBefore));
+    expect(existsSync(join(fixtureSite, "dist/softstart"))).toBe(false);
+    expect(existsSync(join(fixtureSite, "public/boards/softstart"))).toBe(false);
   }, 120_000);
 });


### PR DESCRIPTION
The homepage now explains what kicad-tools does and links visitors to Python/MCP examples, routing examples, design checks and board evidence. Three capability cards distinguish implemented tools from experimental routing and missing hardware/manufacturing qualification.

Shared navigation adds Documentation, a keyboard skip link and active-page state; mobile navigation wraps. One stylesheet replaces three identical global blocks. Version badges read pyproject.toml, and the footer separates site build time/commit from evidence dates. The local-only softstart fixture is excluded from discovery and staging. Deployment cadence is documented.

Closes #5295. Part of #5278. Board readiness ingestion remains #5296, current benchmark evidence #5297, and final routing-status/navigation decisions #5298 and Phase3.

Validation:
- 81 site tests pass, including version scope/missing-value controls and a real build with softstart absent/present (identical homepage apart from build time; no local fixture route or staged files).
- Astro check: zero errors, zero warnings, 98 existing hints. Production build: 12 pages. Whitespace check passes.
- Headless Chrome: homepage, Board00 detail and benchmarks at320/390/1280px pass skip-link first-tab/focus transfer, active-page state, local anchors, displayed version and document-overflow checks.
- Before/after desktop and mobile screenshots captured and inspected for homepage and benchmarks; detail captures retained. Gallery status/data contracts and benchmark measurements are unchanged.

Local evidence: `/tmp/5295-{tests,check,build}.log`, `/tmp/5295-interactions.json`, `/tmp/5295-{before,after}-*-{390,1280}.png`. No deployment or live-site qualification claimed; independent review and CI remain required.
