### PR TITLE
fix(router): preserve split-net copper during diff-pair tuning

### DIFF
--- a/src/kicad_tools/router/core.py
+++ b/src/kicad_tools/router/core.py
@@ -16235,8 +16235,23 @@ class Autorouter:
 
         results: dict[tuple[str, str], DiffPairTuneResult] = {}
 
-        # Build routes_by_net lookup from the autorouter's current state.
-        routes_by_net: dict[int, Route] = {r.net: r for r in self.routes}
+        # Complete-net views include fixed escapes and every mutable fragment.
+        fragments_by_net: dict[int, list[Route]] = {}
+        for route in self.routes:
+            fragments_by_net.setdefault(route.net, []).append(route)
+        routes_by_net = {
+            net: fragments[0]
+            if len(fragments) == 1
+            else Route(
+                net=net,
+                net_name=fragments[0].net_name,
+                segments=[segment for route in fragments for segment in route.segments],
+                vias=[via for route in fragments for via in route.vias],
+                is_escape=all(route.is_escape for route in fragments),
+            )
+            for net, fragments in fragments_by_net.items()
+        }
+        fixed_segment_ids = {id(s) for r in self.routes if r.is_escape for s in r.segments}
 
         # Update the skew tracker so the post-tuning results are queryable.
         # Use the layer-stack count when available, else default to 2.
@@ -16245,7 +16260,7 @@ class Autorouter:
         else:
             num_layers = 2
         self._diffpair_length_tracker.record_routes(
-            routes=self.routes,
+            routes=list(routes_by_net.values()),
             detected_pairs=detected_pairs,
             num_copper_layers=num_layers,
         )
@@ -16281,25 +16296,41 @@ class Autorouter:
                 # True; flag-off keeps the pre-#4085 geometric selection.
                 grid=self.grid,
                 prefer_reserved_slack=self.enable_slack_corridor_widening,
+                fixed_segment_ids=fixed_segment_ids,
             )
 
-            # Commit any new Route references back into self.routes and the
-            # working ``routes_by_net`` map so the next pair's neighbor
-            # self-check sees the updated geometry.
-            if p_route is not None and dp.pair.positive.net_id in routes_by_net:
-                if p_route is not routes_by_net[dp.pair.positive.net_id]:
-                    routes_by_net[dp.pair.positive.net_id] = p_route
-                    for i, r in enumerate(self.routes):
-                        if r.net == dp.pair.positive.net_id:
-                            self.routes[i] = p_route
-                            break
-            if n_route is not None and dp.pair.negative.net_id in routes_by_net:
-                if n_route is not routes_by_net[dp.pair.negative.net_id]:
-                    routes_by_net[dp.pair.negative.net_id] = n_route
-                    for i, r in enumerate(self.routes):
-                        if r.net == dp.pair.negative.net_id:
-                            self.routes[i] = n_route
-                            break
+            changed = {
+                net: route
+                for net, route in (
+                    (dp.pair.positive.net_id, p_route),
+                    (dp.pair.negative.net_id, n_route),
+                )
+                if route is not None and net in routes_by_net and route is not routes_by_net[net]
+            }
+            routes_by_net.update(changed)
+            if changed:
+                previous = list(self.routes)
+                replacements = {}
+                for net, route in changed.items():
+                    escapes = [r for r in previous if r.net == net and r.is_escape]
+                    fixed_vias = {id(v) for r in escapes for v in r.vias}
+                    replacements[net] = (
+                        Route(
+                            net=net,
+                            net_name=route.net_name,
+                            segments=[s for s in route.segments if id(s) not in fixed_segment_ids],
+                            vias=[v for v in route.vias if id(v) not in fixed_vias],
+                        )
+                        if escapes
+                        else route
+                    )
+                published = []
+                for fragment in previous:
+                    if fragment.net not in changed or fragment.is_escape:
+                        published.append(fragment)
+                    elif fragment.net in replacements:
+                        published.append(replacements.pop(fragment.net))
+                self.restore_route_snapshot(published, replaced_routes=previous)
 
             results[(p_name, n_name)] = result
 
