### PR TITLE
fix(router): choose affordable safe grids before refusing routing

### DIFF
--- a/src/kicad_tools/router/cache.py
+++ b/src/kicad_tools/router/cache.py
@@ -75,7 +75,8 @@ def routing_cache_context(options: Mapping[str, object], net_class_map: dict) ->
 # Edge.Cuts bounds/origin change the routing domain for identical PCB bytes.
 # Bumped strictly above both parents so neither isolated implementation's
 # cache entries are silently reused.
-CACHE_VERSION = "2.5.1-outline-domain"
+# Auto-grid candidate preference and phase-shifted zones change routed copper.
+CACHE_VERSION = "2.5.2-safe-auto-grid"
 
 
 def get_default_cache_path() -> Path:

--- a/src/kicad_tools/router/io.py
+++ b/src/kicad_tools/router/io.py
@@ -1040,8 +1040,8 @@ def _compute_zone_resolution_and_offset(
     Args:
         comp_pads: List of Pad objects belonging to the component.
         coarse_resolution: The coarse global grid resolution in mm.  The
-            chosen fine resolution will be strictly finer than this (a
-            fine zone at the coarse resolution would be redundant).
+            chosen resolution can equal this when a different origin offset
+            aligns the component; a shifted zone is not redundant.
         min_fine_resolution: Floor for the fine grid resolution (mm).
             Below this, the candidate is rejected as impractical.
 
@@ -1056,17 +1056,16 @@ def _compute_zone_resolution_and_offset(
     # Build candidate resolutions: fixed grid-fraction values plus
     # GCD-derived candidates from this component's pad spacings.  Coarsest
     # values come first so we prefer the cheapest fine zone that works.
-    fixed_candidates = [0.1, 0.05, 0.04, 0.025, 0.02, 0.0125, 0.01]
+    fixed_candidates = [coarse_resolution, 0.1, 0.0635, 0.05, 0.04, 0.025, 0.02, 0.0125, 0.01]
     gcd_candidates = _compute_gcd_grid_candidates(comp_pads, min_grid=min_fine_resolution)
     raw_candidates = sorted(
         {round(c, 6) for c in (fixed_candidates + gcd_candidates)},
         reverse=True,
     )
 
-    # Keep only candidates strictly finer than the coarse grid and at or
-    # above the minimum floor.  A fine zone at >= coarse_resolution would
-    # not refine anything (the coarse grid would suffice).
-    candidates = [c for c in raw_candidates if c < coarse_resolution and c >= min_fine_resolution]
+    # A phase-shifted zone can use the same spacing as the coarse grid.
+    # Keep the existing minimum floor and never choose a coarser spacing.
+    candidates = [c for c in raw_candidates if c <= coarse_resolution and c >= min_fine_resolution]
 
     if not candidates:
         # Fall back to half the coarse grid floored at the minimum.  This
@@ -1117,7 +1116,7 @@ def auto_select_grid_resolution(
         board_height: Board height in mm (for memory constraint check)
         max_cells: Maximum grid cells to allow (default: 500k for performance)
         candidates: Optional list of candidate resolutions to try.
-                   Default: [0.5, 0.25, 0.127, 0.1, 0.065, 0.05, 0.0508]
+                   Default: [0.5, 0.25, 0.127, 0.1, 0.065, 0.0635, 0.05, 0.0508]
                    plus GCD-derived candidates from pad spacings.
                    When candidates is None, GCD-based candidates are
                    automatically computed from pad positions and added
@@ -1165,12 +1164,13 @@ def auto_select_grid_resolution(
     #             imperial THT (2.54mm / 0.127 = 20, 5.08mm / 0.127 = 40)
     #   - 0.1mm: Metric footprints, QFP (0.5mm / 0.1 = 5)
     #   - 0.065mm: TSSOP (0.65mm / 0.065 = 10 exact)
+    #   - 0.0635mm (2.5 mil): half the 5-mil lattice, with tighter clearance
     #   - 0.05mm: Good metric alignment but NOT imperial-compatible
     #             (2.54 / 0.05 = 50.8, off-grid by 0.04mm)
     #   - 0.0508mm (2 mil): Imperial-compatible for tight DRC constraints
     #             (2.54 / 0.0508 = 50 exact, 5.08 / 0.0508 = 100 exact)
     if candidates is None:
-        candidates = [0.5, 0.25, 0.127, 0.1, 0.065, 0.05, 0.0508]
+        candidates = [0.5, 0.25, 0.127, 0.1, 0.065, 0.0635, 0.05, 0.0508]
 
         # Add GCD-derived candidates from pad spacings.  This handles
         # packages like SSOP/TSSOP whose 0.65mm pitch doesn't align to
@@ -1452,6 +1452,17 @@ def auto_select_grid_resolution(
         min_spacing = _min_pad_center_spacing(pad_list)
         has_fine_pitch = min_spacing is not None and min_spacing <= FINE_PITCH_SPACING_MM
     memory_forced_unsafe_grid = grid_unsafe_by_memory_cap and not lattice_rescued and has_fine_pitch
+    if memory_forced_unsafe_grid:
+        # Pad alignment must not make us reject an otherwise usable safe grid.
+        # The memory filter has already bounded these candidates. Prefer the
+        # best aligned clearance-safe survivor before invoking the hard gate.
+        safe_candidates = [c for c in valid_candidates if c <= recommended_max]
+        if safe_candidates:
+            best_resolution = min(safe_candidates, key=lambda c: (_off_grid_for(c)[0], -c))
+            best_off_grid, best_offset = _off_grid_for(best_resolution)
+            off_grid_pct = best_off_grid / total_pads * 100 if total_pads else 0.0
+            grid_unsafe_by_memory_cap = False
+            memory_forced_unsafe_grid = False
     if grid_unsafe_by_memory_cap:
         if lattice_rescued:
             # Issue #3441: the lattice rescue *chose* this grid because it

--- a/tests/test_grid_auto_selection.py
+++ b/tests/test_grid_auto_selection.py
@@ -1724,3 +1724,42 @@ class TestIssue2387MultiResPlanWithBoardDims:
                     f"memory-busting grid; got {plan.coarse_resolution}mm "
                     f"-> {cells:.0f} cells"
                 )
+
+
+class TestShiftedCoarseGridSelection:
+    @pytest.mark.parametrize("noise", [0.0, 0.0000001])
+    def test_shifted_header_uses_coarse_spacing_without_refinement(self, noise):
+        from kicad_tools.router.io import _compute_zone_resolution_and_offset
+
+        pads = [
+            PadPosition(x=10.0111 + i * 2.54 + (noise if i % 2 else 0), y=20.0136)
+            for i in range(18)
+        ]
+        resolution, x_offset, y_offset = _compute_zone_resolution_and_offset(pads, 0.127)
+        assert resolution == 0.127
+        assert _count_off_grid_with_offset(pads, resolution, x_offset, y_offset) == 0
+
+    def test_genuinely_off_grid_pad_still_requires_refinement(self):
+        from kicad_tools.router.io import _compute_zone_resolution_and_offset
+
+        pads = [PadPosition(x=i * 2.54, y=0) for i in range(18)]
+        pads[-1].x += 0.04
+        resolution, x_offset, y_offset = _compute_zone_resolution_and_offset(pads, 0.127)
+        assert resolution < 0.127
+        assert _count_off_grid_with_offset(pads, resolution, x_offset, y_offset) == 0
+
+    def test_safe_survivor_precedes_coarse_alignment_under_memory_pressure(self):
+        pads = [PadPosition(x=0, y=0), PadPosition(x=0.5, y=0)]
+        result = auto_select_grid_resolution(
+            pads,
+            clearance=0.15,
+            board_width=30,
+            board_height=30,
+            max_cells=500_000,
+            candidates=[0.1, 0.05, 0.005],
+        )
+        assert result.memory_capped
+        assert result.resolution == 0.05
+        assert result.clearance_compliant_at_clearance_over_2
+        assert not result.memory_forced_unsafe_grid
+        assert 30 * 30 / result.resolution**2 <= result.memory_budget_used

--- a/tests/test_grid_safety_gate_fleet.py
+++ b/tests/test_grid_safety_gate_fleet.py
@@ -1,28 +1,10 @@
-"""Issue #3911: fleet-level enforcement of the memory-forced-unsafe-grid gate.
+"""Fleet auto-grid safety: usable safe candidates must precede refusal.
 
-The unit suite (``test_grid_auto_selection.py`` /
-``test_route_grid_safety_gate.py``) exercises the flag and the CLI gate on
-synthetic pad sets.  This file closes the gap the judge flagged on PR #3945:
-the "no regression on boards 00-04, 06, 07" claim must be enforced by a test,
-not just asserted in the PR description.
-
-It runs the *real* auto-grid selector over every committed demo-board input
-PCB (the pre-route ``*.kicad_pcb`` each recipe hands to ``kct route``) at the
-route default clearance (0.15mm) and asserts exactly which boards trip the
-gate:
-
-* Board 05 (bldc-motor-controller) is the ONLY board that both (a) is coerced
-  onto a grid > clearance/2 by the memory budget and (b) is fine-pitch (0.5mm
-  DRV8301) -- so it is the only board the gate refuses by default.  Its recipe
-  passes ``--allow-unsafe-grid`` to opt in explicitly.
-* Every OTHER board must leave ``memory_forced_unsafe_grid`` False, so
-  ``kct route`` keeps producing their routed artifacts (the four CI board jobs
-  the judge saw go red on the un-narrowed gate: board 01 / 05 / 07 end-to-end
-  and match-group regression).
-
-The selector is evaluated at BOTH the gate's default budget (500k, what
-``route_cmd`` passes) and the multi-resolution routing budget (2M) so a future
-budget change on either path cannot silently re-introduce the over-fire.
+The historical Board05 geometry formerly selected a coarse aligned grid and
+tripped the gate despite an affordable clearance-safe candidate. It must now
+select the safe grid; genuine no-safe-candidate refusal remains covered by
+synthetic selector and CLI gate tests. Other fleet boards retain their prior
+ungated behavior at both supported cell budgets.
 """
 
 from __future__ import annotations
@@ -45,15 +27,14 @@ REPO_ROOT = Path(__file__).resolve().parent.parent
 ROUTE_DEFAULT_CLEARANCE = 0.15
 
 #: (board dir, input-PCB stem, expected memory_forced_unsafe_grid).
-#: Board 05 is the sole gated board (fine-pitch + memory-coerced); every other
-#: board must stay False so its CI end-to-end / regression job keeps routing.
+#: Board05 now uses its affordable safe candidate; no fixture needs refusal.
 FLEET: list[tuple[str, str, bool]] = [
     ("00-simple-led", "simple_led", False),
     ("01-voltage-divider", "voltage_divider", False),
     ("02-charlieplex-led", "charlieplex_3x3", False),
     ("03-usb-joystick", "usb_joystick", False),
     ("04-stm32-devboard", "stm32_devboard", False),
-    ("05-bldc-motor-controller", "bldc_controller", True),
+    ("05-bldc-motor-controller", "bldc_controller", False),
     ("06-diffpair-test", "diffpair_test", False),
     ("07-matchgroup-test", "matchgroup_test", False),
 ]
@@ -72,7 +53,7 @@ def _input_pcb(board_dir: str, stem: str) -> Path:
 @pytest.mark.parametrize("budget", [500_000, 2_000_000])
 @pytest.mark.parametrize("board_dir,stem,expected", FLEET)
 def test_fleet_gate_signal(board_dir: str, stem: str, expected: bool, budget: int) -> None:
-    """Only board 05 trips ``memory_forced_unsafe_grid`` -- at either budget."""
+    """Keep fleet routes ungated and historical Board05 on an affordable safe grid."""
     pcb = _input_pcb(board_dir, stem)
     if not pcb.exists():
         pytest.skip(f"input PCB not committed: {pcb}")
@@ -97,23 +78,15 @@ def test_fleet_gate_signal(board_dir: str, stem: str, expected: bool, budget: in
         f"(expected {expected}); selected grid {result.resolution}mm, "
         f"clearance/2={ROUTE_DEFAULT_CLEARANCE / 2}mm, "
         f"memory_capped={result.memory_capped}. "
-        "A True here on a non-05 board is the over-fire that refuses a board "
-        "which routes cleanly; a False on board 05 lets the predicted shorts "
-        "ship silently."
     )
-
-
-def test_exactly_one_board_is_gated() -> None:
-    """Guard the fleet map itself: precisely one board opts into the gate."""
-    gated = [b for b, _, expected in FLEET if expected]
-    assert gated == ["05-bldc-motor-controller"], (
-        f"Expected board 05 to be the sole gated board, got {gated}"
-    )
+    if board_dir == "05-bldc-motor-controller":
+        assert result.resolution <= ROUTE_DEFAULT_CLEARANCE / 2
+        assert dims[0] * dims[1] / result.resolution**2 <= result.memory_budget_used
 
 
 #: The verbatim substring of the alarming auto-grid warning (issue #3942).
 #: It literally claims risk "at fine-pitch pads", so it must fire ONLY on the
-#: fine-pitch memory-coerced board (05) -- never on a clean, no-fine-pitch board
+#: fine-pitch memory-coerced board -- never on an affordable safe selection
 #: that routes DRC-clean (boards 01 / 07 tripped it before the #3942 gate fix).
 _MEMORY_CAP_WARNING = "memory budget cap forces grid"
 
@@ -159,9 +132,7 @@ def test_fleet_memory_cap_warning_matches_gate(
     assert fired is expected, (
         f"{board_dir} @ max_cells={budget:,}: memory-cap clearance warning "
         f"fired={fired} (expected {expected}). The warning claims risk 'at "
-        f"fine-pitch pads' and must track the gate exactly -- a True on a "
-        f"non-05 board is the #3942 false alarm that tells a DRC-clean board "
-        f"it is at risk; a False on board 05 drops a genuine warning. "
+        f"fine-pitch pads' and must track the selected grid's gate. "
         f"Warnings seen: {warning_texts}"
     )
 

--- a/tests/test_router_grid_auto_bump.py
+++ b/tests/test_router_grid_auto_bump.py
@@ -142,8 +142,8 @@ def _on_grid_resistor_pads(
 class TestComputeZoneResolutionAndOffset:
     """Tests for the per-component (resolution, offset) solver."""
 
-    def test_on_grid_component_picks_coarsest_finer_than_coarse(self):
-        """A component whose pads are on a 0.05mm grid prefers 0.05mm."""
+    def test_on_grid_component_keeps_coarse_spacing(self):
+        """Already aligned pads do not require a finer spacing."""
         # 4 pads at x = 10, 11, 12, 13; y = 5 (all multiples of 0.05)
         pads = [_make_pad(10.0 + i, 5.0, "R1", str(i + 1)) for i in range(4)]
         res, x_off, y_off = _compute_zone_resolution_and_offset(
@@ -151,12 +151,11 @@ class TestComputeZoneResolutionAndOffset:
             coarse_resolution=0.1,
             min_fine_resolution=0.005,
         )
-        # The coarsest fine grid finer than 0.1mm that aligns is 0.05mm.
-        assert res == 0.05
+        assert res == 0.1
         assert (x_off, y_off) == (0.0, 0.0)
 
     def test_half_grid_pads_use_offset(self):
-        """Pads at half-grid use 0.05mm with no offset (50.025mm % 0.05 = 0.025)."""
+        """A shifted origin aligns half-grid pads without doubling resolution."""
         # USB-C-style pads at x = 137.250 (10x exact for 0.05mm: 2745.0)
         pads = [
             _make_pad(137.250, 100.0, "J1", "1"),
@@ -168,9 +167,8 @@ class TestComputeZoneResolutionAndOffset:
             coarse_resolution=0.1,
             min_fine_resolution=0.005,
         )
-        # 137.250 % 0.05 = 0 (250.5 = exact 250 in float terms within
-        # threshold). 0.05 should be chosen at offset (0, 0).
-        assert res == 0.05
+        assert res == 0.1
+        assert x_off == pytest.approx(0.05)
         # All pads must be on the chosen (res, offset) grid:
         for p in pads:
             assert _is_on_grid_with_offset(p.x, res, x_off)


### PR DESCRIPTION
PocketBeagle's default grid selection rejected routing even though a clearance-safe candidate fit its uniform-grid cell budget. Select the best aligned safe survivor before invoking the existing unsafe-grid gate, add the standard 2.5-mil candidate, and allow a component zone to retain the coarse spacing when only its origin needs shifting. Cache epoch advances to invalidate earlier route geometry.

Diagnosis on the pinned normalized board refutes the suggested rounding cause: P1/P2 each have 36 pads at 2.54 mm center spacing, all aligned on a shifted 0.127 mm grid. The old zone solver excluded that spacing and selected 0.02 mm. Separately, the uniform selector chose 0.127 mm for alignment despite an affordable 0.065 mm candidate; the gate correctly rejected the chosen grid. Zone cost did not cause that gate decision.

After repair, default selection uses 0.0635 mm (about 477,401 uniform cells, below 500,000). Each header zone drops from 771,720 to 76,529 estimated cells. The total adaptive-plan estimate is about 1.11 million cells; this PR does not claim the existing adaptive aggregate estimate is bounded by the uniform-grid budget. It changes neither the cell-budget retry ceiling nor any clearance tolerance, manufacturing check, board geometry, or unsafe-grid opt-in.

Validation:

- 420 tests passed across grid selection, shifted zones, adaptive consumers, fleet selection, cache and the full CLI safety-gate suite. New controls cover exact/near-grid shifted headers, genuine off-grid refinement, and an affordable safe candidate under memory pressure. Existing no-affordable-safe-grid and CLI refusal controls remain enabled.
- Historical Board05 now selects an affordable clearance-safe grid rather than rejecting its previously preferred coarse candidate. Its fleet tests explicitly assert clearance/2 and cell-budget compliance; no routing/manufacturing qualification is claimed by those selection tests.
- Ruff lint/format, whitespace and version gates pass. Lock-pinned mypy baseline passes (1422 within 1472; no new errors). An initial advisory test failure with the shared stale host environment reproduced on unchanged main; all 78 CLI gate tests pass in the fresh lock-pinned worktree environment.
- Reproduced the original default CLI exit1 at grid selection. Built native extensions in the pinned KiCad10.0.5 runtime and repeated the default seed42 invocation with the final production source, a fresh cache and an external 120-second process limit. It now passes grid selection and reaches PCB loading, where every layer attempt is refused by the existing unsupported curved Edge.Cuts check. Exit1 remains; no route output or completed benchmark is claimed. The external deadline did not fire.

Local reproducibility artifacts: `/tmp/loom-4945-before.{stdout,stderr}`, `/tmp/loom-4945-native/` (build, final source hashes/commit and final route streams), `/tmp/loom-4945-final-tests.log`, `/tmp/loom-4945-cli-gate-tests.log`, `/tmp/loom-4945-mypy-pinned.log`. Third-party PCB bytes and historical reports remain uncommitted/unchanged.

Closes #4945.