### PR TITLE
fix(router): retain bare net names through normalization

### DIFF
--- a/src/kicad_tools/router/io.py
+++ b/src/kicad_tools/router/io.py
@@ -2088,23 +2088,31 @@ def extract_pad_positions(pcb_path_or_text: str | Path) -> list[PadPosition]:
     return positions
 
 
-# Match complete references while skipping quoted strings and comments elsewhere.
-# This keeps text such as a property containing "(net 7 FAKE)" out of the map.
-_NET_ATOM = r'"(?:\\.|[^"\\])*"|[^\s()";]+'
-_NET_REFERENCE = re.compile(
-    rf"(?P<reference>\(net\s+(?P<first>{_NET_ATOM})"
-    rf'(?:\s+(?P<second>{_NET_ATOM}))?\s*\))|"(?:\\.|[^"\\])*"|;[^\n]*'
-)
+# Tokenize whole atoms before considering the next comment boundary. In the
+# project parser, SPI;SELECT and SPI#SELECT are atoms; # and ; start comments
+# only when encountered where a new token would begin.
+_NET_TOKEN = re.compile(r'(?P<comment>[#;][^\n]*)|"(?:\\.|[^"\\])*"|[()]|[^\s()]+')
 
 
 def _iter_net_references(text: str) -> Iterator[tuple[int | None, str]]:
     """Read numeric/name, name-only and numeric-only references consistently."""
     from kicad_tools.sexp import parse_string
 
-    for match in _NET_REFERENCE.finditer(text):
-        if match.group("reference") is None:
+    tokens = (match.group() for match in _NET_TOKEN.finditer(text) if not match.group("comment"))
+    for token in tokens:
+        if token != "(":
             continue
-        first, second = match.group("first", "second")
+        if next(tokens, None) != "net":
+            continue
+        values: list[str] = []
+        for token in tokens:
+            if token == ")":
+                break
+            values.append(token)
+        if not 1 <= len(values) <= 2 or "(" in values:
+            continue
+        first = values[0]
+        second = values[1] if len(values) == 2 else None
         numeric = first.isdecimal()
         if second is not None and not numeric:
             continue

--- a/src/kicad_tools/router/io.py
+++ b/src/kicad_tools/router/io.py
@@ -38,6 +38,7 @@ import logging
 import math
 import re
 import warnings
+from collections.abc import Iterator
 from dataclasses import dataclass, replace
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -2087,6 +2088,43 @@ def extract_pad_positions(pcb_path_or_text: str | Path) -> list[PadPosition]:
     return positions
 
 
+# Match complete references while skipping quoted strings and comments elsewhere.
+# This keeps text such as a property containing "(net 7 FAKE)" out of the map.
+_NET_ATOM = r'"(?:\\.|[^"\\])*"|[^\s()";]+'
+_NET_REFERENCE = re.compile(
+    rf"(?P<reference>\(net\s+(?P<first>{_NET_ATOM})"
+    rf'(?:\s+(?P<second>{_NET_ATOM}))?\s*\))|"(?:\\.|[^"\\])*"|;[^\n]*'
+)
+
+
+def _iter_net_references(text: str) -> Iterator[tuple[int | None, str]]:
+    """Read numeric/name, name-only and numeric-only references consistently."""
+    from kicad_tools.sexp import parse_string
+
+    for match in _NET_REFERENCE.finditer(text):
+        if match.group("reference") is None:
+            continue
+        first, second = match.group("first", "second")
+        numeric = first.isdecimal()
+        if second is not None and not numeric:
+            continue
+        net_num = int(first) if numeric else None
+        name = second if second is not None else ("" if numeric else first)
+        if name.startswith('"'):
+            # Use the project's string decoder, including escaped quotes/backslashes.
+            name = str(parse_string(f"(name {name})").children[0].value)
+        yield net_num, name
+
+
+def _resolve_pad_net(text: str, net_map: dict[str, int]) -> tuple[int, str]:
+    net_num, name = next(_iter_net_references(text), (None, ""))
+    if net_num is None:
+        return net_map.get(name, 0), name
+    if not name:
+        name = next((key for key, value in net_map.items() if value == net_num), "")
+    return net_num, name
+
+
 def _build_net_number_map(pcb_text: str) -> dict[str, int]:
     """Resolve net name -> net number for BOTH KiCad net-reference dialects.
 
@@ -2111,20 +2149,17 @@ def _build_net_number_map(pcb_text: str) -> dict[str, int]:
     first-seen order -- so name-only nets get a stable, routable id
     instead of collapsing to ``net_num=0``.
     """