@@ -16316,7 +16347,7 @@ class Autorouter:
         # Refresh the skew tracker after tuning so downstream consumers
         # (e.g. the Phase 3J DRC rule) see the updated lengths.
         self._diffpair_length_tracker.record_routes(
-            routes=self.routes,
+            routes=list(routes_by_net.values()),
             detected_pairs=detected_pairs,
             num_copper_layers=num_layers,
         )

--- a/src/kicad_tools/router/diffpair_length_tuning.py
+++ b/src/kicad_tools/router/diffpair_length_tuning.py
@@ -156,6 +156,7 @@ def tune_diff_pair_skew(
     length_critical: bool = True,
     grid: RoutingGrid | None = None,
     prefer_reserved_slack: bool = False,
+    fixed_segment_ids: set[int] | None = None,
 ) -> tuple[Route, Route, DiffPairTuneResult]:
     """Tune the skew of a detected diff pair by serpentining the shorter half.
 
@@ -194,6 +195,8 @@ def tune_diff_pair_skew(
             or ``prefer_reserved_slack=False`` (both defaults) segment
             selection is byte-identical to the pre-#4085 geometric
             heuristic.
+        fixed_segment_ids: Fixed escape segment identities; retained in measurement
+            and clearance views, but never selected or replaced as meander hosts.
         prefer_reserved_slack: Issue #4085.  Gate for the slack-aware
             segment preference above.  Default ``False`` (inert).  Has no
             effect unless ``grid`` is also supplied.
@@ -254,6 +257,7 @@ def tune_diff_pair_skew(
         )
 
     from .length import LengthTracker  # avoid cycle
+    from .primitives import Route
 
     l_p = LengthTracker.calculate_route_length(p_route)
     l_n = LengthTracker.calculate_route_length(n_route)
@@ -324,6 +328,7 @@ def tune_diff_pair_skew(
             current_shorter,
             grid=grid if prefer_reserved_slack else None,
             reserved_net_id=shorter_id if prefer_reserved_slack else None,
+            fixed_segment_ids=fixed_segment_ids,
         )
         if best is None:
             result.reason = "no_suitable_segment"
@@ -361,9 +366,23 @@ def tune_diff_pair_skew(
         )
         attempt_generator = SerpentineGenerator(attempt_config)
 
-        candidate_route, serp_result = attempt_generator.add_serpentine(
-            current_shorter, serpentine_target
-        )
+        if fixed_segment_ids:
+            # Generate on the selected mutable host; reranking the full net
+            # could otherwise select a longer fixed escape or a different corridor.
+            serp_result = attempt_generator.generate_trombone(insertion_segment, length_needed)
+            candidate_route = Route(
+                net=current_shorter.net,
+                net_name=current_shorter.net_name,
+                segments=current_shorter.segments[:seg_idx]
+                + serp_result.new_segments
+                + current_shorter.segments[seg_idx + 1 :],
+                vias=current_shorter.vias.copy(),
+                is_escape=current_shorter.is_escape,
+            )
+        else:
+            candidate_route, serp_result = attempt_generator.add_serpentine(
+                current_shorter, serpentine_target
+            )
         result.serpentine_results.append(serp_result)
 
         if not serp_result.success:

--- a/src/kicad_tools/router/optimizer/serpentine.py
+++ b/src/kicad_tools/router/optimizer/serpentine.py
@@ -112,6 +112,7 @@ class SerpentineGenerator:
         *,
         grid: RoutingGrid | None = None,
         reserved_net_id: int | None = None,
+        fixed_segment_ids: set[int] | None = None,
     ) -> tuple[int, Segment] | None:
         """Find the best segment in a route for serpentine insertion.
 
@@ -135,6 +136,7 @@ class SerpentineGenerator:
                 the pre-#4085 purely-geometric heuristic -- every existing
                 caller (``tune_match_group``, ``apply_length_tuning``,
                 ...) is unaffected.