+    references = list(_iter_net_references(pcb_text))
     net_map: dict[str, int] = {}
-    for match in re.finditer(r'\(net\s+(\d+)\s+"([^"]*)"\)', pcb_text):
-        net_num, net_name = int(match.group(1)), match.group(2)
-        if net_num > 0 and net_name and net_name not in net_map:
+    for net_num, net_name in references:
+        if net_num is not None and net_num > 0 and net_name and net_name not in net_map:
             net_map[net_name] = net_num
 
-    used_ids = set(net_map.values())
+    # Reserve numeric-only references too, so synthesis never aliases authored IDs.
+    used_ids = {number for number, _ in references if number is not None and number > 0}
     next_id = 1
-    # Name-only inline references, e.g. pad/segment/via ``(net "NAME")``
-    # with no numeric id -- never matched by the pattern above (which
-    # requires a digit immediately after ``(net``).
-    for match in re.finditer(r'\(net\s+"([^"]*)"\)', pcb_text):
-        net_name = match.group(1)
-        if not net_name or net_name in net_map:
+    for net_num, net_name in references:
+        if net_num is not None or not net_name or net_name in net_map:
             continue
         while next_id in used_ids:
             next_id += 1
@@ -2163,7 +2198,6 @@ def load_pads_for_analysis(pcb_path_or_text: str | Path) -> list[Pad]:
     # Resolve net name <-> number for both KiCad net-reference dialects
     # (numeric-plus-name and KiCad 9/10 name-only) -- issue #4983.
     net_name_to_num = _build_net_number_map(pcb_text)
-    net_num_to_name = {v: k for k, v in net_name_to_num.items()}
 
     # Split by footprint for easier parsing
     footprint_sections = re.split(r"(?=\((?:footprint|module)\s)", pcb_text)
@@ -2236,22 +2270,7 @@ def load_pads_for_analysis(pcb_path_or_text: str | Path) -> list[Pad]:
             pad_rot = float(pad_rot_match.group(1)) if pad_rot_match else 0.0
             width, height, pad_rotation = _resolve_pad_dims_and_rotation(pad_rot, width, height)
 
-            # Extract net. Handles both the numeric-plus-name dialect
-            # (``(net N "NAME")``) and the KiCad 9/10 name-only dialect
-            # (``(net "NAME")`` with no numeric id) -- issue #4983.
-            net_match = re.search(r"\(net\s+(\d+)", pad_block)
-            if net_match:
-                net_num = int(net_match.group(1))
-                net_name_match = re.search(r'\(net\s+\d+\s+"?([^"\)]+)"?\)', pad_block)
-                net_name = (
-                    net_name_match.group(1).strip()
-                    if net_name_match
-                    else net_num_to_name.get(net_num, "")
-                )
-            else:
-                net_name_match = re.search(r'\(net\s+"([^"]*)"\)', pad_block)
-                net_name = net_name_match.group(1).strip() if net_name_match else ""
-                net_num = net_name_to_num.get(net_name, 0) if net_name else 0
+            net_num, net_name = _resolve_pad_net(pad_block, net_name_to_num)
 
             # Determine layer
             layer = Layer.F_CU
@@ -3386,7 +3405,10 @@ def _extract_pad_blocks(section: str) -> list[str]:
         while i < len(section):
             char = section[i]
 
-            if char == '"' and (i == 0 or section[i - 1] != "\\"):
+            if in_string and char == "\\":
+                i += 2
+                continue
+            if char == '"':
                 in_string = not in_string
             elif not in_string:
                 if char == "(":
@@ -3826,21 +3848,7 @@ def load_pcb_for_routing(
             pad_w = float(size_match.group(1))
             pad_h = float(size_match.group(2))
 
-            # Extract net (if present)
-            # KiCad 7/8: (net <number> "name"), KiCad 9+: (net "name")
-            net_match = re.search(r'\(net\s+(\d+)\s+"([^"]+)"\)', pad_block)
-            if net_match:
-                net_num = int(net_match.group(1))
-                net_name = net_match.group(2)
-            else:
-                # KiCad 9 name-only format
-                net_name_match = re.search(r'\(net\s+"([^"]+)"\)', pad_block)
-                if net_name_match:
-                    net_name = net_name_match.group(1)
-                    net_num = net_map.get(net_name, 0)
-                else:
-                    net_num = 0
-                    net_name = ""
+            net_num, net_name = _resolve_pad_net(pad_block, net_map)
 
             # Extract drill size if present
             drill_match = re.search(r"\(drill\s+([\d.]+)", pad_block)

--- a/tests/test_benchmark_external.py
+++ b/tests/test_benchmark_external.py
@@ -429,3 +429,27 @@ class TestLoadWithUpgrade:
         # not a valid path to run).
         result = normalize.load_with_upgrade(FIXTURE_PCB, kicad_cli=Path("/should/not/be/used"))
         assert isinstance(result, PCB)
+
+
+def test_normalization_preserves_routing_net_names(normalize, tmp_path):
+    from kicad_tools.router.io import _build_net_number_map, load_pcb_for_routing
+
+    source = tmp_path / "source.kicad_pcb"
+    # Preserve bare atoms through the same load/rip-up/save path used by STRF.
+    source.write_text(FIXTURE_PCB.read_text().replace('"SIGNAL_A"', "SIGNAL_A"))
+    output = tmp_path / "normalized.kicad_pcb"
+    normalize.normalize_board(source, output)
+    board = PCB.load(output)
+    names = {net.name for net in board.nets.values() if net.name}
+    net_map = _build_net_number_map(output.read_text())
+    assert set(net_map) == names
+    router, routed_map = load_pcb_for_routing(str(output))
+    assert routed_map == net_map
+    expected = {
+        (fp.reference, pad.number): pad.net_name
+        for fp in board.footprints
+        for pad in fp.pads
+        if pad.net_name
+    }
+    actual = {key: router.net_names[net] for net, keys in router.nets.items() for key in keys}
+    assert actual == expected

--- a/tests/test_router_name_only_net_routing_4983.py
+++ b/tests/test_router_name_only_net_routing_4983.py
@@ -418,3 +418,39 @@ class TestRejectLostRouteOnlyBindings:
         rc = _reject_lost_route_only_bindings(args, 0)
         assert rc is not None
         assert rc != 0
+
+
+class TestBareNetReferences:
+    def test_mixed_ids_escaping_and_nonreference_text(self):
+        text = r"""(kicad_pcb (net 41 USB_D+) (net SPI3_SCK) (net 1)
+          (net 9 "quoted\"name\\path") (net " spaced ")
+          (property "Description" "(net 99 FAKE)")
+          ; (net 88 COMMENT)
+          (net USB_D+) (net 0 ""))"""
+        assert _build_net_number_map(text) == {
+            "USB_D+": 41,
+            'quoted"name\\path': 9,
+            "SPI3_SCK": 2,
+            " spaced ": 3,
+        }
+
+    def test_quoted_bare_graph_equivalence_and_roundtrip(self, tmp_path):
+        from kicad_tools.sexp import parse_string
+
+        for template in (_NUMERIC_FIXTURE, _NAME_ONLY_FIXTURE):
+            for name in ("USB_D+", "SPI3_SCK", "/bus/D-", "+-_", 'quote"slash\\'):
+                encoded = name.replace("\\", "\\\\").replace('"', '\\"')
+                quoted = template.replace('"SIGNAL"', f'"{encoded}"')
+                forms = [quoted, parse_string(quoted).to_string()]
+                if '"' not in name and "\\" not in name:
+                    forms.append(quoted.replace(f'"{encoded}"', name))
+                for index, text in enumerate(forms):
+                    path = tmp_path / f"form-{index}.kicad_pcb"
+                    path.write_text(text)
+                    router, net_map = load_pcb_for_routing(str(path))
+                    assert net_map == {name: 1}
+                    assert len(router.nets[1]) == 2
+                    assert router.net_names[1] == name
+                    pads = load_pads_for_analysis(path)
+                    assert len(pads) == 2
+                    assert {pad.net for pad in pads} == {1}

--- a/tests/test_router_name_only_net_routing_4983.py
+++ b/tests/test_router_name_only_net_routing_4983.py
@@ -438,7 +438,15 @@ class TestBareNetReferences:
         from kicad_tools.sexp import parse_string
 
         for template in (_NUMERIC_FIXTURE, _NAME_ONLY_FIXTURE):
-            for name in ("USB_D+", "SPI3_SCK", "/bus/D-", "+-_", 'quote"slash\\'):
+            for name in (
+                "USB_D+",
+                "SPI3_SCK",
+                "SPI;SELECT",
+                "SPI#SELECT",
+                "/bus/D-",
+                "+-_",
+                'quote"slash\\',
+            ):
                 encoded = name.replace("\\", "\\\\").replace('"', '\\"')
                 quoted = template.replace('"SIGNAL"', f'"{encoded}"')
                 forms = [quoted, parse_string(quoted).to_string()]
@@ -454,3 +462,18 @@ class TestBareNetReferences:
                     pads = load_pads_for_analysis(path)
                     assert len(pads) == 2
                     assert {pad.net for pad in pads} == {1}
+
+    def test_comment_boundaries_match_parser(self):
+        from kicad_tools.sexp import parse_string
+
+        text = """(kicad_pcb
+          # (net 99 FAKE_HASH)
+          ; (net 88 FAKE_SEMICOLON)
+          (net # ignored before numeric id
+            41 ; ignored before name
+            USB_D+)
+          (net 42 SPI;SELECT) (net 43 SPI#SELECT)
+          (net "#quoted") (net ";quoted"))"""
+        expected = {"USB_D+": 41, "SPI;SELECT": 42, "SPI#SELECT": 43, "#quoted": 1, ";quoted": 2}
+        assert _build_net_number_map(text) == expected
+        assert _build_net_number_map(parse_string(text).to_string()) == expected


### PR DESCRIPTION
Normalization can serialize valid net names as bare atoms, but routing accepted only quoted names. On the pinned STRF input this silently removed 21 named nets and matched none of the eight tuned sidecar entries. Shared net-reference parsing now preserves numeric/name and name-only references in quoted or bare form across the net map and both pad readers. Authored IDs remain reserved, synthetic IDs stay deterministic, quoted escapes are decoded, and strings/comments containing apparent references are ignored. The scanner consumes complete atoms before recognizing # or ; comments at token boundaries, preserving internal punctuation such as SPI;SELECT. Pad-block scanning also handles an escaped trailing backslash correctly.

Closes #5302.

Validation:
- Current repair: 261 focused routing IO, #4983 dialect and external-benchmark tests pass with matching native extensions, zero skips. Quoted/bare SPI;SELECT and SPI#SELECT round trips preserve both pads; both comment forms and comments between reference tokens are covered. Both added review controls fail on the prior PR head. The prior head also passed 260 tests with the Python backend.
- All three new regression controls fail on unchanged main e799f868 (two dialect controls plus the strengthened normalization control).
- Exact STRF normalized input SHA256 `12d4e05ee37fa59c036cc4dea32d9e8ea3b84c28617b5be2da76322ca6998bca`: both the net map and real router contain all 49 named nets; all 8 tuned sidecar entries match (schema has 50 entries including net0).
- Ruff, format and diff checks pass. Local mypy reports 1429 errors, all within the 1472 baseline; installed mypy 1.19.1 differs from lockfile 2.3.1, so CI remains authoritative.
- At the prior head 1a171068, the fresh pinned tuned STRF benchmark completed with native routing in 120.677s: 49 named nets, no original 0/8 sidecar mismatch, but route exit 2/partial, zero newly completed connections and 0/2 complete USB pairs. Native KiCad CLI was not found, so its DRC was skipped. The harness exit 0 means report generation succeeded; it does not mean routing passed. Full STRF routing qualification is not claimed.

Native modules were copied from the prior local #5293 build; the complete source diff to this base contains only Python files and tests, so native sources and CPython ABI match. No external board bytes are committed.