+            fixed_segment_ids: Segments that contribute length but cannot host a meander.
             reserved_net_id: Issue #4085.  The net id whose reservation
                 marks the slack corridor.  Ignored when ``grid`` is
                 ``None``.
@@ -150,6 +152,8 @@ class SerpentineGenerator:
         best_segment: Segment | None = None
 
         for i, seg in enumerate(route.segments):
+            if fixed_segment_ids and id(seg) in fixed_segment_ids:
+                continue
             length = segment_length(seg)
 
             # Skip segments that are too short

--- a/tests/test_diffpair_split_routes.py
+++ b/tests/test_diffpair_split_routes.py
@@ -1,0 +1,181 @@
+"""Real skew tuning must retain split-net ownership and refresh collision views."""
+
+import copy
+
+import pytest
+
+from kicad_tools.router.connectivity_invariant import (
+    enforce_connectivity_invariant,
+    snapshot_connectivity,
+)
+from kicad_tools.router.core import Autorouter
+from kicad_tools.router.diffpair_detection import detect_diff_pairs
+from kicad_tools.router.layers import Layer
+from kicad_tools.router.length import LengthTracker
+from kicad_tools.router.optimizer import make_collision_checker
+from kicad_tools.router.primitives import Pad, Route, Segment, Via
+
+
+def fragment(net, a, b, y, escape=False):
+    return Route(
+        net=net,
+        net_name={1: "USB_D+", 2: "USB_D-"}.get(net, "OTHER"),
+        is_escape=escape,
+        segments=[Segment(a, y, b, y, 0.2, Layer.F_CU, net=net)],
+    )
+
+
+def setup(shorter=1, *, native=False, escape_length=1, split=False):
+    if native:
+        from kicad_tools.router.cpp_backend import is_cpp_available
+
+        if not is_cpp_available():
+            pytest.skip("matching C++ backend unavailable")
+    ar = Autorouter(width=60, height=40, force_python=not native)
+    ar.net_names = {1: "USB_D+", 2: "USB_D-"}
+    for net, y in [(1, 10), (2, 20)]:
+        end = 5 + escape_length + (9 if net == shorter else 13)
+        boundary = 5 + escape_length
+        ar.routes.append(fragment(net, 5, boundary, y, True))
+        if split:
+            ar.routes.extend(
+                [fragment(net, boundary, boundary + 3, y), fragment(net, boundary + 3, end, y)]
+            )
+        else:
+            ar.routes.append(fragment(net, boundary, end, y))
+        ar.nets[net] = [(f"U{net}", "1"), (f"J{net}", "1")]
+        for key, x in zip(ar.nets[net], [5, end], strict=True):
+            ar.pads[key] = Pad(
+                x=x,
+                y=y,
+                width=0.4,
+                height=0.4,
+                layer=Layer.F_CU,
+                net=net,
+                net_name=ar.net_names[net],
+                ref=key[0],
+                pin=key[1],
+            )
+    for route in ar.routes:
+        ar._mark_route(route)
+    return ar, detect_diff_pairs(net_names=ar.net_names)
+
+
+def length(ar, net):
+    return sum(LengthTracker.calculate_route_length(r) for r in ar.routes if r.net == net)
+
+
+@pytest.mark.parametrize("native", [False, True])
+@pytest.mark.parametrize(
+    "shorter,escape_length,split", [(1, 1, False), (2, 1, True), (1, 17, True)]
+)
+def test_split_pair_publishes_once_and_refreshes_state(native, shorter, escape_length, split):
+    ar, pairs = setup(shorter, native=native, escape_length=escape_length, split=split)
+    original = list(ar.routes)
+    escapes = [r for r in original if r.is_escape]
+    fixed_geometry = copy.deepcopy([(r.segments, r.vias) for r in escapes])
+    independent = fragment(9, 2, 3, 35)
+    ar.grid.mark_route(independent)
+    checker = make_collision_checker(ar.grid, ignore_overflow=True)
+    connected = snapshot_connectivity(ar)
+    result = ar.apply_diffpair_length_tuning(pairs, verbose=False)[("USB_D+", "USB_D-")]
+    assert result.reason == "tuned"
+    assert abs(length(ar, 1) - length(ar, 2)) <= 0.5
+    assert result.skew_after_mm == pytest.approx(abs(length(ar, 1) - length(ar, 2)))
+    assert ar.diffpair_length_tracker.lengths[shorter] == pytest.approx(length(ar, shorter))
+    assert all(any(r is escape for r in ar.routes) for escape in escapes)
+    assert [(r.segments, r.vias) for r in escapes] == fixed_geometry
+    assert sum(r.net == shorter and not r.is_escape for r in ar.routes) == 1
+    assert not any(r in ar.routes for r in original if r.net == shorter and not r.is_escape)
+    assert {id(r) for r in ar.grid.routes} == {id(r) for r in ar.routes} | {id(independent)}
+    enforce_connectivity_invariant(
+        ar, connected, phase="split pair tuning", strict=True, quiet=True
+    )
+    segment = next(
+        s
+        for r in ar.routes
+        if r.net == shorter and not r.is_escape
+        for s in r.segments
+        if s.y1 != s.y2
+    )
+    assert not checker.path_is_clear(
+        segment.x1, segment.y1, segment.x2, segment.y2, segment.layer, segment.width, 99
+    )
+    gx, gy = ar.grid.world_to_grid((segment.x1 + segment.x2) / 2, (segment.y1 + segment.y2) / 2)
+    if native:
+        assert ar.grid._cpp_grid.is_blocked_for_net(gx, gy, 0, 99)
+    if ar.grid._rtree_available:
+        indexed = [s for items in ar.grid._seg_rtree_items.values() for s in items.values()]
+        assert {id(s) for s in indexed} == {id(s) for r in ar.grid.routes for s in r.segments}
+    first = list(ar.routes)
+    second = ar.apply_diffpair_length_tuning(pairs, verbose=False)[("USB_D+", "USB_D-")]
+    assert second.reason == "already_within_tolerance"
+    assert all(a is b for a, b in zip(first, ar.routes, strict=True))
+
+
+def test_escape_only_and_via_identity_are_preserved():
+    ar, pairs = setup()
+    for route in ar.routes:
+        route.is_escape = True
+    via = Via(6, 10, 0.6, 0.3, (Layer.F_CU, Layer.B_CU), net=1)
+    ar.routes[0].vias.append(via)
+    original = list(ar.routes)
+    result = ar.apply_diffpair_length_tuning(pairs, verbose=False)[("USB_D+", "USB_D-")]
+    assert result.reason == "no_suitable_segment"
+    assert all(a is b for a, b in zip(original, ar.routes, strict=True))
+    assert ar.routes[0].vias[0] is via
+
+
+def test_earlier_foreign_fragment_rejects_and_retains_original_objects():
+    ar, pairs = setup()
+    # The shorter half bulges away from the partner at y=20, toward y<10.
+    ar.routes.extend([fragment(9, 5, 20, 9.5), fragment(9, 2, 3, 35)])
+    for route in ar.routes[-2:]:
+        ar._mark_route(route)
+    original = list(ar.routes)
+    geometry = copy.deepcopy([(r.segments, r.vias) for r in original])
+    result = ar.apply_diffpair_length_tuning(pairs, verbose=False)[("USB_D+", "USB_D-")]
+    assert result.reason == "post_insertion_drc_violation"
+    assert all(a is b for a, b in zip(original, ar.routes, strict=True))
+    assert [(r.segments, r.vias) for r in ar.routes] == geometry
+    assert result.skew_after_mm == pytest.approx(4)
+
+
+@pytest.mark.parametrize("reverse", [False, True])
+def test_fragment_order_and_vias_are_preserved_once(reverse):
+    ar, pairs = setup(split=True)
+    vias = [
+        Via(6, 10, 0.6, 0.3, (Layer.F_CU, Layer.B_CU), net=1),
+        Via(9, 10, 0.6, 0.3, (Layer.F_CU, Layer.B_CU), net=1),
+    ]
+    ar.routes[0].vias.append(vias[0])
+    ar.routes[1].vias.append(vias[1])
+    if reverse:
+        ar.routes.reverse()
+    ar.restore_route_snapshot(ar.routes)
+    original = list(ar.routes)
+    ar.apply_diffpair_length_tuning(pairs, verbose=False)
+    assert abs(length(ar, 1) - length(ar, 2)) <= 0.5
+    assert sorted(id(v) for r in ar.routes for v in r.vias) == sorted(map(id, vias))
+    assert any(r is old for r in ar.routes for old in original if old.is_escape and old.net == 1)
+    assert ar.diffpair_length_tracker.lengths[1] == pytest.approx(length(ar, 1))
+    assert ar.diffpair_length_tracker.lengths[2] == pytest.approx(length(ar, 2))
+
+
+@pytest.mark.parametrize("disabled", [False, True])
+def test_untuned_fragments_keep_identity_and_complete_tracker(disabled):
+    from kicad_tools.router.rules import NetClassRouting
+
+    ar, pairs = setup(split=True)
+    if disabled:
+        ar.net_class_map = {"USB_D+": NetClassRouting(name="No tuning", length_critical=False)}
+    else:
+        # Trim the longer channel to the same complete-net length.
+        ar.routes[-1].segments[0].x2 -= 4
+        ar.restore_route_snapshot(ar.routes)
+    original = list(ar.routes)
+    result = ar.apply_diffpair_length_tuning(pairs, verbose=False)[("USB_D+", "USB_D-")]
+    assert result.reason == ("not_length_critical" if disabled else "already_within_tolerance")
+    assert all(a is b for a, b in zip(original, ar.routes, strict=True))
+    assert ar.diffpair_length_tracker.lengths[1] == pytest.approx(length(ar, 1))
+    assert ar.diffpair_length_tracker.lengths[2] == pytest.approx(length(ar, 2))


### PR DESCRIPTION
Diff-pair skew tuning previously measured the last fragment of each net and replaced its first fragment. A real 10 mm/14 mm pair could report zero skew while publishing 22 mm/14 mm, losing an escape and retaining duplicate channel copper.

Build complete-net views, exclude fixed escapes from serpentine host selection, and publish each accepted mutable replacement once through shared snapshot restoration. Preserve escape/via ownership, independent grid copper, and original objects on no-op or rejected tuning. Feed complete views to the refreshed pair tracker so its lengths agree with published copper. Existing default planar/unspecified-stack-thickness measurement semantics remain unchanged.

Closes #5293. This repairs `apply_diffpair_length_tuning`; sibling #5291 changes `apply_match_group_tuning`. Review combined core.py integration when either merges. This does not close or qualify Board07 issue #5286.

Validation:
- 90 regression tests passed, zero skips, with freshly built matching native extensions: split-pair controls, skew tuning/tracking, snapshot/negotiated geometry, clearance and CLI checks.
- Controls cover both shorter polarities, multiple/reordered fragments, longer fixed escapes, via identity, real pad connectivity, independent grid copper, prebuilt collision checkers, native occupancy/spatial indexes, repeated/disabled/within-tolerance paths and rejection against earlier foreign copper.
- Seven initial Python controls fail against unmodified main696315f0; three native cases skip in that isolated base archive. Corrected source passes all final 12 controls, including native cases.
- Ruff, formatting and whitespace pass. Cold mypy: 1422 existing errors within the 1472 baseline, no new errors.

Evidence: /tmp/kicad-5293-final-regression.log, /tmp/kicad-5293-negative.log, /tmp/kicad-5293-native-build.log and /tmp/kicad-5293-mypy.log. Fresh CI and independent review are required.